### PR TITLE
Helper for exporting table definitions as json

### DIFF
--- a/webui/src/main/java/ch/unibas/dmi/dbis/polyphenydb/webui/SchemaToJsonMapper.java
+++ b/webui/src/main/java/ch/unibas/dmi/dbis/polyphenydb/webui/SchemaToJsonMapper.java
@@ -1,0 +1,170 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.webui;
+
+
+import ch.unibas.dmi.dbis.polyphenydb.PolySqlType;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogColumn;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogKey;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.combined.CatalogCombinedTable;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlWriter;
+import ch.unibas.dmi.dbis.polyphenydb.sql.dialect.PolyphenyDbSqlDialect;
+import ch.unibas.dmi.dbis.polyphenydb.sql.pretty.SqlPrettyWriter;
+import com.google.gson.Gson;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+
+public class SchemaToJsonMapper {
+
+    private final static Gson gson = new Gson();
+
+
+    public static String exportTableDefinitionAsJson( @NonNull CatalogCombinedTable combinedTable, boolean exportPrimaryKey, boolean exportDefaultValues ) {
+        List<JsonColumn> columns = new LinkedList<>();
+        for ( CatalogColumn catalogColumn : combinedTable.getColumns() ) {
+            String defaultValue = null;
+            String defaultFunctionName = null;
+            if ( exportDefaultValues ) {
+                if ( catalogColumn.defaultValue != null ) {
+                    defaultValue = catalogColumn.defaultValue.value;
+                    defaultFunctionName = catalogColumn.defaultValue.functionName;
+                }
+            }
+            columns.add( new JsonColumn(
+                    catalogColumn.name,
+                    catalogColumn.type.name(),
+                    catalogColumn.length,
+                    catalogColumn.scale,
+                    catalogColumn.nullable,
+                    defaultValue,
+                    defaultFunctionName ) );
+        }
+        List<String> primaryKeyColumnNames = null;
+        if ( exportPrimaryKey ) {
+            for ( CatalogKey catalogKey : combinedTable.getKeys() ) {
+                if ( catalogKey.id == combinedTable.getTable().primaryKey ) {
+                    primaryKeyColumnNames = catalogKey.columnNames;
+                    break;
+                }
+            }
+        }
+        JsonTable table = new JsonTable( combinedTable.getTable().name, columns, primaryKeyColumnNames );
+        return gson.toJson( table );
+    }
+
+
+    public static String getCreateTableStatementFromJson( @NonNull String json, boolean createPrimaryKey, boolean addDefaultValueDefinition, @NonNull String schemaName, String storeName ) {
+        JsonTable table = gson.fromJson( json, JsonTable.class );
+        SqlWriter writer = new SqlPrettyWriter( PolyphenyDbSqlDialect.DEFAULT, true, null );
+        writer.keyword( "CREATE TABLE" );
+
+        // Print schemaName.tableName
+        SqlWriter.Frame identifierFrame = writer.startList( SqlWriter.FrameTypeEnum.IDENTIFIER );
+        writer.identifier( schemaName );
+        writer.sep( ".", true );
+        writer.identifier( table.tableName );
+        writer.endList( identifierFrame );
+
+        // Print column list
+        SqlWriter.Frame columnFrame = writer.startList( "(", ")" );
+        for ( JsonColumn column : table.columns ) {
+            writer.sep( "," );
+            writer.identifier( column.columnName );
+            writer.keyword( column.type );
+            if ( column.length != null ) {
+                SqlWriter.Frame columnTypeFrame = writer.startList( SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")" );
+                writer.print( column.length );
+                if ( column.scale != null ) {
+                    writer.sep( ",", true );
+                    writer.print( column.scale );
+                }
+                writer.endList( columnTypeFrame );
+            }
+            if ( !column.nullable ) {
+                writer.keyword( "NOT NULL" );
+            }
+            if ( addDefaultValueDefinition ) {
+                if ( column.defaultValue != null ) {
+                    writer.keyword( "DEFAULT" );
+                    if ( Arrays.asList( PolySqlType.VARCHAR.name(), PolySqlType.TEXT.name(), PolySqlType.DATE.name(), PolySqlType.TIME.name(), PolySqlType.TIMESTAMP.name() ).contains( column.type ) ) {
+                        writer.literal( "'" + column.defaultValue + "'" );
+                    } else {
+                        writer.literal( column.defaultValue );
+                    }
+                } else if ( column.defaultFunctionName != null ) {
+                    writer.keyword( "DEFAULT" );
+                    writer.print( column.defaultFunctionName );
+                }
+            }
+        }
+        if ( createPrimaryKey && table.primaryKeyColumnNames != null ) {
+            writer.sep( "," );
+            writer.keyword( "PRIMARY KEY" );
+            SqlWriter.Frame primaryKeyFrame = writer.startList( SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")" );
+            for ( String columnName : table.primaryKeyColumnNames ) {
+                writer.sep( "," );
+                writer.identifier( columnName );
+            }
+            writer.endList( primaryKeyFrame );
+        }
+        writer.endList( columnFrame );
+
+        // ON STORE storeName
+        if ( storeName != null ) {
+            writer.keyword( "ON STORE" );
+            writer.identifier( storeName );
+        }
+
+        return writer.toSqlString().getSql();
+    }
+
+
+    @AllArgsConstructor
+    private static class JsonTable {
+
+        public final String tableName;
+        public final List<JsonColumn> columns;
+        public final List<String> primaryKeyColumnNames;
+    }
+
+
+    @AllArgsConstructor
+    private static class JsonColumn {
+
+        public final String columnName;
+        public final String type;
+        public final Integer length;
+        public final Integer scale;
+        public final boolean nullable;
+        public final String defaultValue;
+        public final String defaultFunctionName;
+    }
+
+}

--- a/webui/src/test/java/ch/unibas/dmi/dbis/polyphenydb/webui/SchemaToJsonMapperTest.java
+++ b/webui/src/test/java/ch/unibas/dmi/dbis/polyphenydb/webui/SchemaToJsonMapperTest.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.webui;
+
+
+import ch.unibas.dmi.dbis.polyphenydb.PolySqlType;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.Catalog.SchemaType;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.Catalog.TableType;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogColumn;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogDatabase;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogDefaultValue;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogKey;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogSchema;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogTable;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogUser;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.combined.CatalogCombinedTable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class SchemaToJsonMapperTest {
+
+
+    private static final String mockJson = "{\"tableName\":\"stores\",\"columns\":[{\"columnName\":\"sid\",\"type\":\"INTEGER\",\"nullable\":false},{\"columnName\":\"name\",\"type\":\"VARCHAR\",\"length\":50,\"nullable\":false},{\"columnName\":\"location\",\"type\":\"VARCHAR\",\"length\":30,\"nullable\":true,\"defaultValue\":\"Basel\"}],\"primaryKeyColumnNames\":[\"sid\",\"name\"]}";
+
+
+    @Test
+    public void exportTest() {
+        CatalogCombinedTable catalogCombinedTable = new CatalogCombinedTable(
+                new CatalogTable( 4, "stores", 1, "public", 1, "APP", 1, "hans", TableType.TABLE, "", 23L ),
+                Arrays.asList(
+                        new CatalogColumn( 5, "sid", 4, "stores", 1, "public", 1, "APP", 1, PolySqlType.INTEGER, null, null, false, null, null ),
+                        new CatalogColumn( 6, "name", 4, "stores", 1, "public", 1, "APP", 2, PolySqlType.VARCHAR, 50, null, false, null, null ),
+                        new CatalogColumn( 7, "location", 4, "stores", 1, "public", 1, "APP", 3, PolySqlType.VARCHAR, 30, null, true, null, new CatalogDefaultValue( 7, PolySqlType.VARCHAR, "Basel", null ) )
+                ),
+                new CatalogSchema( 1, "public", 1, "APP", 1, "hans", SchemaType.RELATIONAL ),
+                new CatalogDatabase( 1, "APP", 1, "hans", 1L, "public" ),
+                new CatalogUser( 1, "hans", "secrete" ),
+                new ArrayList<>(),
+                Arrays.asList(
+                        new CatalogKey( 23L, 4, "stores", 1, "public", 1, "APP", Arrays.asList( 5L, 6L ), Arrays.asList( "sid", "name" ) ),
+                        new CatalogKey( 24L, 4, "stores", 1, "public", 1, "APP", Arrays.asList( 6L ), Arrays.asList( "name" ) )
+                )
+        );
+        String json = SchemaToJsonMapper.exportTableDefinitionAsJson( catalogCombinedTable, true, true );
+        Assert.assertEquals( json, mockJson );
+    }
+
+
+    @Test
+    public void getStatementTest() {
+        String statement = SchemaToJsonMapper.getCreateTableStatementFromJson( mockJson, true, true, "foo", "hsqldb1" );
+        final String expected1 = "CREATE TABLE \"foo\".\"stores\" (\"sid\" INTEGER NOT NULL, \"name\" VARCHAR(50) NOT NULL, \"location\" VARCHAR(30) DEFAULT 'Basel', PRIMARY KEY(\"sid\", \"name\")) ON STORE \"hsqldb1\"";
+        Assert.assertEquals( statement, expected1 );
+
+        statement = SchemaToJsonMapper.getCreateTableStatementFromJson( mockJson, false, false, "foo", null );
+        final String expected2 = "CREATE TABLE \"foo\".\"stores\" (\"sid\" INTEGER NOT NULL, \"name\" VARCHAR(50) NOT NULL, \"location\" VARCHAR(30))";
+        Assert.assertEquals( statement, expected2 );
+    }
+
+}


### PR DESCRIPTION
This PR adds a helper class that allows exporting the definition of a table as JSON. The JSON includes

- The table name (without schema part)
- The column definitions (name, type, length, scale, nullability, default value)
- The primary key

It can be selected whether the default values and the primary key definition should be included in the export.

Furthermore, the helper class supports creating a `CREATE TABLE` statement based on such a JSON. In can be selected whether the statement should define a primary key and default values. The schema name can be specified. It is also possible to specify the name of the data store the table should be placed on.