### PR TITLE
Disable locking on underlying data stores 

### DIFF
--- a/dbms/build.gradle
+++ b/dbms/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     testImplementation group: "junit", name: "junit", version: junit_version
     testImplementation group: "org.hamcrest", name: "hamcrest-core", version: hamcrest_core_version  // BSD 3-clause
 
+    testImplementation group: 'com.konghq', name: 'unirest-java', version: unirest_version
+
     //testCompile group: "net.hydromatic", name: "foodmart-data-hsqldb", version: foodmart_data_hsqldb_version
     //testCompile group: "net.hydromatic", name: "foodmart-queries", version: foodmart_queries_version
     //testCompile group: "net.hydromatic", name: "quidem", version: quidem_version

--- a/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/stores/PostgresqlStore.java
+++ b/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/stores/PostgresqlStore.java
@@ -18,6 +18,7 @@ package org.polypheny.db.adapter.jdbc.stores;
 
 
 import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +70,7 @@ public class PostgresqlStore extends AbstractJdbcStore {
         dataSource.setUsername( settings.get( "username" ) );
         dataSource.setPassword( settings.get( "password" ) );
         dataSource.setDefaultAutoCommit( false );
+        dataSource.setDefaultTransactionIsolation( Connection.TRANSACTION_READ_UNCOMMITTED );
         return new TransactionalConnectionFactory( dataSource, Integer.parseInt( settings.get( "maxConnections" ) ) );
     }
 

--- a/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
+++ b/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
@@ -121,7 +121,7 @@ public class DbmsMeta implements ProtobufMeta {
      */
     public static final int UNLIMITED_COUNT = -2;
 
-    public static final boolean SEND_FIRST_FRAME_WITH_RESPONSE = true;
+    public static final boolean SEND_FIRST_FRAME_WITH_RESPONSE = false;
 
     private static final ConcurrentMap<String, PolyphenyDbConnectionHandle> OPEN_CONNECTIONS = new ConcurrentHashMap<>();
     private static final ConcurrentMap<String, PolyphenyDbStatementHandle> OPEN_STATEMENTS = new ConcurrentHashMap<>();
@@ -986,6 +986,8 @@ public class DbmsMeta implements ProtobufMeta {
                         h.id,
                         false,
                         signature,
+                        // Due to a bug in Avatica (it wrongly replaces the courser type) I have per default disabled sending data with the first frame.
+                        // TODO MV:  Due to the performance benefits of sending data together with the first frame, this issue should be addressed
                         maxRowsInFirstFrame != 0 && SEND_FIRST_FRAME_WITH_RESPONSE
                                 ? fetch( h, 0, (int) Math.min( Math.max( maxRowCount, maxRowsInFirstFrame ), Integer.MAX_VALUE ) )
                                 : null //Frame.MORE // Send first frame to together with the response to save a fetch call

--- a/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
+++ b/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
@@ -121,7 +121,7 @@ public class DbmsMeta implements ProtobufMeta {
      */
     public static final int UNLIMITED_COUNT = -2;
 
-    public static final boolean SEND_FIRST_FRAME_WITH_RESPONSE = false;
+    public static final boolean SEND_FIRST_FRAME_WITH_RESPONSE = true;
 
     private static final ConcurrentMap<String, PolyphenyDbConnectionHandle> OPEN_CONNECTIONS = new ConcurrentHashMap<>();
     private static final ConcurrentMap<String, PolyphenyDbStatementHandle> OPEN_STATEMENTS = new ConcurrentHashMap<>();
@@ -986,9 +986,7 @@ public class DbmsMeta implements ProtobufMeta {
                         h.id,
                         false,
                         signature,
-                        // Due to a bug in Avatica (it wrongly replaces the courser type) I have per default disabled sending data with the first frame.
-                        // TODO MV:  Due to the performance benefits of sending data together with the first frame, this issue should be addressed
-                        maxRowsInFirstFrame > 0 && SEND_FIRST_FRAME_WITH_RESPONSE
+                        maxRowsInFirstFrame != 0 && SEND_FIRST_FRAME_WITH_RESPONSE
                                 ? fetch( h, 0, (int) Math.min( Math.max( maxRowCount, maxRowsInFirstFrame ), Integer.MAX_VALUE ) )
                                 : null //Frame.MORE // Send first frame to together with the response to save a fetch call
                 ) );


### PR DESCRIPTION
This PR disables the locking on underlying data stores where possible. Furthermore, this PR fixes failing integration tests.