### PR TITLE
SQL support for deploying and removing stores

### DIFF
--- a/core/_docs/reference.md
+++ b/core/_docs/reference.md
@@ -106,6 +106,8 @@ alterStatement:
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD PLACEMENT storeUniqueName
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName DROP PLACEMENT storeUniqueName
      | ALTER CONFIG key SET value
+     | ALTER STORES ADD storeName USING adapterClass WITH config 
+     | ALTER STORES DROP storeName
 
 explain:
       EXPLAIN PLAN
@@ -876,6 +878,7 @@ STATEMENT,
 **STDDEV_SAMP**,
 STORE,
 **STORED**,
+STORES,
 **STREAM**,
 STRUCTURE,
 STYLE,

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -28,6 +28,8 @@ data: {
             "org.polypheny.db.sql.ddl.SqlDdlNodes"
             "org.polypheny.db.sql.ddl.SqlTruncate"
             "org.polypheny.db.sql.ddl.SqlAlterConfig"
+            "org.polypheny.db.sql.ddl.SqlAlterStoresAdd"
+            "org.polypheny.db.sql.ddl.SqlAlterStoresDrop"
             "org.polypheny.db.sql.ddl.SqlAlterSchema"
             "org.polypheny.db.sql.ddl.alterschema.*"
             "org.polypheny.db.sql.ddl.SqlAlterTable"
@@ -313,6 +315,7 @@ data: {
             "SQL_VARBINARY"
             "SQL_VARCHAR"
             "STORE"
+            "STORES"
             "STATE"
             "STATEMENT"
             "STRUCTURE"
@@ -386,6 +389,8 @@ data: {
             "SqlAlterSchema"
             "SqlAlterTable"
             "SqlAlterConfig"
+            "SqlAlterStoresAdd"
+            "SqlAlterStoresDrop"
         ]
 
         # List of methods for parsing extensions to "CREATE [OR REPLACE]" calls. Each must accept arguments "(SqlParserPos pos, boolean replace)".

--- a/core/src/main/codegen/includes/parserImpls.ftl
+++ b/core/src/main/codegen/includes/parserImpls.ftl
@@ -347,3 +347,30 @@ SqlAlterConfig SqlAlterConfig(Span s) :
     }
 }
 
+
+SqlAlterStoresAdd SqlAlterStoresAdd(Span s) :
+{
+    final SqlNode storeName;
+    final SqlNode adapterName;
+    final SqlNode config;
+}
+{
+    <STORES> <ADD> storeName = Expression(ExprContext.ACCEPT_NONCURSOR)
+    <USING> adapterName = Expression(ExprContext.ACCEPT_NONCURSOR)
+    <WITH> config = Expression(ExprContext.ACCEPT_NONCURSOR)
+    {
+        return new SqlAlterStoresAdd(s.end(this), storeName, adapterName, config);
+    }
+}
+
+
+SqlAlterStoresDrop SqlAlterStoresDrop(Span s) :
+{
+    final SqlNode storeName;
+}
+{
+    <STORES> <DROP> storeName = Expression(ExprContext.ACCEPT_NONCURSOR)
+    {
+        return new SqlAlterStoresDrop(s.end(this), storeName);
+    }
+}

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -6539,6 +6539,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < STDDEV_POP: "STDDEV_POP" >
 |   < STDDEV_SAMP: "STDDEV_SAMP" >
 |   < STORE: "STORE" >
+|   < STORES: "STORES" >
 |   < STREAM: "STREAM" >
 |   < STRUCTURE: "STRUCTURE" >
 |   < STYLE: "STYLE" >

--- a/core/src/main/java/org/polypheny/db/sql/ddl/SqlAlterStoresAdd.java
+++ b/core/src/main/java/org/polypheny/db/sql/ddl/SqlAlterStoresAdd.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019-2020 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.sql.ddl;
+
+
+import com.google.gson.Gson;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.polypheny.db.adapter.StoreManager;
+import org.polypheny.db.jdbc.Context;
+import org.polypheny.db.sql.SqlAlter;
+import org.polypheny.db.sql.SqlKind;
+import org.polypheny.db.sql.SqlNode;
+import org.polypheny.db.sql.SqlOperator;
+import org.polypheny.db.sql.SqlSpecialOperator;
+import org.polypheny.db.sql.SqlWriter;
+import org.polypheny.db.sql.parser.SqlParserPos;
+import org.polypheny.db.transaction.Transaction;
+import org.polypheny.db.util.ImmutableNullableList;
+
+
+/**
+ * Parse tree for {@code CREATE STORE storeName USING adapterName WITH config} statement.
+ */
+@Slf4j
+public class SqlAlterStoresAdd extends SqlAlter {
+
+    private static final SqlOperator OPERATOR = new SqlSpecialOperator( "ALTER STORES ADD", SqlKind.OTHER_DDL );
+
+    private final SqlNode storeName;
+    private final SqlNode adapterName;
+    private final SqlNode config;
+
+
+    /**
+     * Creates a SqlAlterSchemaOwner.
+     */
+    public SqlAlterStoresAdd( SqlParserPos pos, SqlNode storeName, SqlNode adapterName, SqlNode config ) {
+        super( OPERATOR, pos );
+        this.storeName = Objects.requireNonNull( storeName );
+        this.adapterName = Objects.requireNonNull( adapterName );
+        this.config = Objects.requireNonNull( config );
+    }
+
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of( storeName, adapterName, config );
+    }
+
+
+    @Override
+    public void unparse( SqlWriter writer, int leftPrec, int rightPrec ) {
+        writer.keyword( "ALTER" );
+        writer.keyword( "STORES" );
+        writer.keyword( "ADD" );
+        storeName.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "USING" );
+        adapterName.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "WÍTH" );
+        config.unparse( writer, leftPrec, rightPrec );
+    }
+
+
+    @Override
+    public void execute( Context context, Transaction transaction ) {
+        String storeNameStr = removeQuotationMarks( storeName.toString() );
+        String adapterNameStr = removeQuotationMarks( adapterName.toString() );
+        Map<String, String> configMap = new Gson().fromJson( removeQuotationMarks( config.toString() ), Map.class );
+        try {
+            StoreManager.getInstance().addStore( transaction.getCatalog(), adapterNameStr, storeNameStr, configMap );
+        } catch ( Exception e ) {
+            log.error( "Could not deploy store", e );
+        }
+    }
+
+
+    private String removeQuotationMarks( String str ) {
+        if ( str.startsWith( "'" ) ) {
+            str = str.substring( 1 );
+        }
+        if ( str.endsWith( "'" ) ) {
+            str = StringUtils.chop( str );
+        }
+        return str;
+    }
+}
+


### PR DESCRIPTION
This PR adds support for deploying and removing stores using SQL.

Deploy a store:
```ALTER STORES ADD storeName USING adapterClass WITH configAsJson```

Remove a store
```ALTER STORES DROP storeName```