### PR TITLE
Improve settings management in stores + minor fixes to Store

### DIFF
--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/Store.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/Store.java
@@ -63,6 +63,10 @@ public abstract class Store {
 
     public abstract void shutdown();
 
+    /**
+     * Informs a store that its settings have changed.
+     * @param updatedSettings List of setting names that have changed.
+     */
     protected abstract void reloadSettings(List<String> updatedSettings);
 
     protected List<String> applySettings( Map<String, String> newSettings ) {

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/Store.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/Store.java
@@ -65,14 +65,16 @@ public abstract class Store {
 
     /**
      * Informs a store that its settings have changed.
+     *
      * @param updatedSettings List of setting names that have changed.
      */
-    protected abstract void reloadSettings(List<String> updatedSettings);
+    protected abstract void reloadSettings( List<String> updatedSettings );
+
 
     protected List<String> applySettings( Map<String, String> newSettings ) {
         List<String> updatedSettings = new ArrayList<>();
-        for ( Entry<String, String> newSetting: newSettings.entrySet() ) {
-            if ( ! Objects.equals( this.settings.get( newSetting.getKey() ), newSetting.getValue() )) {
+        for ( Entry<String, String> newSetting : newSettings.entrySet() ) {
+            if ( !Objects.equals( this.settings.get( newSetting.getKey() ), newSetting.getValue() ) ) {
                 this.settings.put( newSetting.getKey(), newSetting.getValue() );
                 updatedSettings.add( newSetting.getKey() );
             }
@@ -103,7 +105,7 @@ public abstract class Store {
     public void updateSettings( Map<String, String> newSettings ) {
         this.validateSettings( newSettings, false );
         List<String> updatedSettings = this.applySettings( newSettings );
-        this.reloadSettings(updatedSettings);
+        this.reloadSettings( updatedSettings );
     }
 
 

--- a/csv-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/csv/CsvStore.java
+++ b/csv-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/csv/CsvStore.java
@@ -13,7 +13,6 @@ import ch.unibas.dmi.dbis.polyphenydb.schema.SchemaPlus;
 import ch.unibas.dmi.dbis.polyphenydb.schema.Table;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -128,7 +127,7 @@ public class CsvStore extends Store {
 
     @Override
     protected void reloadSettings( List<String> updatedSettings ) {
-        if (updatedSettings.contains( "directory" )) {
+        if ( updatedSettings.contains( "directory" ) ) {
             csvDir = new File( this.settings.get( "directory" ) );
         }
     }

--- a/csv-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/csv/CsvStore.java
+++ b/csv-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/csv/CsvStore.java
@@ -121,22 +121,16 @@ public class CsvStore extends Store {
 
 
     @Override
-    public void applySetting( AdapterSetting setting, String newValue ) {
-        //noinspection SwitchStatementWithTooFewBranches
-        switch ( setting.name ) {
-            case "directory":
-                csvDir = new File( newValue );
-                break;
-
-            default:
-                throw new RuntimeException( "Missing entry for setting \"" + setting.name + "\"!" );
-        }
+    public void shutdown() {
+        // Nothing to do
     }
 
 
     @Override
-    public void shutdown() {
-        // Nothing to do
+    protected void reloadSettings( List<String> updatedSettings ) {
+        if (updatedSettings.contains( "directory" )) {
+            csvDir = new File( this.settings.get( "directory" ) );
+        }
     }
 
 }

--- a/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/HsqldbStore.java
+++ b/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/HsqldbStore.java
@@ -233,7 +233,6 @@ public class HsqldbStore extends AbstractJdbcStore {
     }
 
 
-
     @Override
     public void shutdown() {
         try {

--- a/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/HsqldbStore.java
+++ b/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/HsqldbStore.java
@@ -233,11 +233,6 @@ public class HsqldbStore extends AbstractJdbcStore {
     }
 
 
-    @Override
-    public void applySetting( AdapterSetting setting, String newValue ) {
-        // There is no modifiable setting for this store
-    }
-
 
     @Override
     public void shutdown() {
@@ -248,6 +243,12 @@ public class HsqldbStore extends AbstractJdbcStore {
         } catch ( SQLException e ) {
             log.warn( "Exception while shutting down " + getUniqueName(), e );
         }
+    }
+
+
+    @Override
+    protected void reloadSettings( List<String> updatedSettings ) {
+        // There is no modifiable setting for this store
     }
 
 

--- a/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/PostgresqlStore.java
+++ b/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/PostgresqlStore.java
@@ -54,6 +54,7 @@ import org.apache.commons.dbcp2.BasicDataSource;
 //   - Check all the functions whether they are properly adjusted to Postgres.
 //   - Link to Postgres documentation.
 
+
 @Slf4j
 public class PostgresqlStore extends AbstractJdbcStore {
 
@@ -64,9 +65,9 @@ public class PostgresqlStore extends AbstractJdbcStore {
     public static final List<AdapterSetting> AVAILABLE_SETTINGS = ImmutableList.of(
             new AdapterSettingString( "host", false, true, false, "localhost" ),
             new AdapterSettingInteger( "port", false, true, false, 5432 ),
-            new AdapterSettingString( "database",  false, true, false, "postgres"),
-            new AdapterSettingString( "username",  false, true, false, "postgres"),
-            new AdapterSettingString( "password",  false, true, false, "")
+            new AdapterSettingString( "database", false, true, false, "postgres" ),
+            new AdapterSettingString( "username", false, true, false, "postgres" ),
+            new AdapterSettingString( "password", false, true, false, "" )
     );
 
     private final BasicDataSource dataSource;
@@ -79,6 +80,7 @@ public class PostgresqlStore extends AbstractJdbcStore {
     private String dbName;
     private String dbUsername;
     private String dbPassword;
+
 
     public PostgresqlStore( int storeId, String uniqueName, final Map<String, String> settings ) {
         super( storeId, uniqueName, settings );
@@ -135,8 +137,8 @@ public class PostgresqlStore extends AbstractJdbcStore {
         qualifiedNames.add( combinedTable.getSchema().name );
         qualifiedNames.add( combinedTable.getTable().name );
         String physicalTableName = new JdbcPhysicalNameProvider( context.getTransaction().getCatalog() ).getPhysicalTableName( qualifiedNames ).names.get( 0 );
-        if (log.isDebugEnabled()) {
-            log.debug( "PostgreSQL createTable: Qualified names: {}, physicalTableName: {}", qualifiedNames, physicalTableName);
+        if ( log.isDebugEnabled() ) {
+            log.debug( "PostgreSQL createTable: Qualified names: {}, physicalTableName: {}", qualifiedNames, physicalTableName );
         }
         builder.append( "CREATE TABLE " ).append( dialect.quoteIdentifier( physicalTableName ) ).append( " ( " );
         boolean first = true;
@@ -326,8 +328,9 @@ public class PostgresqlStore extends AbstractJdbcStore {
         throw new RuntimeException( "Unknown type: " + polySqlType.name() );
     }
 
+
     private void executeUpdate( StringBuilder builder ) {
-        if (log.isDebugEnabled()) {
+        if ( log.isDebugEnabled() ) {
             log.debug( "PostgreSQL JDBC executing query: {}", builder.toString() );
         }
         Statement statement = null;
@@ -355,6 +358,7 @@ public class PostgresqlStore extends AbstractJdbcStore {
             }
         }
     }
+
 
     private String getConnectionUrl() {
         return String.format( "jdbc:postgresql://%s:%d/%s", this.dbHostname, this.dbPort, this.dbName );

--- a/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/PostgresqlStore.java
+++ b/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/PostgresqlStore.java
@@ -290,15 +290,8 @@ public class PostgresqlStore extends AbstractJdbcStore {
 
 
     @Override
-    protected void applySetting( AdapterSetting s, String newValue ) {
-        // This is in preparation of an AdapterSetting rework...
-        // first we disconnect from the postgres instance
-        /*try {
-            dataSource.close();
-        } catch ( SQLException e ) {
-            log.warn( "Exception while shutting down " + getUniqueName(), e );
-        }*/
-        // Now we can reconnect.
+    protected void reloadSettings( List<String> updatedSettings ) {
+        // TODO: Implement disconnect and reconnect to PostgreSQL instance.
     }
 
 

--- a/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/PostgresqlStore.java
+++ b/jdbc-adapter/src/main/java/ch/unibas/dmi/dbis/polyphenydb/adapter/jdbc/stores/PostgresqlStore.java
@@ -282,6 +282,7 @@ public class PostgresqlStore extends AbstractJdbcStore {
     @Override
     public void shutdown() {
         try {
+            removeInformationPage();
             dataSource.close();
         } catch ( SQLException e ) {
             log.warn( "Exception while shutting down " + getUniqueName(), e );


### PR DESCRIPTION
This changes how a store is informed about changed settings. Instead of being told about changes one by one, it now simply gets a list of settings that changed.

This also includes a small fix to the shutdown method of the PostgreSQL store.