### PR TITLE
Improvements for Icarus routing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ allprojects {
     }
 
     repositories {
+        mavenLocal()
         maven {
             // DBIS Nexus
             url "https://dbis-nexus.dmi.unibas.ch/repository/maven2/"

--- a/core/src/main/java/org/polypheny/db/sql/ddl/altertable/SqlAlterTableDropPlacement.java
+++ b/core/src/main/java/org/polypheny/db/sql/ddl/altertable/SqlAlterTableDropPlacement.java
@@ -99,6 +99,8 @@ public class SqlAlterTableDropPlacement extends SqlAlterTable {
             if ( placements.containsKey( storeInstance.getStoreId() ) ) {
                 // Physically delete the data from the store
                 storeInstance.dropTable( context, catalogTable );
+                // Inform routing
+                transaction.getRouter().dropPlacements( Catalog.getInstance().getColumnPlacementsOnStore( storeInstance.getStoreId(), catalogTable.id ) );
                 // Delete placement in the catalog
                 for ( long columnId : placements.get( storeInstance.getStoreId() ) ) {
                     Catalog.getInstance().deleteColumnPlacement( storeInstance.getStoreId(), columnId );

--- a/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
@@ -467,10 +467,11 @@ public class IcarusRouter extends AbstractRouter {
                 }
             }
             // calc percents
-            int onePercent = hundredPercent / 100;
+            double onePercent = hundredPercent / 100.0;
             for ( Map.Entry<Integer, Double> entry : map.entrySet() ) {
                 if ( threshold >= entry.getValue() ) {
-                    int t = Math.min( entry.getValue().intValue() / onePercent, 100 ); // This is not nice... But if there is only one entry with 100 percent, it some time happens that we get 101
+                    double d = entry.getValue().intValue() / onePercent;
+                    int t = Math.min( (int) d, 100 ); // This is not nice... But if there is only one entry with 100 percent, it some time happens that we get 101
                     percents.add( t );
                     stores.put( entry.getKey(), entry.getValue() );
                 }

--- a/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
@@ -171,9 +171,9 @@ public class IcarusRouter extends AbstractRouter {
             }
         } else {
             int p = 0;
-            int random = (int) (Math.random() * 100) + 1;
+            int random = Math.min( (int) (Math.random() * 100) + 1, 100 );
             for ( Map.Entry<Integer, Integer> entry : routingTableRow.entrySet() ) {
-                p += entry.getValue();
+                p += Math.max( entry.getValue(), 0 ); // avoid subtracting -2
                 if ( p >= random ) {
                     return entry.getKey();
                 }

--- a/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
@@ -94,7 +94,7 @@ public class IcarusRouter extends AbstractRouter {
     private static final ConfigInteger LONG_RUNNING_SIMILAR_THRESHOLD = new ConfigInteger(
             "icarusRouting/longRunningSimilarThreshold",
             "The amount of time (specified as percentage of the fastest time) a store can be slower than the fastest store in order to be still considered for executing queries of a certain query class. Setting this to zero results in only considering the fastest store.",
-            100 );
+            0 );
     private static final ConfigInteger SHORT_RUNNING_LONG_RUNNING_THRESHOLD = new ConfigInteger(
             "icarusRouting/shortRunningLongRunningThreshold",
             "The minimal execution time (in milliseconds) for a query to be considered as long-running. Queries with lower execution times are considered as short-running.",

--- a/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
@@ -489,7 +489,7 @@ public class IcarusRouter extends AbstractRouter {
             if ( sum == 0 ) {
                 log.error( "Routing table row is empty! This should not happen!" );
             } else if ( sum > 100 ) {
-                log.error( "Routing table row does sum up to a value greater 100! This should not happen!" );
+                log.error( "Routing table row does sum up to a value greater 100! This should not happen! The value is: " + sum + " | Entries: " + row.values().toString() );
             } else if ( sum < 100 ) {
                 if ( fastestStore == -1 ) {
                     log.error( "Fastest Store is -1! This should not happen!" );

--- a/dbms/src/main/java/org/polypheny/db/router/RouterManager.java
+++ b/dbms/src/main/java/org/polypheny/db/router/RouterManager.java
@@ -36,6 +36,9 @@ public class RouterManager {
     private RouterFactory currentRouter = null;
 
 
+    protected final WebUiPage routingPage;
+
+
     public static RouterManager getInstance() {
         return INSTANCE;
     }
@@ -43,11 +46,12 @@ public class RouterManager {
 
     public RouterManager() {
         final ConfigManager configManager = ConfigManager.getInstance();
-        final WebUiPage routingPage = new WebUiPage(
+        routingPage = new WebUiPage(
                 "routingPage",
                 "Routing Settings",
                 "Settings influencing the query routing." );
-        final WebUiGroup routingGroup = new WebUiGroup( "routingGroup", routingPage.getId() );
+        final WebUiGroup routingGroup = new WebUiGroup( "routingGroup", routingPage.getId(), 1 );
+        routingGroup.withTitle( "General" );
         configManager.registerWebUiPage( routingPage );
         configManager.registerWebUiGroup( routingGroup );
 

--- a/information/src/main/java/org/polypheny/db/information/InformationManager.java
+++ b/information/src/main/java/org/polypheny/db/information/InformationManager.java
@@ -259,7 +259,11 @@ public class InformationManager {
             this.pages.get( page ).addGroup( g );
         }
 
-        p.refresh();
+        // p can be null if the client requests a unknown page. This often happens after a restart of Polypheny-DB if a
+        // certain information page is not (yet) available.
+        if ( p != null ) {
+            p.refresh();
+        }
         return p;
     }
 

--- a/information/src/main/java/org/polypheny/db/webui/InformationServer.java
+++ b/information/src/main/java/org/polypheny/db/webui/InformationServer.java
@@ -70,7 +70,12 @@ public class InformationServer implements InformationObserver {
         http.post( "/getPage", ( req, res ) -> {
             //input: req: {pageId: "page1"}
             try {
-                return im.getPage( req.body() ).asJson();
+                InformationPage page = im.getPage( req.body() );
+                if ( page == null ) {
+                    log.error( "Request for unknown page: " + req.body() );
+                    return "";
+                }
+                return page.asJson();
             } catch ( Exception e ) {
                 // if input not number or page does not exist
                 log.error( "Caught exception!", e );

--- a/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
+++ b/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
@@ -960,18 +960,25 @@ public class DbmsMeta implements ProtobufMeta {
         } else if ( signature.statementType == StatementType.IS_DML ) {
             Iterator<?> iterator = signature.enumerable( connection.getCurrentTransaction().getDataContext() ).iterator();
             Object object = null;
+            int rowsChanged = -1;
             while ( iterator.hasNext() ) {
                 object = iterator.next();
+                int num;
+                if ( object == null ) {
+                    throw new NullPointerException();
+                } else if ( object.getClass().isArray() ) {
+                    num = ((Number) ((Object[]) object)[0]).intValue();
+                } else {
+                    num = ((Number) object).intValue();
+                }
+                // Check if num is equal for all stores
+                if ( rowsChanged != -1 && rowsChanged != num ) {
+                    throw new RuntimeException( "The number of changed rows is not equal for all stores!" );
+                }
+                rowsChanged = num;
             }
-            int num;
-            if ( object == null ) {
-                throw new NullPointerException();
-            } else if ( object.getClass().isArray() ) {
-                num = ((Number) ((Object[]) object)[0]).intValue();
-            } else {
-                num = ((Number) object).intValue();
-            }
-            MetaResultSet metaResultSet = MetaResultSet.count( h.connectionId, h.id, num );
+
+            MetaResultSet metaResultSet = MetaResultSet.count( h.connectionId, h.id, rowsChanged );
             resultSets = ImmutableList.of( metaResultSet );
         } else {
             statement.setSignature( signature );

--- a/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
+++ b/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
@@ -958,14 +958,18 @@ public class DbmsMeta implements ProtobufMeta {
             MetaResultSet resultSet = MetaResultSet.count( statement.getConnection().getConnectionId().toString(), h.id, 1 );
             resultSets = ImmutableList.of( resultSet );
         } else if ( signature.statementType == StatementType.IS_DML ) {
-            Object o = signature.enumerable( connection.getCurrentTransaction().getDataContext() ).iterator().next();
+            Iterator<?> iterator = signature.enumerable( connection.getCurrentTransaction().getDataContext() ).iterator();
+            Object object = null;
+            while ( iterator.hasNext() ) {
+                object = iterator.next();
+            }
             int num;
-            if ( o == null ) {
+            if ( object == null ) {
                 throw new NullPointerException();
-            } else if ( o.getClass().isArray() ) {
-                num = ((Number) ((Object[]) o)[0]).intValue();
+            } else if ( object.getClass().isArray() ) {
+                num = ((Number) ((Object[]) object)[0]).intValue();
             } else {
-                num = ((Number) o).intValue();
+                num = ((Number) object).intValue();
             }
             MetaResultSet metaResultSet = MetaResultSet.count( h.connectionId, h.id, num );
             resultSets = ImmutableList.of( metaResultSet );

--- a/webui/build.gradle
+++ b/webui/build.gradle
@@ -4,11 +4,6 @@ group "org.polypheny"
 version = versionMajor + "." + versionMinor + versionQualifier
 
 
-repositories {
-    mavenLocal()
-}
-
-
 apply plugin: "java-library"
 apply plugin: "idea"
 apply plugin: "io.freefair.lombok"
@@ -21,6 +16,12 @@ javadoc.options.encoding = "UTF-8"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
+
+
+configurations.all {
+    // check for updates every build
+    resolutionStrategy.cacheChangingModulesFor 0, "seconds"
+}
 
 
 configurations {


### PR DESCRIPTION
This PR includes several improvements for Icarus routing:

- DML queries are now also working for more than two stores.
- Correctly remove stores from the routing table if the corresponding placement has been dropped.
- Fix an issue in the routing table calculation which could have caused sum of values > 100.
- Adding additional configuration options for Icarus routing.
- Checking whether all stores report the same number of rows changed for DML queries.

Furthermore, this PR improves the handling of requests for unknown information pages in the information manager.