### PR TITLE
Enable SQL Statistics

### DIFF
--- a/core/src/main/java/org/polypheny/db/sql/ddl/SqlDropObject.java
+++ b/core/src/main/java/org/polypheny/db/sql/ddl/SqlDropObject.java
@@ -36,6 +36,8 @@ package org.polypheny.db.sql.ddl;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.polypheny.db.sql.SqlDrop;
 import org.polypheny.db.sql.SqlExecutableStatement;
 import org.polypheny.db.sql.SqlIdentifier;
@@ -48,8 +50,10 @@ import org.polypheny.db.sql.parser.SqlParserPos;
 /**
  * Base class for parse trees of {@code DROP TABLE}, {@code DROP VIEW}, and {@code DROP TYPE} statements.
  */
+@Slf4j
 abstract class SqlDropObject extends SqlDrop implements SqlExecutableStatement {
 
+    @Getter
     protected final SqlIdentifier name;
 
 

--- a/core/src/main/java/org/polypheny/db/sql/ddl/SqlDropSchema.java
+++ b/core/src/main/java/org/polypheny/db/sql/ddl/SqlDropSchema.java
@@ -39,6 +39,7 @@ import static org.polypheny.db.util.Static.RESOURCE;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
+import lombok.Getter;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.CatalogSchema;
 import org.polypheny.db.catalog.entity.CatalogTable;
@@ -63,6 +64,7 @@ import org.polypheny.db.transaction.Statement;
  */
 public class SqlDropSchema extends SqlDrop implements SqlExecutableStatement {
 
+    @Getter
     private final SqlIdentifier name;
 
     private static final SqlOperator OPERATOR = new SqlSpecialOperator( "DROP SCHEMA", SqlKind.DROP_TABLE );

--- a/statistic/src/main/java/org/polypheny/db/statistic/StatisticsManager.java
+++ b/statistic/src/main/java/org/polypheny/db/statistic/StatisticsManager.java
@@ -26,6 +26,9 @@ import java.util.concurrent.Executors;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.polypheny.db.catalog.Catalog;
+import org.polypheny.db.catalog.exceptions.GenericCatalogException;
+import org.polypheny.db.catalog.exceptions.UnknownDatabaseException;
 import org.polypheny.db.config.Config;
 import org.polypheny.db.config.Config.ConfigListener;
 import org.polypheny.db.config.RuntimeConfig;
@@ -188,6 +191,14 @@ public class StatisticsManager<T extends Comparable<T>> {
         }
 
         String[] splits = qualifiedTable.replace( "\"", "" ).split( "\\." );
+        if ( splits.length == 1 ) {
+            // default schema here
+            try {
+                splits = new String[]{ Catalog.getInstance().getDatabase( "APP" ).defaultSchemaName, splits[0] };
+            } catch ( GenericCatalogException | UnknownDatabaseException e ) {
+                throw new RuntimeException( e );
+            }
+        }
         if ( splits.length != 2 ) {
             return;
         }


### PR DESCRIPTION
This branch moves the statistic trigger away from the the specific _insertRow()_, _deleteRow()_, etc. methods to the general _SqlUpdate_ function in the _Crud_ class. 
This allows, in addition to tracking of UI changed data, to also track SQL inserted data via frontend.

**Change**
- enables statistics for SQL modification through the frontend
