### PR TITLE
Query plan and implementation caching

### DIFF
--- a/cassandra-adapter/src/main/java/org/polypheny/db/adapter/cassandra/CassandraLimit.java
+++ b/cassandra-adapter/src/main/java/org/polypheny/db/adapter/cassandra/CassandraLimit.java
@@ -78,6 +78,16 @@ public class CassandraLimit extends SingleRel implements CassandraRel {
 
 
     @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (getConvention() != null ? getConvention().getName() : "") + "$" +
+                (offset != null ? offset.hashCode() + "$" : "") +
+                (fetch != null ? fetch.hashCode() : "") + "&";
+    }
+
+
+    @Override
     public void implement( CassandraImplementContext context ) {
         context.visitChild( 0, getInput() );
         if ( offset != null ) {

--- a/config/src/main/java/org/polypheny/db/config/ConfigEnum.java
+++ b/config/src/main/java/org/polypheny/db/config/ConfigEnum.java
@@ -27,13 +27,13 @@ import org.polypheny.db.config.exception.ConfigRuntimeException;
 
 public class ConfigEnum extends Config {
 
-    @SerializedName( "values" )
+    @SerializedName("values")
     private final Set<Enum> enumValues;
     private Enum value;
 
 
-    public ConfigEnum( final String key, final Class enumClass, final Enum defaultValue ) {
-        super( key );
+    public ConfigEnum( final String key, final String description, final Class enumClass, final Enum defaultValue ) {
+        super( key, description );
         //noinspection unchecked
         enumValues = ImmutableSet.copyOf( EnumSet.allOf( enumClass ) );
         setEnum( defaultValue );

--- a/config/src/main/java/org/polypheny/db/config/ConfigEnumList.java
+++ b/config/src/main/java/org/polypheny/db/config/ConfigEnumList.java
@@ -31,13 +31,13 @@ import org.polypheny.db.config.exception.ConfigRuntimeException;
 
 public class ConfigEnumList extends Config {
 
-    @SerializedName( "values" )
+    @SerializedName("values")
     private final Set<Enum> enumValues;
     private final List<Enum> value;
 
 
-    public ConfigEnumList( final String key, final Class enumClass ) {
-        super( key );
+    public ConfigEnumList( final String key, final String description, final Class enumClass ) {
+        super( key, description );
         //noinspection unchecked
         enumValues = ImmutableSet.copyOf( EnumSet.allOf( enumClass ) );
         this.value = new ArrayList<>();
@@ -45,8 +45,8 @@ public class ConfigEnumList extends Config {
     }
 
 
-    public ConfigEnumList( final String key, final Class superClass, final List<Enum> defaultValue ) {
-        this( key, superClass );
+    public ConfigEnumList( final String key, final String description, final Class superClass, final List<Enum> defaultValue ) {
+        this( key, description, superClass );
         setEnumList( defaultValue );
     }
 

--- a/config/src/main/java/org/polypheny/db/webui/ConfigServer.java
+++ b/config/src/main/java/org/polypheny/db/webui/ConfigServer.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.polypheny.db.config.Config;

--- a/config/src/test/java/org/polypheny/db/config/ConfigManagerTest.java
+++ b/config/src/test/java/org/polypheny/db/config/ConfigManagerTest.java
@@ -132,7 +132,7 @@ public class ConfigManagerTest implements ConfigListener {
 
     @Test
     public void configEnum() {
-        Config c = new ConfigEnum( "enum", testEnum.class, testEnum.FOO );
+        Config c = new ConfigEnum( "enum", "Test description", testEnum.class, testEnum.FOO );
         cm.registerConfig( c );
         ConfigObserver o = new ConfigObserver();
         cm.getConfig( "enum" ).addObserver( o );
@@ -156,7 +156,7 @@ public class ConfigManagerTest implements ConfigListener {
 
     @Test
     public void configEnumList() {
-        Config c = new ConfigEnumList( "enumList", testEnum.class, ImmutableList.of( testEnum.BAR ) );
+        Config c = new ConfigEnumList( "enumList", "Test description", testEnum.class, ImmutableList.of( testEnum.BAR ) );
         cm.registerConfig( c );
         ConfigObserver o = new ConfigObserver();
         cm.getConfig( "enumList" ).addObserver( o );
@@ -346,13 +346,13 @@ public class ConfigManagerTest implements ConfigListener {
         Assert.assertEquals( c.getLong(), Integer.MAX_VALUE + 9999999L );
 
         // Check if it works for Enum values
-        c = new ConfigEnum( "test.junit.enum", testEnum.class, testEnum.FOO_BAR );
+        c = new ConfigEnum( "test.junit.enum", "Test description", testEnum.class, testEnum.FOO_BAR );
         Assert.assertEquals( c.getEnum(), testEnum.FOO_BAR );
         cm.registerConfig( c );
         Assert.assertEquals( c.getEnum(), testEnum.FOO );
 
         // Check if it works for Enum Lists
-        c = new ConfigEnumList( "test.junit.enumList", testEnum.class, ImmutableList.of( testEnum.FOO_BAR ) );
+        c = new ConfigEnumList( "test.junit.enumList", "Test description", testEnum.class, ImmutableList.of( testEnum.FOO_BAR ) );
         Assert.assertEquals( c.getEnumList(), ImmutableList.of( testEnum.FOO_BAR ) );
         cm.registerConfig( c );
         Assert.assertEquals( c.getEnumList(), ImmutableList.of( testEnum.FOO, testEnum.BAR ) );

--- a/config/src/test/java/org/polypheny/db/config/ConfigServerTest.java
+++ b/config/src/test/java/org/polypheny/db/config/ConfigServerTest.java
@@ -84,10 +84,10 @@ public class ConfigServerTest {
         Config clazzList = new ConfigClazzList( "clazz_list", TestClass.class, Arrays.asList( FooImplementation.class, BarImplementation.class ) ).withUi( "g2", 3 );
         cm.registerConfig( clazzList );
 
-        Config enum1 = new ConfigEnum( "enum",  TestEnum .class, TestEnum.A ).withUi( "g2", 4 );
+        Config enum1 = new ConfigEnum( "enum", "Test description", TestEnum.class, TestEnum.A ).withUi( "g2", 4 );
         cm.registerConfig( enum1 );
 
-        Config enumList = new ConfigEnumList( "enumList", TestEnum.class, Arrays.asList( TestEnum.A, TestEnum.B )).withUi( "g2", 5 );
+        Config enumList = new ConfigEnumList( "enumList", "Test description", TestEnum.class, Arrays.asList( TestEnum.A, TestEnum.B ) ).withUi( "g2", 5 );
         cm.registerConfig( enumList );
 
         Config c10 = new ConfigInteger( "max_execution_time", 30 ).withUi( "g3" );

--- a/core/src/main/java/org/polypheny/db/adapter/enumerable/EnumerableBindable.java
+++ b/core/src/main/java/org/polypheny/db/adapter/enumerable/EnumerableBindable.java
@@ -78,6 +78,12 @@ public class EnumerableBindable extends ConverterImpl implements BindableRel {
 
 
     @Override
+    public String relCompareString() {
+        return "EnumerableBindable$" + input.relCompareString() + "&";
+    }
+
+
+    @Override
     public Class<Object[]> getElementType() {
         return Object[].class;
     }

--- a/core/src/main/java/org/polypheny/db/adapter/enumerable/EnumerableInterpreter.java
+++ b/core/src/main/java/org/polypheny/db/adapter/enumerable/EnumerableInterpreter.java
@@ -105,6 +105,12 @@ public class EnumerableInterpreter extends SingleRel implements EnumerableRel {
 
 
     @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" + input.relCompareString() + "$" + factor + "&";
+    }
+
+
+    @Override
     public Result implement( EnumerableRelImplementor implementor, Prefer pref ) {
         final JavaTypeFactory typeFactory = implementor.getTypeFactory();
         final BlockBuilder builder = new BlockBuilder();

--- a/core/src/main/java/org/polypheny/db/adapter/enumerable/EnumerableLimit.java
+++ b/core/src/main/java/org/polypheny/db/adapter/enumerable/EnumerableLimit.java
@@ -99,6 +99,15 @@ public class EnumerableLimit extends SingleRel implements EnumerableRel {
 
 
     @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (offset != null ? offset.hashCode() + "$" : "") +
+                (fetch != null ? fetch.hashCode() : "") + "&";
+    }
+
+
+    @Override
     public RelWriter explainTerms( RelWriter pw ) {
         return super.explainTerms( pw )
                 .itemIf( "offset", offset, offset != null )

--- a/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
+++ b/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
@@ -206,10 +206,29 @@ public enum RuntimeConfig {
             "Cache polypheny-db schema",
             true,
             ConfigType.BOOLEAN ),
+
     REST_API_SERVER_PORT( "runtime/restapiServerPort",
             "The port on which the REST API should listen.",
             8089,
-            ConfigType.INTEGER);
+            ConfigType.INTEGER ),
+
+    QUERY_PLAN_CACHING( "runtime/queryPlanCaching",
+            "Cache planned and optimized query plans.",
+            true,
+            ConfigType.BOOLEAN,
+            "queryPlanCachingGroup" ),
+
+    QUERY_PLAN_CACHING_DML( "runtime/queryPlanCachingDml",
+            "Cache DML query plans.",
+            false,
+            ConfigType.BOOLEAN,
+            "queryPlanCachingGroup" ),
+
+    QUERY_PLAN_CACHING_SIZE( "runtime/queryPlanCachingSize",
+            "Size of the query plan cache. If the limit is reached, the least recently used entry is removed.",
+            1000,
+            ConfigType.INTEGER,
+            "queryPlanCachingGroup" );
 
 
     private final String key;
@@ -230,9 +249,12 @@ public enum RuntimeConfig {
         planningGroup.withTitle( "Query Planning" );
         final WebUiGroup parsingGroup = new WebUiGroup( "parsingGroup", processingPage.getId() );
         parsingGroup.withTitle( "Query Parsing" );
+        final WebUiGroup queryPlanCachingGroup = new WebUiGroup( "queryPlanCachingGroup", processingPage.getId() );
+        queryPlanCachingGroup.withTitle( "Query Plan Caching" );
         configManager.registerWebUiPage( processingPage );
         configManager.registerWebUiGroup( parsingGroup );
         configManager.registerWebUiGroup( planningGroup );
+        configManager.registerWebUiGroup( queryPlanCachingGroup );
 
         // Runtime settings
         final WebUiPage runtimePage = new WebUiPage(

--- a/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
+++ b/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
@@ -355,7 +355,7 @@ public enum RuntimeConfig {
                 break;
 
             case ENUM:
-                config = new ConfigEnum( key, defaultValue.getClass(), (Enum) defaultValue );
+                config = new ConfigEnum( key, description, defaultValue.getClass(), (Enum) defaultValue );
                 break;
 
             case BOOLEAN_TABLE:

--- a/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
+++ b/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
@@ -228,7 +228,25 @@ public enum RuntimeConfig {
             "Size of the query plan cache. If the limit is reached, the least recently used entry is removed.",
             1000,
             ConfigType.INTEGER,
-            "queryPlanCachingGroup" );
+            "queryPlanCachingGroup" ),
+
+    IMPLEMENTATION_CACHING( "runtime/implementationCaching",
+            "Cache implemented query plans.",
+            true,
+            ConfigType.BOOLEAN,
+            "implementationCachingGroup" ),
+
+    IMPLEMENTATION_CACHING_DML( "runtime/implementationCachingDml",
+            "Cache implementation for DML queries.",
+            false,
+            ConfigType.BOOLEAN,
+            "implementationCachingGroup" ),
+
+    IMPLEMENTATION_CACHING_SIZE( "runtime/implementationCachingSize",
+            "Size of the implementation cache. If the limit is reached, the least recently used entry is removed.",
+            1000,
+            ConfigType.INTEGER,
+            "implementationCachingGroup" );
 
 
     private final String key;
@@ -251,10 +269,13 @@ public enum RuntimeConfig {
         parsingGroup.withTitle( "Query Parsing" );
         final WebUiGroup queryPlanCachingGroup = new WebUiGroup( "queryPlanCachingGroup", processingPage.getId() );
         queryPlanCachingGroup.withTitle( "Query Plan Caching" );
+        final WebUiGroup implementationCachingGroup = new WebUiGroup( "implementationCachingGroup", processingPage.getId() );
+        implementationCachingGroup.withTitle( "Implementation Caching" );
         configManager.registerWebUiPage( processingPage );
         configManager.registerWebUiGroup( parsingGroup );
         configManager.registerWebUiGroup( planningGroup );
         configManager.registerWebUiGroup( queryPlanCachingGroup );
+        configManager.registerWebUiGroup( implementationCachingGroup );
 
         // Runtime settings
         final WebUiPage runtimePage = new WebUiPage(

--- a/core/src/main/java/org/polypheny/db/interpreter/Bindables.java
+++ b/core/src/main/java/org/polypheny/db/interpreter/Bindables.java
@@ -290,6 +290,15 @@ public class Bindables {
         public Node implement( InterpreterImplementor implementor ) {
             throw new UnsupportedOperationException(); // TODO:
         }
+
+
+        //
+        // TODO: This might be to restrictive
+        //
+        @Override
+        public boolean isImplementationCacheable() {
+            return false;
+        }
     }
 
 

--- a/core/src/main/java/org/polypheny/db/interpreter/Bindables.java
+++ b/core/src/main/java/org/polypheny/db/interpreter/Bindables.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Enumerable;
 import org.polypheny.db.adapter.DataContext;
 import org.polypheny.db.adapter.enumerable.AggImplementor;
@@ -259,6 +260,15 @@ public class Bindables {
 
             // Multiply the cost by a factor that makes a scan more attractive if filters and projects are pushed to the table scan
             return super.computeSelfCost( planner, mq ).multiplyBy( f * p * 0.01d );
+        }
+
+
+        @Override
+        public String relCompareString() {
+            return "BindableTableScan$" +
+                    String.join( ".", table.getQualifiedName() ) +
+                    (filters != null ? filters.stream().map( RexNode::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                    (projects != null ? projects.toString() : "") + "&";
         }
 
 

--- a/core/src/main/java/org/polypheny/db/plan/hep/HepRelVertex.java
+++ b/core/src/main/java/org/polypheny/db/plan/hep/HepRelVertex.java
@@ -77,6 +77,13 @@ public class HepRelVertex extends AbstractRelNode {
 
 
     @Override
+    public String relCompareString() {
+        // Compare makes no sense here. Use hashCode() to avoid errors.
+        return this.getClass().getSimpleName() + "$" + hashCode() + "&";
+    }
+
+
+    @Override
     public RelOptCost computeSelfCost( RelOptPlanner planner, RelMetadataQuery mq ) {
         // HepRelMetadataProvider is supposed to intercept this and redirect to the real rels. But sometimes it doesn't.
         return planner.getCostFactory().makeTinyCost();

--- a/core/src/main/java/org/polypheny/db/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/polypheny/db/plan/volcano/RelSubset.java
@@ -160,6 +160,13 @@ public class RelSubset extends AbstractRelNode {
 
 
     @Override
+    public String relCompareString() {
+        // Compare makes no sense here. Use hashCode() to avoid errors.
+        return this.getClass().getSimpleName() + "$" + hashCode() + "&";
+    }
+
+
+    @Override
     public RelOptCost computeSelfCost( RelOptPlanner planner, RelMetadataQuery mq ) {
         return planner.getCostFactory().makeZeroCost();
     }

--- a/core/src/main/java/org/polypheny/db/processing/QueryProcessor.java
+++ b/core/src/main/java/org/polypheny/db/processing/QueryProcessor.java
@@ -20,11 +20,14 @@ package org.polypheny.db.processing;
 import org.polypheny.db.jdbc.PolyphenyDbSignature;
 import org.polypheny.db.plan.RelOptPlanner;
 import org.polypheny.db.rel.RelRoot;
+import org.polypheny.db.rel.type.RelDataType;
 
 
 public interface QueryProcessor {
 
     PolyphenyDbSignature prepareQuery( RelRoot logicalRoot );
+
+    PolyphenyDbSignature prepareQuery( RelRoot logicalRoot, RelDataType parameters );
 
     RelOptPlanner getPlanner();
 

--- a/core/src/main/java/org/polypheny/db/processing/SqlProcessor.java
+++ b/core/src/main/java/org/polypheny/db/processing/SqlProcessor.java
@@ -34,4 +34,5 @@ public interface SqlProcessor {
 
     PolyphenyDbSignature<?> prepareDdl( SqlNode parsed );
 
+    RelDataType getParameterRowType( SqlNode left );
 }

--- a/core/src/main/java/org/polypheny/db/rel/AbstractRelNode.java
+++ b/core/src/main/java/org/polypheny/db/rel/AbstractRelNode.java
@@ -254,7 +254,7 @@ public abstract class AbstractRelNode implements RelNode {
 
 
     @Override
-    public Set<CorrelationId> getVariablesSet() {
+    public ImmutableSet<CorrelationId> getVariablesSet() {
         return ImmutableSet.of();
     }
 

--- a/core/src/main/java/org/polypheny/db/rel/RelNode.java
+++ b/core/src/main/java/org/polypheny/db/rel/RelNode.java
@@ -322,6 +322,11 @@ public interface RelNode extends RelOptNode, Cloneable {
     RelNode accept( RexShuttle shuttle );
 
     /**
+     * Returns a string which allows to compare rel plans.
+     */
+    String relCompareString();
+
+    /**
      * Context of a relational expression, for purposes of checking validity.
      */
     interface Context {

--- a/core/src/main/java/org/polypheny/db/rel/RelNode.java
+++ b/core/src/main/java/org/polypheny/db/rel/RelNode.java
@@ -327,7 +327,7 @@ public interface RelNode extends RelOptNode, Cloneable {
     String relCompareString();
 
     /**
-     * For optimized trees. Returns whether the involved operators support implementation caching. Defult is true.
+     * For optimized trees. Returns whether the involved operators support implementation caching. Default is true.
      * Only override if you need to set this to false.
      */
     default boolean isImplementationCacheable() {

--- a/core/src/main/java/org/polypheny/db/rel/RelNode.java
+++ b/core/src/main/java/org/polypheny/db/rel/RelNode.java
@@ -327,6 +327,18 @@ public interface RelNode extends RelOptNode, Cloneable {
     String relCompareString();
 
     /**
+     * For optimized trees. Returns whether the involved operators support implementation caching. Defult is true.
+     * Only override if you need to set this to false.
+     */
+    default boolean isImplementationCacheable() {
+        boolean isCacheable = true;
+        for ( RelNode child : getInputs() ) {
+            isCacheable &= child.isImplementationCacheable();
+        }
+        return isCacheable;
+    }
+
+    /**
      * Context of a relational expression, for purposes of checking validity.
      */
     interface Context {

--- a/core/src/main/java/org/polypheny/db/rel/RelShuttleImpl.java
+++ b/core/src/main/java/org/polypheny/db/rel/RelShuttleImpl.java
@@ -67,14 +67,15 @@ public class RelShuttleImpl implements RelShuttle {
     /**
      * Visits a particular child of a parent.
      */
-    protected RelNode visitChild( RelNode parent, int i, RelNode child ) {
+    protected <T extends RelNode> T visitChild( T parent, int i, RelNode child ) {
         stack.push( parent );
         try {
             RelNode child2 = child.accept( this );
             if ( child2 != child ) {
                 final List<RelNode> newInputs = new ArrayList<>( parent.getInputs() );
                 newInputs.set( i, child2 );
-                return parent.copy( parent.getTraitSet(), newInputs );
+                //noinspection unchecked
+                return (T) parent.copy( parent.getTraitSet(), newInputs );
             }
             return parent;
         } finally {
@@ -83,7 +84,7 @@ public class RelShuttleImpl implements RelShuttle {
     }
 
 
-    protected RelNode visitChildren( RelNode rel ) {
+    protected <T extends RelNode> T visitChildren( T rel ) {
         for ( Ord<RelNode> input : Ord.zip( rel.getInputs() ) ) {
             rel = visitChild( rel, input.i, input.e );
         }

--- a/core/src/main/java/org/polypheny/db/rel/convert/ConverterImpl.java
+++ b/core/src/main/java/org/polypheny/db/rel/convert/ConverterImpl.java
@@ -88,5 +88,11 @@ public abstract class ConverterImpl extends SingleRel implements Converter {
         return traitDef;
     }
 
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" + input.relCompareString() + "&";
+    }
+
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/Aggregate.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Aggregate.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Ord;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelOptCost;
@@ -429,6 +430,16 @@ public abstract class Aggregate extends SingleRel {
      */
     public Group getGroupType() {
         return Group.induce( groupSet, groupSets );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (groupSet != null ? groupSet.toString() : "") + "$" +
+                (groupSets != null ? groupSets.stream().map( Objects::toString ).collect( Collectors.joining( " $ " ) ) : "") + "$" +
+                indicator + "&";
     }
 
 

--- a/core/src/main/java/org/polypheny/db/rel/core/AggregateCall.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/AggregateCall.java
@@ -60,7 +60,8 @@ public class AggregateCall {
     public final RelDataType type;
     public final String name;
 
-    // We considered using ImmutableIntList but we would not save much memory: since all values are small, ImmutableList uses cached Integer values.
+    // We considered using ImmutableIntList but we would not save much memory: since all values are small,
+    // ImmutableList uses cached Integer values.
     private final ImmutableList<Integer> argList;
     public final int filterArg;
     public final RelCollation collation;
@@ -70,15 +71,23 @@ public class AggregateCall {
      * Creates an AggregateCall.
      *
      * @param aggFunction Aggregate function
-     * @param distinct Whether distinct
+     * @param distinct    Whether distinct
      * @param approximate Whether approximate
-     * @param argList List of ordinals of arguments
-     * @param filterArg Ordinal of filter argument (the {@code FILTER (WHERE ...)} clause in SQL), or -1
-     * @param collation How to sort values before aggregation (the {@code WITHIN GROUP} clause in SQL)
-     * @param type Result type
-     * @param name Name (may be null)
+     * @param argList     List of ordinals of arguments
+     * @param filterArg   Ordinal of filter argument (the {@code FILTER (WHERE ...)} clause in SQL), or -1
+     * @param collation   How to sort values before aggregation (the {@code WITHIN GROUP} clause in SQL)
+     * @param type        Result type
+     * @param name        Name (may be null)
      */
-    private AggregateCall( SqlAggFunction aggFunction, boolean distinct, boolean approximate, List<Integer> argList, int filterArg, RelCollation collation, RelDataType type, String name ) {
+    private AggregateCall(
+            SqlAggFunction aggFunction,
+            boolean distinct,
+            boolean approximate,
+            List<Integer> argList,
+            int filterArg,
+            RelCollation collation,
+            RelDataType type,
+            String name ) {
         this.type = Objects.requireNonNull( type );
         this.name = name;
         this.aggFunction = Objects.requireNonNull( aggFunction );
@@ -93,12 +102,26 @@ public class AggregateCall {
     /**
      * Creates an AggregateCall, inferring its type if {@code type} is null.
      */
-    public static AggregateCall create( SqlAggFunction aggFunction, boolean distinct, boolean approximate, List<Integer> argList, int filterArg, RelCollation collation,
-            int groupCount, RelNode input, RelDataType type, String name ) {
+    public static AggregateCall create(
+            SqlAggFunction aggFunction,
+            boolean distinct,
+            boolean approximate,
+            List<Integer> argList,
+            int filterArg,
+            RelCollation collation,
+            int groupCount,
+            RelNode input,
+            RelDataType type,
+            String name ) {
         if ( type == null ) {
             final RelDataTypeFactory typeFactory = input.getCluster().getTypeFactory();
             final List<RelDataType> types = PolyTypeUtil.projectTypes( input.getRowType(), argList );
-            final Aggregate.AggCallBinding callBinding = new Aggregate.AggCallBinding( typeFactory, aggFunction, types, groupCount, filterArg >= 0 );
+            final Aggregate.AggCallBinding callBinding = new Aggregate.AggCallBinding(
+                    typeFactory,
+                    aggFunction,
+                    types,
+                    groupCount,
+                    filterArg >= 0 );
             type = aggFunction.inferReturnType( callBinding );
         }
         return create( aggFunction, distinct, approximate, argList, filterArg, collation, type, name );
@@ -108,7 +131,15 @@ public class AggregateCall {
     /**
      * Creates an AggregateCall.
      */
-    public static AggregateCall create( SqlAggFunction aggFunction, boolean distinct, boolean approximate, List<Integer> argList, int filterArg, RelCollation collation, RelDataType type, String name ) {
+    public static AggregateCall create(
+            SqlAggFunction aggFunction,
+            boolean distinct,
+            boolean approximate,
+            List<Integer> argList,
+            int filterArg,
+            RelCollation collation,
+            RelDataType type,
+            String name ) {
         return new AggregateCall( aggFunction, distinct, approximate, argList, filterArg, collation, type, name );
     }
 
@@ -255,11 +286,11 @@ public class AggregateCall {
 
 
     /**
-     * Creates a binding of this call in the context of an {@link org.polypheny.db.rel.logical.LogicalAggregate}, which can then be used to infer the return type.
+     * Creates a binding of this call in the context of an {@link org.polypheny.db.rel.logical.LogicalAggregate},
+     * which can then be used to infer the return type.
      */
     public Aggregate.AggCallBinding createBinding( Aggregate aggregateRelBase ) {
         final RelDataType rowType = aggregateRelBase.getInput().getRowType();
-
         return new Aggregate.AggCallBinding(
                 aggregateRelBase.getCluster().getTypeFactory(),
                 aggFunction,
@@ -296,9 +327,7 @@ public class AggregateCall {
         final RelDataType newType =
                 oldGroupKeyCount == newGroupKeyCount
                         && argList.equals( this.argList )
-                        && filterArg == this.filterArg
-                        ? type
-                        : null;
+                        && filterArg == this.filterArg ? type : null;
         return create( aggFunction, distinct, approximate, argList, filterArg, collation, newGroupKeyCount, input, newType, getName() );
     }
 
@@ -309,7 +338,9 @@ public class AggregateCall {
     public AggregateCall transform( Mappings.TargetMapping mapping ) {
         return copy(
                 Mappings.apply2( (Mapping) mapping, argList ),
-                hasFilter() ? Mappings.apply( mapping, filterArg ) : -1,
+                hasFilter()
+                        ? Mappings.apply( mapping, filterArg )
+                        : -1,
                 RelCollations.permute( collation, mapping ) );
     }
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/Calc.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Calc.java
@@ -96,12 +96,7 @@ public abstract class Calc extends SingleRel {
 
     @Override
     public boolean isValid( Litmus litmus, Context context ) {
-        if ( !RelOptUtil.equal(
-                "program's input type",
-                program.getInputRowType(),
-                "child's output type",
-                getInput().getRowType(),
-                litmus ) ) {
+        if ( !RelOptUtil.equal( "program's input type", program.getInputRowType(), "child's output type", getInput().getRowType(), litmus ) ) {
             return litmus.fail( null );
         }
         if ( !program.isValid( litmus, context ) ) {
@@ -157,6 +152,17 @@ public abstract class Calc extends SingleRel {
         if ( exprs == oldExprs && projects == oldProjects && condition == oldCondition ) {
             return this;
         }
-        return copy( traitSet, getInput(), new RexProgram( program.getInputRowType(), exprs, projects, (RexLocalRef) condition, program.getOutputRowType() ) );
+        return copy(
+                traitSet,
+                getInput(),
+                new RexProgram( program.getInputRowType(), exprs, projects, (RexLocalRef) condition, program.getOutputRowType() ) );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (program != null ? program.toString() : "") + "&";
     }
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/Collect.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Collect.java
@@ -90,6 +90,14 @@ public class Collect extends SingleRel {
     }
 
 
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (fieldName != null ? fieldName : "") + "&";
+    }
+
+
     public RelNode copy( RelTraitSet traitSet, RelNode input ) {
         assert traitSet.containsIfApplicable( Convention.NONE );
         return new Collect( getCluster(), traitSet, input, fieldName );

--- a/core/src/main/java/org/polypheny/db/rel/core/Correlate.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Correlate.java
@@ -37,7 +37,6 @@ package org.polypheny.db.rel.core;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
-import java.util.Set;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelOptCost;
 import org.polypheny.db.plan.RelOptPlanner;
@@ -58,7 +57,8 @@ import org.polypheny.db.util.Litmus;
 /**
  * A relational operator that performs nested-loop joins.
  *
- * It behaves like a kind of {@link org.polypheny.db.rel.core.Join}, but works by setting variables in its environment and restarting its right-hand input.
+ * It behaves like a kind of {@link org.polypheny.db.rel.core.Join}, but works by setting variables in its environment and
+ * restarting its right-hand input.
  *
  * Correlate is not a join since: typical rules should not match Correlate.
  *
@@ -199,7 +199,7 @@ public abstract class Correlate extends BiRel {
 
 
     @Override
-    public Set<CorrelationId> getVariablesSet() {
+    public ImmutableSet<CorrelationId> getVariablesSet() {
         return ImmutableSet.of( correlationId );
     }
 
@@ -221,5 +221,15 @@ public abstract class Correlate extends BiRel {
         RelOptCost rescanCost = rightCost.multiplyBy( Math.max( 1.0, restartCount - 1 ) );
 
         return planner.getCostFactory().makeCost( rowCount /* generate results */ + leftRowCount /* scan left results */, 0, 0 ).plus( rescanCost );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                left.relCompareString() + "$" +
+                right.relCompareString() + "$" +
+                (requiredColumns != null ? requiredColumns.toString() : "") + "$" +
+                (joinType != null ? joinType.name() : "") + "&";
     }
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/EquiJoin.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/EquiJoin.java
@@ -55,7 +55,16 @@ public abstract class EquiJoin extends Join {
     /**
      * Creates an EquiJoin.
      */
-    public EquiJoin( RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right, RexNode condition, ImmutableIntList leftKeys, ImmutableIntList rightKeys, Set<CorrelationId> variablesSet, JoinRelType joinType ) {
+    public EquiJoin(
+            RelOptCluster cluster,
+            RelTraitSet traits,
+            RelNode left,
+            RelNode right,
+            RexNode condition,
+            ImmutableIntList leftKeys,
+            ImmutableIntList rightKeys,
+            Set<CorrelationId> variablesSet,
+            JoinRelType joinType ) {
         super( cluster, traits, left, right, condition, variablesSet, joinType );
         this.leftKeys = Objects.requireNonNull( leftKeys );
         this.rightKeys = Objects.requireNonNull( rightKeys );

--- a/core/src/main/java/org/polypheny/db/rel/core/Exchange.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Exchange.java
@@ -36,6 +36,7 @@ package org.polypheny.db.rel.core;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelOptCost;
 import org.polypheny.db.plan.RelOptPlanner;
@@ -119,5 +120,15 @@ public abstract class Exchange extends SingleRel {
     public RelWriter explainTerms( RelWriter pw ) {
         return super.explainTerms( pw ).item( "distribution", distribution );
     }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (distribution != null ? distribution.getType().name() : "") + "$" +
+                (distribution != null ? distribution.getKeys().stream().map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "&";
+    }
+
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/Filter.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Filter.java
@@ -57,7 +57,7 @@ import org.polypheny.db.util.Litmus;
 /**
  * Relational expression that iterates over its input and returns elements for which
  * <code>condition</code> evaluates to <code>true</code>.
- * <p>
+ *
  * If the condition allows nulls, then a null value is treated the same as false.
  *
  * @see org.polypheny.db.rel.logical.LogicalFilter

--- a/core/src/main/java/org/polypheny/db/rel/core/Filter.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Filter.java
@@ -55,8 +55,9 @@ import org.polypheny.db.util.Litmus;
 
 
 /**
- * Relational expression that iterates over its input and returns elements for which <code>condition</code> evaluates to <code>true</code>.
- *
+ * Relational expression that iterates over its input and returns elements for which
+ * <code>condition</code> evaluates to <code>true</code>.
+ * <p>
  * If the condition allows nulls, then a null value is treated the same as false.
  *
  * @see org.polypheny.db.rel.logical.LogicalFilter
@@ -154,5 +155,13 @@ public abstract class Filter extends SingleRel {
     @Override
     public RelWriter explainTerms( RelWriter pw ) {
         return super.explainTerms( pw ).item( "condition", condition );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (condition != null ? condition.hashCode() : "") + "&";
     }
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/Intersect.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Intersect.java
@@ -35,6 +35,7 @@ package org.polypheny.db.rel.core;
 
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
 import org.polypheny.db.rel.RelInput;
@@ -75,5 +76,13 @@ public abstract class Intersect extends SetOp {
         }
         dRows *= 0.25;
         return dRows;
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                inputs.stream().map( RelNode::relCompareString ).collect( Collectors.joining( "$" ) ) + "$" +
+                all + "&";
     }
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/Join.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Join.java
@@ -63,7 +63,7 @@ import org.polypheny.db.util.Util;
 
 /**
  * Relational expression that combines two relational expressions according to some condition.
- * <p>
+ *
  * Each output row has columns from the left and right inputs. The set of output rows is a subset of the cartesian product
  * of the two inputs; precisely which subset depends on the join condition.
  */

--- a/core/src/main/java/org/polypheny/db/rel/core/Join.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Join.java
@@ -63,8 +63,9 @@ import org.polypheny.db.util.Util;
 
 /**
  * Relational expression that combines two relational expressions according to some condition.
- *
- * Each output row has columns from the left and right inputs. The set of output rows is a subset of the cartesian product of the two inputs; precisely which subset depends on the join condition.
+ * <p>
+ * Each output row has columns from the left and right inputs. The set of output rows is a subset of the cartesian product
+ * of the two inputs; precisely which subset depends on the join condition.
  */
 public abstract class Join extends BiRel {
 
@@ -84,7 +85,8 @@ public abstract class Join extends BiRel {
      * Creates a Join.
      *
      * Note: We plan to change the {@code variablesStopped} parameter to {@code Set&lt;CorrelationId&gt; variablesSet}
-     * because {@link #getVariablesSet()} is preferred over {@link #getVariablesStopped()}. This constructor is not deprecated, for now, because maintaining overloaded constructors in multiple sub-classes would be onerous.
+     * because {@link #getVariablesSet()} is preferred over {@link #getVariablesStopped()}. This constructor is not
+     * deprecated, for now, because maintaining overloaded constructors in multiple sub-classes would be onerous.
      *
      * @param cluster Cluster
      * @param traitSet Trait set
@@ -174,7 +176,7 @@ public abstract class Join extends BiRel {
 
 
     @Override
-    public Set<CorrelationId> getVariablesSet() {
+    public ImmutableSet<CorrelationId> getVariablesSet() {
         return variablesSet;
     }
 
@@ -246,6 +248,16 @@ public abstract class Join extends BiRel {
      */
     public JoinInfo analyzeCondition() {
         return JoinInfo.of( left, right, condition );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                left.relCompareString() + "$" +
+                right.relCompareString() + "$" +
+                (condition != null ? condition.hashCode() : "") + "$" +
+                (joinType != null ? joinType.name() : "") + "&";
     }
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/Match.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Match.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
 import org.polypheny.db.rel.RelCollation;
@@ -239,6 +240,25 @@ public abstract class Match extends SingleRel {
                 .item( "subsets", getSubsets().values().asList() )
                 .item( "patternDefinitions", getPatternDefinitions().values().asList() )
                 .item( "inputFields", getInput().getRowType().getFieldNames() );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                rowType.toString() + "$" +
+                (pattern != null ? pattern.hashCode() : "") + "$" +
+                strictStart + "$" +
+                strictEnd + "$" +
+                (patternDefinitions != null ? patternDefinitions.values().stream().map( RexNode::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                (measures != null ? measures.values().stream().map( RexNode::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                (after != null ? after.hashCode() : "") + "$" +
+                (subsets != null ? String.join( "$", subsets.keySet() ) : "") + "$" +
+                (subsets != null ? subsets.values().stream().map( s -> String.join( "$", s ) ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                allRows + "$" +
+                (partitionKeys != null ? partitionKeys.stream().map( Objects::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                (interval != null ? interval.hashCode() : "") + "&";
     }
 
 

--- a/core/src/main/java/org/polypheny/db/rel/core/Minus.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Minus.java
@@ -35,6 +35,7 @@ package org.polypheny.db.rel.core;
 
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
 import org.polypheny.db.rel.RelInput;
@@ -69,5 +70,13 @@ public abstract class Minus extends SetOp {
     @Override
     public double estimateRowCount( RelMetadataQuery mq ) {
         return RelMdUtil.getMinusRowCount( mq, this );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                inputs.stream().map( RelNode::relCompareString ).collect( Collectors.joining( "$" ) ) + "$" +
+                all + "&";
     }
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/ModifyCollect.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/ModifyCollect.java
@@ -18,9 +18,9 @@ package org.polypheny.db.rel.core;
 
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
-import org.polypheny.db.rel.RelInput;
 import org.polypheny.db.rel.RelNode;
 import org.polypheny.db.rel.metadata.RelMetadataQuery;
 import org.polypheny.db.sql.SqlKind;
@@ -36,17 +36,17 @@ public abstract class ModifyCollect extends SetOp {
     }
 
 
-    /**
-     * Creates a Union by parsing serialized output.
-     */
-    protected ModifyCollect( RelInput input ) {
-        super( input );
+    @Override
+    public double estimateRowCount( RelMetadataQuery mq ) {
+        return 1;
     }
 
 
     @Override
-    public double estimateRowCount( RelMetadataQuery mq ) {
-        return 1;
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                inputs.stream().map( RelNode::relCompareString ).collect( Collectors.joining( "$" ) ) + "$" +
+                all + "&";
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/Project.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Project.java
@@ -38,7 +38,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Ord;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelOptCost;
@@ -328,5 +330,13 @@ public abstract class Project extends SingleRel {
         return true;
     }
 
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (exps != null ? exps.stream().map( Objects::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                rowType.toString() + "&";
+    }
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/Sample.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Sample.java
@@ -85,6 +85,13 @@ public class Sample extends SingleRel {
     }
 
 
+    @Override
+    public String relCompareString() {
+        // Compare makes no sense here. Use hashCode() to avoid errors.
+        return this.getClass().getSimpleName() + "$" + hashCode() + "&";
+    }
+
+
     /**
      * Retrieve the sampling parameters for this Sample.
      */

--- a/core/src/main/java/org/polypheny/db/rel/core/Sort.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Sort.java
@@ -36,6 +36,8 @@ package org.polypheny.db.rel.core;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Ord;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelOptCost;
@@ -193,6 +195,16 @@ public abstract class Sort extends SingleRel {
         pw.itemIf( "offset", offset, offset != null );
         pw.itemIf( "fetch", fetch, fetch != null );
         return pw;
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (collation != null ? collation.getFieldCollations().stream().map( RelFieldCollation::getDirection ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                (offset != null ? offset.hashCode() : "") + "$" +
+                (fetch != null ? fetch.hashCode() : "") + "&";
     }
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/SortExchange.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/SortExchange.java
@@ -35,12 +35,14 @@ package org.polypheny.db.rel.core;
 
 
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
 import org.polypheny.db.rel.RelCollation;
 import org.polypheny.db.rel.RelCollationTraitDef;
 import org.polypheny.db.rel.RelDistribution;
 import org.polypheny.db.rel.RelDistributionTraitDef;
+import org.polypheny.db.rel.RelFieldCollation;
 import org.polypheny.db.rel.RelInput;
 import org.polypheny.db.rel.RelNode;
 import org.polypheny.db.rel.RelWriter;
@@ -113,6 +115,15 @@ public abstract class SortExchange extends Exchange {
     @Override
     public RelWriter explainTerms( RelWriter pw ) {
         return super.explainTerms( pw ).item( "collation", collation );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (distribution != null ? distribution.getKeys().stream().map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                (collation != null ? collation.getFieldCollations().stream().map( RelFieldCollation::getDirection ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "&";
     }
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/TableFunctionScan.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/TableFunctionScan.java
@@ -40,6 +40,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Ord;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
@@ -223,6 +224,15 @@ public abstract class TableFunctionScan extends AbstractRelNode {
      */
     public Type getElementType() {
         return elementType;
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                getInputs().stream().map( RelNode::relCompareString ).collect( Collectors.joining( "$" ) ) + "$" +
+                (getCall() != null ? getCall().hashCode() : "") + "$" +
+                rowType.toString() + "&";
     }
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/TableModify.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/TableModify.java
@@ -37,6 +37,7 @@ package org.polypheny.db.rel.core;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelOptCost;
 import org.polypheny.db.plan.RelOptPlanner;
@@ -242,6 +243,18 @@ public abstract class TableModify extends SingleRel {
         // REVIEW jvs: Just for now...
         double rowCount = mq.getRowCount( this );
         return planner.getCostFactory().makeCost( rowCount, 0, 0 );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                String.join( ".", table.getQualifiedName() ) + "$" +
+                getInputs().stream().map( RelNode::relCompareString ).collect( Collectors.joining( "$" ) ) + "$" +
+                getOperation().name() + "$" +
+                (getUpdateColumnList() != null ? String.join( "$", getUpdateColumnList() ) + "$" : "") +
+                (getSourceExpressionList() != null ? getSourceExpressionList().stream().map( RexNode::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                isFlattened() + "&";
     }
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/TableScan.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/TableScan.java
@@ -178,4 +178,11 @@ public abstract class TableScan extends AbstractRelNode {
     public RelNode accept( RelShuttle shuttle ) {
         return shuttle.visit( this );
     }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                String.join( ".", table.getQualifiedName() ) + "&";
+    }
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/Uncollect.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Uncollect.java
@@ -111,6 +111,12 @@ public class Uncollect extends SingleRel {
     }
 
 
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" + input.relCompareString() + "$" + withOrdinality + "&";
+    }
+
+
     public RelNode copy( RelTraitSet traitSet, RelNode input ) {
         assert traitSet.containsIfApplicable( Convention.NONE );
         return new Uncollect( getCluster(), traitSet, input, withOrdinality );

--- a/core/src/main/java/org/polypheny/db/rel/core/Union.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Union.java
@@ -35,6 +35,7 @@ package org.polypheny.db.rel.core;
 
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
 import org.polypheny.db.rel.RelInput;
@@ -71,6 +72,14 @@ public abstract class Union extends SetOp {
             dRows *= 0.5;
         }
         return dRows;
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                inputs.stream().map( RelNode::relCompareString ).collect( Collectors.joining( "$" ) ) + "$" +
+                all + "&";
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/rel/core/Values.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Values.java
@@ -36,6 +36,7 @@ package org.polypheny.db.rel.core;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.polypheny.db.plan.RelOptCluster;
@@ -188,6 +189,14 @@ public abstract class Values extends AbstractRelNode {
                             .collect( Collectors.joining( ", ", "[", "]" ) ) );
         }
         return relWriter;
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                rowType.toString() + "$" +
+                (tuples != null ? tuples.stream().map( t -> t.stream().map( RexLiteral::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) ).collect( Collectors.joining( "$" ) ) : "") + "&";
     }
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/core/Window.java
+++ b/core/src/main/java/org/polypheny/db/rel/core/Window.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.AbstractList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Ord;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelOptCost;
@@ -212,6 +213,17 @@ public abstract class Window extends SingleRel {
             count += group.aggCalls.size();
         }
         return planner.getCostFactory().makeCost( rowsIn, rowsIn * count, 0 );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                input.relCompareString() + "$" +
+                (constants != null ? constants.stream().map( RexLiteral::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                rowType.toString() + "$" +
+                (groups != null ? groups.hashCode() : "") + "&";
+
     }
 
 

--- a/core/src/main/java/org/polypheny/db/rel/logical/LogicalFilter.java
+++ b/core/src/main/java/org/polypheny/db/rel/logical/LogicalFilter.java
@@ -36,7 +36,6 @@ package org.polypheny.db.rel.logical;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
-import java.util.Set;
 import org.polypheny.db.plan.Convention;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
@@ -111,7 +110,7 @@ public final class LogicalFilter extends Filter {
 
 
     @Override
-    public Set<CorrelationId> getVariablesSet() {
+    public ImmutableSet<CorrelationId> getVariablesSet() {
         return variablesSet;
     }
 

--- a/core/src/main/java/org/polypheny/db/rel/logical/LogicalModifyCollect.java
+++ b/core/src/main/java/org/polypheny/db/rel/logical/LogicalModifyCollect.java
@@ -21,15 +21,13 @@ import java.util.List;
 import org.polypheny.db.plan.Convention;
 import org.polypheny.db.plan.RelOptCluster;
 import org.polypheny.db.plan.RelTraitSet;
-import org.polypheny.db.rel.RelInput;
 import org.polypheny.db.rel.RelNode;
 import org.polypheny.db.rel.RelShuttle;
 import org.polypheny.db.rel.core.ModifyCollect;
-import org.polypheny.db.rel.core.Union;
 
 
 /**
- * Sub-class of {@link Union} not targeted at any particular engine or calling convention.
+ * Sub-class of {@link ModifyCollect} not targeted at any particular engine or calling convention.
  */
 public final class LogicalModifyCollect extends ModifyCollect {
 
@@ -40,14 +38,6 @@ public final class LogicalModifyCollect extends ModifyCollect {
      */
     public LogicalModifyCollect( RelOptCluster cluster, RelTraitSet traitSet, List<RelNode> inputs, boolean all ) {
         super( cluster, traitSet, inputs, all );
-    }
-
-
-    /**
-     * Creates a LogicalUnion by parsing serialized output.
-     */
-    public LogicalModifyCollect( RelInput input ) {
-        super( input );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/rel/logical/LogicalTableScan.java
+++ b/core/src/main/java/org/polypheny/db/rel/logical/LogicalTableScan.java
@@ -50,8 +50,9 @@ import org.polypheny.db.schema.Table;
 /**
  * A <code>LogicalTableScan</code> reads all the rows from a {@link RelOptTable}.
  *
- * If the table is a <code>net.sf.saffron.ext.JdbcTable</code>, then this is literally possible. But for other kinds of tables, there may be many ways to read the data from the table.
- * For some kinds of table, it may not even be possible to read all of the rows unless some narrowing constraint is applied.
+ * If the table is a <code>net.sf.saffron.ext.JdbcTable</code>, then this is literally possible. But for other kinds of tables,
+ * there may be many ways to read the data from the table. For some kinds of table, it may not even be possible to read all of
+ * the rows unless some narrowing constraint is applied.
  *
  * In the example of the <code>net.sf.saffron.ext.ReflectSchema</code> schema,
  *
@@ -105,12 +106,14 @@ public final class LogicalTableScan extends TableScan {
         final Table table = relOptTable.unwrap( Table.class );
         final RelTraitSet traitSet =
                 cluster.traitSetOf( Convention.NONE )
-                        .replaceIfs( RelCollationTraitDef.INSTANCE, () -> {
-                            if ( table != null ) {
-                                return table.getStatistic().getCollations();
-                            }
-                            return ImmutableList.of();
-                        } );
+                        .replaceIfs(
+                                RelCollationTraitDef.INSTANCE,
+                                () -> {
+                                    if ( table != null ) {
+                                        return table.getStatistic().getCollations();
+                                    }
+                                    return ImmutableList.of();
+                                } );
         return new LogicalTableScan( cluster, traitSet, relOptTable );
     }
 }

--- a/core/src/main/java/org/polypheny/db/rel/rules/MultiJoin.java
+++ b/core/src/main/java/org/polypheny/db/rel/rules/MultiJoin.java
@@ -38,9 +38,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Ord;
 import org.polypheny.db.plan.Convention;
 import org.polypheny.db.plan.RelOptCluster;
@@ -210,6 +213,20 @@ public final class MultiJoin extends AbstractRelNode {
                 projFields,
                 joinFieldRefCountsMap,
                 postJoinFilter );
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return "MultiJoin$" +
+                inputs.stream().map( RelNode::relCompareString ).collect( Collectors.joining( "$" ) ) + "$" +
+                (joinFilter != null ? joinFilter.hashCode() : "") + "$" +
+                rowType.toString() + "$" +
+                isFullOuterJoin + "$" +
+                (outerJoinConditions != null ? outerJoinConditions.stream().map( RexNode::hashCode ).map( Objects::toString ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                (joinTypes != null ? joinTypes.stream().map( t -> Arrays.toString( JoinRelType.values() ) ).collect( Collectors.joining( "$" ) ) : "") + "$" +
+                (projFields != null ? projFields.stream().map( Objects::toString ).collect( Collectors.joining( " $ " ) ) : "") + "$" +
+                (postJoinFilter != null ? postJoinFilter.hashCode() : "") + "&";
     }
 
 

--- a/core/src/main/java/org/polypheny/db/rel/stream/Chi.java
+++ b/core/src/main/java/org/polypheny/db/rel/stream/Chi.java
@@ -52,5 +52,11 @@ public class Chi extends SingleRel {
     protected Chi( RelOptCluster cluster, RelTraitSet traits, RelNode input ) {
         super( cluster, traits, input );
     }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" + input.relCompareString() + "&";
+    }
 }
 

--- a/core/src/main/java/org/polypheny/db/rel/stream/LogicalDelta.java
+++ b/core/src/main/java/org/polypheny/db/rel/stream/LogicalDelta.java
@@ -82,5 +82,11 @@ public final class LogicalDelta extends Delta {
     public RelNode copy( RelTraitSet traitSet, List<RelNode> inputs ) {
         return new LogicalDelta( getCluster(), traitSet, AbstractRelNode.sole( inputs ) );
     }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" + input.relCompareString() + "&";
+    }
 }
 

--- a/core/src/main/java/org/polypheny/db/rex/RexCall.java
+++ b/core/src/main/java/org/polypheny/db/rex/RexCall.java
@@ -77,7 +77,7 @@ public class RexCall extends RexNode {
     }
 
 
-    protected RexCall( RelDataType type, SqlOperator op, List<? extends RexNode> operands ) {
+    public RexCall( RelDataType type, SqlOperator op, List<? extends RexNode> operands ) {
         this.type = Objects.requireNonNull( type );
         this.op = Objects.requireNonNull( op );
         this.operands = ImmutableList.copyOf( operands );

--- a/core/src/main/java/org/polypheny/db/sql/SqlDialect.java
+++ b/core/src/main/java/org/polypheny/db/sql/SqlDialect.java
@@ -56,7 +56,6 @@ import org.polypheny.db.rel.type.RelDataType;
 import org.polypheny.db.rel.type.RelDataTypeSystem;
 import org.polypheny.db.rel.type.RelDataTypeSystemImpl;
 import org.polypheny.db.sql.dialect.JethroDataSqlDialect;
-import org.polypheny.db.sql.fun.SqlArrayValueConstructor;
 import org.polypheny.db.sql.fun.SqlStdOperatorTable;
 import org.polypheny.db.sql.parser.SqlParserPos;
 import org.polypheny.db.sql.util.SqlBuilder;

--- a/core/src/test/java/org/polypheny/db/plan/volcano/PlannerTests.java
+++ b/core/src/test/java/org/polypheny/db/plan/volcano/PlannerTests.java
@@ -100,8 +100,7 @@ class PlannerTests {
 
 
         @Override
-        public RelOptCost computeSelfCost( RelOptPlanner planner,
-                RelMetadataQuery mq ) {
+        public RelOptCost computeSelfCost( RelOptPlanner planner, RelMetadataQuery mq ) {
             return planner.getCostFactory().makeInfiniteCost();
         }
 
@@ -118,6 +117,12 @@ class PlannerTests {
         @Override
         public RelWriter explainTerms( RelWriter pw ) {
             return super.explainTerms( pw ).item( "label", label );
+        }
+
+
+        @Override
+        public String relCompareString() {
+            return this.getClass().getSimpleName() + "$" + label + "&";
         }
     }
 
@@ -141,6 +146,12 @@ class PlannerTests {
         @Override
         protected RelDataType deriveRowType() {
             return getInput().getRowType();
+        }
+
+
+        @Override
+        public String relCompareString() {
+            return this.getClass().getSimpleName() + "$" + input.relCompareString() + "&";
         }
     }
 

--- a/core/src/test/java/org/polypheny/db/plan/volcano/TraitPropagationTest.java
+++ b/core/src/test/java/org/polypheny/db/plan/volcano/TraitPropagationTest.java
@@ -405,6 +405,13 @@ public class TraitPropagationTest {
         public RelOptCost computeSelfCost( RelOptPlanner planner, RelMetadataQuery mq ) {
             return planner.getCostFactory().makeCost( 1, 1, 1 );
         }
+
+
+        @Override
+        public String relCompareString() {
+            // Compare makes no sense here. Use hashCode() to avoid errors.
+            return this.getClass().getSimpleName() + "$" + hashCode() + "&";
+        }
     }
 
 

--- a/core/src/test/java/org/polypheny/db/plan/volcano/VolcanoPlannerTraitTest.java
+++ b/core/src/test/java/org/polypheny/db/plan/volcano/VolcanoPlannerTraitTest.java
@@ -394,6 +394,12 @@ public class VolcanoPlannerTraitTest {
         public RelWriter explainTerms( RelWriter pw ) {
             return super.explainTerms( pw ).item( "label", label );
         }
+
+
+        @Override
+        public String relCompareString() {
+            return this.getClass().getSimpleName() + "$" + label + "&";
+        }
     }
 
 
@@ -458,6 +464,12 @@ public class VolcanoPlannerTraitTest {
         }
 
         // TODO: SWZ Implement clone?
+
+
+        @Override
+        public String relCompareString() {
+            return this.getClass().getSimpleName() + "$" + input.relCompareString() + "&";
+        }
     }
 
 

--- a/dbms/src/main/java/org/polypheny/db/processing/ImplementationCache.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/ImplementationCache.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019-2020 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.processing;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+import org.polypheny.db.config.RuntimeConfig;
+import org.polypheny.db.information.InformationAction;
+import org.polypheny.db.information.InformationGraph;
+import org.polypheny.db.information.InformationGraph.GraphData;
+import org.polypheny.db.information.InformationGraph.GraphType;
+import org.polypheny.db.information.InformationGroup;
+import org.polypheny.db.information.InformationKeyValue;
+import org.polypheny.db.information.InformationManager;
+import org.polypheny.db.information.InformationPage;
+import org.polypheny.db.information.InformationTable;
+import org.polypheny.db.information.InformationText;
+import org.polypheny.db.prepare.Prepare.PreparedResult;
+import org.polypheny.db.rel.RelNode;
+
+public class ImplementationCache {
+
+    public static final ImplementationCache INSTANCE = new ImplementationCache();
+
+    private final Cache<String, PreparedResult> implementationCache;
+
+    private final AtomicLong hitsCounter = new AtomicLong(); // Number of requests for which the cache contained the value
+    private final AtomicLong missesCounter = new AtomicLong(); // Number of requests for which the cache hasn't contained the value
+
+
+    public ImplementationCache() {
+        implementationCache = CacheBuilder.newBuilder()
+                .maximumSize( RuntimeConfig.IMPLEMENTATION_CACHING_SIZE.getInteger() )
+                //  .expireAfterWrite(10, TimeUnit.MINUTES)
+                .build();
+        registerMonitoringPage();
+    }
+
+
+    public PreparedResult getIfPresent( RelNode parameterizedNode ) {
+        PreparedResult preparedResult = implementationCache.getIfPresent( parameterizedNode.relCompareString() );
+        if ( preparedResult == null ) {
+            missesCounter.incrementAndGet();
+        } else {
+            hitsCounter.incrementAndGet();
+        }
+        return preparedResult;
+    }
+
+
+    public void put( RelNode parameterizedNode, PreparedResult preparedResult ) {
+        implementationCache.put( parameterizedNode.relCompareString(), preparedResult );
+    }
+
+
+    private void registerMonitoringPage() {
+        InformationManager im = InformationManager.getInstance();
+
+        InformationPage page = new InformationPage( "Implementation Cache" );
+        im.addPage( page );
+
+        // General
+        InformationGroup generalGroup = new InformationGroup( page, "General" ).setOrder( 1 );
+        im.addGroup( generalGroup );
+
+        InformationKeyValue generalKv = new InformationKeyValue( generalGroup );
+        im.registerInformation( generalKv );
+        generalGroup.setRefreshFunction( () -> {
+            generalKv.putPair( "Status", RuntimeConfig.IMPLEMENTATION_CACHING.getBoolean() ? "Active" : "Disabled" );
+            generalKv.putPair( "Current Cache Size", implementationCache.size() + "" );
+            generalKv.putPair( "Maximum Cache Size", RuntimeConfig.IMPLEMENTATION_CACHING_SIZE.getInteger() + "" );
+        } );
+
+        // Hit ratio
+        InformationGroup hitRatioGroup = new InformationGroup( page, "Hit Ratio" ).setOrder( 2 );
+        im.addGroup( hitRatioGroup );
+
+        InformationGraph hitInfoGraph = new InformationGraph(
+                hitRatioGroup,
+                GraphType.DOUGHNUT,
+                new String[]{ "Hits", "Misses" }
+        );
+        hitInfoGraph.setOrder( 1 );
+        im.registerInformation( hitInfoGraph );
+
+        InformationTable hitInfoTable = new InformationTable(
+                hitRatioGroup,
+                Arrays.asList( "Attribute", "Percent", "Absolute" )
+        );
+        hitInfoTable.setOrder( 2 );
+        im.registerInformation( hitInfoTable );
+
+        hitRatioGroup.setRefreshFunction( () -> {
+            long hits = hitsCounter.longValue();
+            long misses = missesCounter.longValue();
+            double hitPercent = (double) hits / (hits + misses);
+            double missesPercent = 1.0 - hitPercent;
+
+            hitInfoGraph.updateGraph(
+                    new String[]{ "Misses", "Hits" },
+                    new GraphData<>( "heap-data", new Long[]{ misses, hits } )
+            );
+
+            DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance();
+            symbols.setDecimalSeparator( '.' );
+            DecimalFormat df = new DecimalFormat( "#.0", symbols );
+            hitInfoTable.reset();
+            hitInfoTable.addRow( "Hits", df.format( hitPercent * 100 ) + " %", hits );
+            hitInfoTable.addRow( "Misses", df.format( missesPercent * 100 ) + " %", misses );
+        } );
+
+        // Invalidate cache
+        InformationGroup invalidateGroup = new InformationGroup( page, "Invalidate" ).setOrder( 3 );
+        im.addGroup( invalidateGroup );
+
+        InformationText invalidateText = new InformationText( invalidateGroup, "Invalidate the implementation cache including the hit and miss counters." );
+        invalidateText.setOrder( 1 );
+        im.registerInformation( invalidateText );
+
+        InformationAction invalidateAction = new InformationAction( invalidateGroup, "Invalidate", parameters -> {
+            implementationCache.invalidateAll();
+            hitsCounter.set( 0 );
+            missesCounter.set( 0 );
+            return "Successfully invalidated the implementation cache!";
+        } );
+        invalidateAction.setOrder( 2 );
+        im.registerInformation( invalidateAction );
+    }
+}

--- a/dbms/src/main/java/org/polypheny/db/processing/QueryParameterizer.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/QueryParameterizer.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019-2020 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.processing;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import org.polypheny.db.rel.RelNode;
+import org.polypheny.db.rel.RelShuttleImpl;
+import org.polypheny.db.rel.logical.LogicalFilter;
+import org.polypheny.db.rel.type.RelDataType;
+import org.polypheny.db.rex.RexCall;
+import org.polypheny.db.rex.RexCorrelVariable;
+import org.polypheny.db.rex.RexDynamicParam;
+import org.polypheny.db.rex.RexFieldAccess;
+import org.polypheny.db.rex.RexInputRef;
+import org.polypheny.db.rex.RexLiteral;
+import org.polypheny.db.rex.RexLocalRef;
+import org.polypheny.db.rex.RexNode;
+import org.polypheny.db.rex.RexOver;
+import org.polypheny.db.rex.RexPatternFieldRef;
+import org.polypheny.db.rex.RexRangeRef;
+import org.polypheny.db.rex.RexSubQuery;
+import org.polypheny.db.rex.RexTableInputRef;
+import org.polypheny.db.rex.RexVisitor;
+
+public class QueryParameterizer extends RelShuttleImpl implements RexVisitor<RexNode> {
+
+    private final AtomicInteger index;
+    @Getter
+    private final Map<String, Object> values;
+    @Getter
+    private final List<RelDataType> types;
+
+
+    public QueryParameterizer( int indexStart, List<RelDataType> parameterRowType ) {
+        index = new AtomicInteger( indexStart );
+        values = new HashMap<>();
+        types = new ArrayList<>( parameterRowType );
+    }
+
+
+    @Override
+    public RelNode visit( LogicalFilter oFilter ) {
+        LogicalFilter filter = (LogicalFilter) super.visit( oFilter );
+        RexNode condition = filter.getCondition();
+        return new LogicalFilter(
+                filter.getCluster(),
+                filter.getTraitSet(),
+                filter.getInput(),
+                condition.accept( this ),
+                filter.getVariablesSet() );
+    }
+
+    //
+    // Rex
+    //
+
+
+    @Override
+    public RexNode visitInputRef( RexInputRef inputRef ) {
+        return inputRef;
+    }
+
+
+    @Override
+    public RexNode visitLocalRef( RexLocalRef localRef ) {
+        return localRef;
+    }
+
+
+    @Override
+    public RexNode visitLiteral( RexLiteral literal ) {
+        int i = index.getAndIncrement();
+        values.put( "?" + i, literal.getValue2() );
+        types.add( literal.getType() );
+        return new RexDynamicParam( literal.getType(), i );
+    }
+
+
+    @Override
+    public RexNode visitCall( RexCall call ) {
+        List<RexNode> newOperands = new LinkedList<>();
+        for ( RexNode operand : call.operands ) {
+            newOperands.add( operand.accept( this ) );
+        }
+        return new RexCall( call.type, call.op, newOperands );
+    }
+
+
+    @Override
+    public RexNode visitOver( RexOver over ) {
+        List<RexNode> newOperands = new LinkedList<>();
+        for ( RexNode operand : over.operands ) {
+            newOperands.add( operand.accept( this ) );
+        }
+        return new RexCall( over.type, over.op, newOperands );
+    }
+
+
+    @Override
+    public RexNode visitCorrelVariable( RexCorrelVariable correlVariable ) {
+        return correlVariable;
+    }
+
+
+    @Override
+    public RexNode visitDynamicParam( RexDynamicParam dynamicParam ) {
+        return dynamicParam;
+    }
+
+
+    @Override
+    public RexNode visitRangeRef( RexRangeRef rangeRef ) {
+        return rangeRef;
+    }
+
+
+    @Override
+    public RexNode visitFieldAccess( RexFieldAccess fieldAccess ) {
+        return fieldAccess;
+    }
+
+
+    @Override
+    public RexNode visitSubQuery( RexSubQuery subQuery ) {
+        return subQuery; //TODO
+    }
+
+
+    @Override
+    public RexNode visitTableInputRef( RexTableInputRef fieldRef ) {
+        return fieldRef;
+    }
+
+
+    @Override
+    public RexNode visitPatternFieldRef( RexPatternFieldRef fieldRef ) {
+        return fieldRef;
+    }
+}

--- a/dbms/src/main/java/org/polypheny/db/processing/QueryParameterizer.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/QueryParameterizer.java
@@ -90,7 +90,7 @@ public class QueryParameterizer extends RelShuttleImpl implements RexVisitor<Rex
     @Override
     public RexNode visitLiteral( RexLiteral literal ) {
         int i = index.getAndIncrement();
-        values.put( "?" + i, literal.getValue2() );
+        values.put( "?" + i, literal.getValue() );
         types.add( literal.getType() );
         return new RexDynamicParam( literal.getType(), i );
     }

--- a/dbms/src/main/java/org/polypheny/db/processing/QueryPlanCache.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/QueryPlanCache.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019-2020 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.processing;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+import org.polypheny.db.config.RuntimeConfig;
+import org.polypheny.db.information.InformationAction;
+import org.polypheny.db.information.InformationGraph;
+import org.polypheny.db.information.InformationGraph.GraphData;
+import org.polypheny.db.information.InformationGraph.GraphType;
+import org.polypheny.db.information.InformationGroup;
+import org.polypheny.db.information.InformationKeyValue;
+import org.polypheny.db.information.InformationManager;
+import org.polypheny.db.information.InformationPage;
+import org.polypheny.db.information.InformationTable;
+import org.polypheny.db.information.InformationText;
+import org.polypheny.db.rel.RelNode;
+
+public class QueryPlanCache {
+
+    public static final QueryPlanCache INSTANCE = new QueryPlanCache();
+
+    private final Cache<String, RelNode> planCache;
+
+    private final AtomicLong hitsCounter = new AtomicLong(); // Number of requests for which the cache contained the value
+    private final AtomicLong missesCounter = new AtomicLong(); // Number of requests for which the cache hasn't contained the value
+
+
+    public QueryPlanCache() {
+        planCache = CacheBuilder.newBuilder()
+                .maximumSize( RuntimeConfig.QUERY_PLAN_CACHING_SIZE.getInteger() )
+                //  .expireAfterWrite(10, TimeUnit.MINUTES)
+                .build();
+        registerMonitoringPage();
+    }
+
+
+    public RelNode getIfPresent( RelNode parameterizedNode ) {
+        RelNode node = planCache.getIfPresent( parameterizedNode.relCompareString() );
+        if ( node == null ) {
+            missesCounter.incrementAndGet();
+        } else {
+            hitsCounter.incrementAndGet();
+        }
+        return node;
+    }
+
+
+    public void put( RelNode parameterizedNode, RelNode optimalNode ) {
+        planCache.put( parameterizedNode.relCompareString(), optimalNode );
+    }
+
+
+    private void registerMonitoringPage() {
+        InformationManager im = InformationManager.getInstance();
+
+        InformationPage page = new InformationPage( "Query Plan Cache" );
+        im.addPage( page );
+
+        // General
+        InformationGroup generalGroup = new InformationGroup( page, "General" ).setOrder( 1 );
+        im.addGroup( generalGroup );
+
+        InformationKeyValue generalKv = new InformationKeyValue( generalGroup );
+        im.registerInformation( generalKv );
+        generalGroup.setRefreshFunction( () -> {
+            generalKv.putPair( "Status", RuntimeConfig.QUERY_PLAN_CACHING.getBoolean() ? "Active" : "Disabled" );
+            generalKv.putPair( "Current Cache Size", planCache.size() + "" );
+            generalKv.putPair( "Maximum Cache Size", RuntimeConfig.QUERY_PLAN_CACHING_SIZE.getInteger() + "" );
+        } );
+
+        // Hit ratio
+        InformationGroup hitRatioGroup = new InformationGroup( page, "Hit Ratio" ).setOrder( 2 );
+        im.addGroup( hitRatioGroup );
+
+        InformationGraph hitInfoGraph = new InformationGraph(
+                hitRatioGroup,
+                GraphType.DOUGHNUT,
+                new String[]{ "Hits", "Misses" }
+        );
+        hitInfoGraph.setOrder( 1 );
+        im.registerInformation( hitInfoGraph );
+
+        InformationTable hitInfoTable = new InformationTable(
+                hitRatioGroup,
+                Arrays.asList( "Attribute", "Percent", "Absolute" )
+        );
+        hitInfoTable.setOrder( 2 );
+        im.registerInformation( hitInfoTable );
+
+        hitRatioGroup.setRefreshFunction( () -> {
+            long hits = hitsCounter.longValue();
+            long misses = missesCounter.longValue();
+            double hitPercent = (double) hits / (hits + misses);
+            double missesPercent = 1.0 - hitPercent;
+
+            hitInfoGraph.updateGraph(
+                    new String[]{ "Misses", "Hits" },
+                    new GraphData<>( "heap-data", new Long[]{ misses, hits } )
+            );
+
+            DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance();
+            symbols.setDecimalSeparator( '.' );
+            DecimalFormat df = new DecimalFormat( "#.0", symbols );
+            hitInfoTable.reset();
+            hitInfoTable.addRow( "Hits", df.format( hitPercent * 100 ) + " %", hits );
+            hitInfoTable.addRow( "Misses", df.format( missesPercent * 100 ) + " %", misses );
+        } );
+
+        // Invalidate cache
+        InformationGroup invalidateGroup = new InformationGroup( page, "Invalidate" ).setOrder( 3 );
+        im.addGroup( invalidateGroup );
+
+        InformationText invalidateText = new InformationText( invalidateGroup, "Invalidate the query plan cache including the hit and miss counters." );
+        invalidateText.setOrder( 1 );
+        im.registerInformation( invalidateText );
+
+        InformationAction invalidateAction = new InformationAction( invalidateGroup, "Invalidate", parameters -> {
+            planCache.invalidateAll();
+            hitsCounter.set( 0 );
+            missesCounter.set( 0 );
+            return "Successfully invalidated the query plan cache!";
+        } );
+        invalidateAction.setOrder( 2 );
+        im.registerInformation( invalidateAction );
+    }
+}

--- a/dbms/src/main/java/org/polypheny/db/processing/SqlProcessorImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/SqlProcessorImpl.java
@@ -259,6 +259,12 @@ public class SqlProcessorImpl implements SqlProcessor, ViewExpander {
     }
 
 
+    @Override
+    public RelDataType getParameterRowType( SqlNode sqlNode ) {
+        return validator.getParameterRowType( sqlNode );
+    }
+
+
     // Add default values for unset fields
     private void addDefaultValues( SqlInsert insert ) {
         Context prepareContext = transaction.getPrepareContext();

--- a/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
@@ -99,7 +99,7 @@ public class IcarusRouter extends AbstractRouter {
     private static final ConfigInteger SHORT_RUNNING_SIMILAR_THRESHOLD = new ConfigInteger(
             "icarusRouting/shortRunningSimilarThreshold",
             "The amount of time (specified as percentage of the fastest time) a store can be slower than the fastest store in order to be still considered for executing queries of a certain query class. Setting this to zero results in only considering the fastest store.",
-            100 );
+            0 );
     private static final ConfigInteger LONG_RUNNING_SIMILAR_THRESHOLD = new ConfigInteger(
             "icarusRouting/longRunningSimilarThreshold",
             "The amount of time (specified as percentage of the fastest time) a store can be slower than the fastest store in order to be still considered for executing queries of a certain query class. Setting this to zero results in only considering the fastest store.",

--- a/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
@@ -524,12 +524,13 @@ public class IcarusRouter extends AbstractRouter {
                 row = calc( map, LONG_RUNNING_SIMILAR_THRESHOLD.getInt(), fastestTime, fastestStore );
             } else {
                 row = new HashMap<>();
+                // init row with 0
+                for ( Integer storeId : map.keySet() ) {
+                    row.put( storeId, 0 );
+                }
                 if ( fastestStore != -1 && fastestTime > 0 ) {
                     row.put( fastestStore, 100 );
                 }
-                /*else {
-                    log.error( "Something went wrong while analyzing data. This should not happen!" );
-                }*/
             }
             return row;
         }

--- a/dbms/src/main/java/org/polypheny/db/router/RouterManager.java
+++ b/dbms/src/main/java/org/polypheny/db/router/RouterManager.java
@@ -48,7 +48,7 @@ public class RouterManager {
         final ConfigManager configManager = ConfigManager.getInstance();
         routingPage = new WebUiPage(
                 "routingPage",
-                "Routing Settings",
+                "Query Routing",
                 "Settings influencing the query routing." );
         final WebUiGroup routingGroup = new WebUiGroup( "routingGroup", routingPage.getId(), 1 );
         routingGroup.withTitle( "General" );

--- a/dbms/src/test/java/org/polypheny/db/plan/RelOptPlanReaderTest.java
+++ b/dbms/src/test/java/org/polypheny/db/plan/RelOptPlanReaderTest.java
@@ -99,6 +99,13 @@ public class RelOptPlanReaderTest {
         public MyRel( RelOptCluster cluster, RelTraitSet traitSet ) {
             super( cluster, traitSet );
         }
+
+
+        @Override
+        public String relCompareString() {
+            // Compare makes no sense here. Use hashCode() to avoid errors.
+            return this.getClass().getSimpleName() + "$" + hashCode() + "&";
+        }
     }
 }
 

--- a/druid-adapter/src/main/java/org/polypheny/db/adapter/druid/DruidQuery.java
+++ b/druid-adapter/src/main/java/org/polypheny/db/adapter/druid/DruidQuery.java
@@ -53,6 +53,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.calcite.avatica.ColumnMetaData;
@@ -617,6 +618,14 @@ public class DruidQuery extends AbstractRelNode implements BindableRel {
         for ( RelOptRule rule : Bindables.RULES ) {
             planner.addRule( rule );
         }
+    }
+
+
+    @Override
+    public String relCompareString() {
+        return this.getClass().getSimpleName() + "$" +
+                String.join( ".", table.getQualifiedName() ) + "$" +
+                (rels != null ? rels.stream().map( RelNode::relCompareString ).collect( Collectors.joining( "$" ) ) : "") + "&";
     }
 
 

--- a/information/src/main/java/org/polypheny/db/information/InformationKeyValue.java
+++ b/information/src/main/java/org/polypheny/db/information/InformationKeyValue.java
@@ -31,7 +31,7 @@ public class InformationKeyValue extends Information {
      *
      * @param group The InformationGroup to which this information belongs
      */
-    InformationKeyValue( InformationGroup group ) {
+    public InformationKeyValue( InformationGroup group ) {
         super( UUID.randomUUID().toString(), group.getId() );
     }
 
@@ -46,6 +46,7 @@ public class InformationKeyValue extends Information {
         super( id, group.getId() );
     }
 
+
     public InformationKeyValue putPair( final String key, final String value ) {
         this.keyValuePairs.put( key, value );
         this.notifyManager();
@@ -56,10 +57,6 @@ public class InformationKeyValue extends Information {
         this.keyValuePairs.remove( key );
         this.notifyManager();
         return this;
-    }
-
-    public String getPair( final String key ) {
-        return this.keyValuePairs.get(key);
     }
 
     public String getValue( final String key ) {

--- a/information/src/main/java/org/polypheny/db/webui/InformationServer.java
+++ b/information/src/main/java/org/polypheny/db/webui/InformationServer.java
@@ -32,7 +32,7 @@ import spark.Service;
 
 
 /**
- * RESTful server for the WebUis, working with the InformationManager.
+ * RESTful server for requesting data from the information manager. It is primarily used by the Polypheny-UI.
  */
 @Slf4j
 public class InformationServer implements InformationObserver {
@@ -41,7 +41,6 @@ public class InformationServer implements InformationObserver {
 
 
     public InformationServer( final int port ) {
-
         Service http = ignite().port( port );
 
         // Needs to be called before defining routes!
@@ -97,12 +96,20 @@ public class InformationServer implements InformationObserver {
 
         http.post( "/refreshPage", ( req, res ) -> {
             //refresh not necessary, since getPage already triggers a refresh
-            im.getPage( req.body() );
+            try {
+                im.getPage( req.body() );
+            } catch ( Exception e ) {
+                log.error( "Caught exception!", e );
+            }
             return "";
         } );
 
         http.post( "/refreshGroup", ( req, res ) -> {
-            im.getGroup( req.body() ).refresh();
+            try {
+                im.getGroup( req.body() ).refresh();
+            } catch ( Exception e ) {
+                log.error( "Caught exception!", e );
+            }
             return "";
         } );
     }
@@ -126,7 +133,7 @@ public class InformationServer implements InformationObserver {
      */
     @Override
     public void observePageList( final String debugId, final InformationPage[] pages ) {
-        //todo can be implemented if needed
+        // TODO: can be implemented if needed
     }
 
 

--- a/information/src/test/java/org/polypheny/db/information/InformationServerTest.java
+++ b/information/src/test/java/org/polypheny/db/information/InformationServerTest.java
@@ -266,7 +266,7 @@ public class InformationServerTest {
         im.addGroup( kvGroup );
         InformationKeyValue iKV = new InformationKeyValue( "kv", kvGroup );
         iKV.putPair( "k1", "value1" ).putPair( "k2", "value2" ).putPair( "k3", "value3" );
-        Assert.assertEquals( iKV.getPair( "k1" ), "value1" );
+        Assert.assertEquals( iKV.getValue( "k1" ), "value1" );
         im.registerInformation( iKV );
         Timer t4 = new Timer();
         final boolean[] alternate = { true };

--- a/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/JdbcRules.java
+++ b/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/JdbcRules.java
@@ -393,6 +393,14 @@ public class JdbcRules {
         public Result implement( JdbcImplementor implementor ) {
             return implementor.implement( this );
         }
+
+
+        @Override
+        public String relCompareString() {
+            return this.getClass().getSimpleName() + "$" +
+                    input.relCompareString() + "$" +
+                    (program != null ? program.toString() : "") + "&";
+        }
     }
 
 

--- a/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/ResultSetEnumerable.java
+++ b/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/ResultSetEnumerable.java
@@ -54,6 +54,7 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.avatica.SqlType;
@@ -219,7 +220,11 @@ public class ResultSetEnumerable<T> extends AbstractEnumerable<T> {
         return preparedStatement -> {
             for ( int i = 0; i < indexes.length; i++ ) {
                 final int index = indexes[i];
-                setDynamicParam( preparedStatement, i + 1, context.get( "?" + index ) );
+                setDynamicParam(
+                        preparedStatement,
+                        i + 1,
+                        context.get( "?" + index ),
+                        preparedStatement.getParameterMetaData().getParameterType( i + 1 ) );
             }
         };
     }
@@ -227,9 +232,9 @@ public class ResultSetEnumerable<T> extends AbstractEnumerable<T> {
 
     /**
      * Assigns a value to a dynamic parameter in a prepared statement, calling the appropriate {@code setXxx}
-     * method based on the type of the value.
+     * method based on the type of the parameter.
      */
-    private static void setDynamicParam( PreparedStatement preparedStatement, int i, Object value ) throws SQLException {
+    private static void setDynamicParam( PreparedStatement preparedStatement, int i, Object value, int sqlType ) throws SQLException {
         if ( value == null ) {
             preparedStatement.setObject( i, null, SqlType.ANY.id );
         } else if ( value instanceof Timestamp ) {
@@ -274,6 +279,16 @@ public class ResultSetEnumerable<T> extends AbstractEnumerable<T> {
             preparedStatement.setURL( i, (URL) value );
         } else if ( value instanceof SQLXML ) {
             preparedStatement.setSQLXML( i, (SQLXML) value );
+        } else if ( value instanceof Calendar ) {
+            if ( SqlType.valueOf( sqlType ) == SqlType.DATE ) {
+                preparedStatement.setDate( i, new java.sql.Date( ((Calendar) value).getTimeInMillis() ) );
+            } else if ( SqlType.valueOf( sqlType ) == SqlType.TIME ) {
+                preparedStatement.setTime( i, new java.sql.Time( ((Calendar) value).getTimeInMillis() ) );
+            } else if ( SqlType.valueOf( sqlType ) == SqlType.TIMESTAMP ) {
+                preparedStatement.setTimestamp( i, new java.sql.Timestamp( ((Calendar) value).getTimeInMillis() ) );
+            } else {
+                throw new RuntimeException( "Unsupported use of Calendar" );
+            }
         } else {
             preparedStatement.setObject( i, value );
         }

--- a/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/ResultSetEnumerable.java
+++ b/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/ResultSetEnumerable.java
@@ -335,18 +335,15 @@ public class ResultSetEnumerable<T> extends AbstractEnumerable<T> {
     }
 
 
-   /* private Enumerator<T> enumeratorBasedOnPreparedStatement() {
-        Connection connection = null;
+    private Enumerator<T> enumeratorBasedOnPreparedStatement() {
         PreparedStatement preparedStatement = null;
         try {
-            connection = connectionHandler.getConnection();
-            preparedStatement = connection.prepareStatement( sql );
+            preparedStatement = connectionHandler.prepareStatement( sql );
             setTimeoutIfPossible( preparedStatement );
             preparedStatementEnricher.enrich( preparedStatement );
             if ( preparedStatement.execute() ) {
                 final ResultSet resultSet = preparedStatement.getResultSet();
                 preparedStatement = null;
-                connection = null;
                 return new ResultSetEnumerator<>( resultSet, rowBuilderFactory );
             } else {
                 Integer updateCount = preparedStatement.getUpdateCount();
@@ -357,11 +354,6 @@ public class ResultSetEnumerable<T> extends AbstractEnumerable<T> {
         } finally {
             closeIfPossible( preparedStatement );
         }
-    } */
-
-
-    private Enumerator<T> enumeratorBasedOnPreparedStatement() {
-        throw new RuntimeException( "Not implemented yet!" );
     }
 
 

--- a/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/ResultSetEnumerable.java
+++ b/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/ResultSetEnumerable.java
@@ -67,6 +67,7 @@ import org.apache.calcite.linq4j.function.Function1;
 import org.apache.calcite.linq4j.tree.Primitive;
 import org.polypheny.db.adapter.DataContext;
 import org.polypheny.db.adapter.jdbc.connection.ConnectionHandler;
+import org.polypheny.db.util.NlsString;
 import org.polypheny.db.util.Static;
 
 
@@ -243,6 +244,8 @@ public class ResultSetEnumerable<T> extends AbstractEnumerable<T> {
             preparedStatement.setTime( i, (Time) value );
         } else if ( value instanceof String ) {
             preparedStatement.setString( i, (String) value );
+        } else if ( value instanceof NlsString ) {
+            preparedStatement.setString( i, ((NlsString) value).getValue() );
         } else if ( value instanceof Integer ) {
             preparedStatement.setInt( i, (Integer) value );
         } else if ( value instanceof Double ) {

--- a/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/connection/ConnectionHandler.java
+++ b/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/connection/ConnectionHandler.java
@@ -40,11 +40,6 @@ public abstract class ConnectionHandler {
      */
     protected ConcurrentLinkedQueue<Statement> openStatements;
 
-    /**
-     * Map of all prepared statements which have to be closed to free resources
-     */
-    protected ConcurrentLinkedQueue<Statement> preparedStatements = new ConcurrentLinkedQueue<>();
-
 
     public int executeUpdate( final String sql ) throws SQLException {
         log.trace( "Executing query on database: {}", sql );
@@ -70,8 +65,11 @@ public abstract class ConnectionHandler {
 
 
     public PreparedStatement prepareStatement( String sql ) throws SQLException {
+        if ( openStatements == null ) {
+            openStatements = new ConcurrentLinkedQueue<>();
+        }
         PreparedStatement preparedStatement = connection.prepareStatement( sql );
-        preparedStatements.add( preparedStatement );
+        openStatements.add( preparedStatement );
         return preparedStatement;
     }
 

--- a/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/connection/ConnectionHandler.java
+++ b/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/connection/ConnectionHandler.java
@@ -18,6 +18,7 @@ package org.polypheny.db.adapter.jdbc.connection;
 
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -38,6 +39,11 @@ public abstract class ConnectionHandler {
      * List of all statements which have to be closed to free resources
      */
     protected ConcurrentLinkedQueue<Statement> openStatements;
+
+    /**
+     * Map of all prepared statements which have to be closed to free resources
+     */
+    protected ConcurrentLinkedQueue<Statement> preparedStatements = new ConcurrentLinkedQueue<>();
 
 
     public int executeUpdate( final String sql ) throws SQLException {
@@ -63,6 +69,13 @@ public abstract class ConnectionHandler {
     }
 
 
+    public PreparedStatement prepareStatement( String sql ) throws SQLException {
+        PreparedStatement preparedStatement = connection.prepareStatement( sql );
+        preparedStatements.add( preparedStatement );
+        return preparedStatement;
+    }
+
+
     public abstract boolean prepare() throws ConnectionHandlerException;
 
     public abstract void commit() throws ConnectionHandlerException;
@@ -78,5 +91,4 @@ public abstract class ConnectionHandler {
         openStatements.add( statement );
         return statement;
     }
-
 }

--- a/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/stores/AbstractJdbcStore.java
+++ b/jdbc-adapter/src/main/java/org/polypheny/db/adapter/jdbc/stores/AbstractJdbcStore.java
@@ -223,8 +223,16 @@ public abstract class AbstractJdbcStore extends Store {
         // We get the physical schema / table name by checking existing column placements of the same logical table placed on this store.
         // This works because there is only one physical table for each logical table on JDBC stores. The reason for choosing this
         // approach rather than using the default physical schema / table names is that this approach allows adding columns to linked tables.
-        String physicalTableName = Catalog.getInstance().getColumnPlacementsOnStore( getStoreId(), catalogTable.id ).get( 0 ).physicalTableName;
-        String physicalSchemaName = Catalog.getInstance().getColumnPlacementsOnStore( getStoreId(), catalogTable.id ).get( 0 ).physicalSchemaName;
+        CatalogColumnPlacement ccp = null;
+        for ( CatalogColumnPlacement p : Catalog.getInstance().getColumnPlacementsOnStore( getStoreId(), catalogTable.id ) ) {
+            // The for loop is required to avoid using the names of the column which we are currently adding (which are null)
+            if ( p.columnId != catalogColumn.id ) {
+                ccp = p;
+                break;
+            }
+        }
+        String physicalTableName = ccp.physicalTableName;
+        String physicalSchemaName = ccp.physicalSchemaName;
         StringBuilder query = buildAddColumnQuery( physicalSchemaName, physicalTableName, physicalColumnName, catalogTable, catalogColumn );
         executeUpdate( query, context );
         // Insert default value

--- a/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
+++ b/jdbc-interface/src/main/java/org/polypheny/db/jdbc/DbmsMeta.java
@@ -945,9 +945,10 @@ public class DbmsMeta implements ProtobufMeta {
         } else {
             Pair<SqlNode, RelDataType> validated = sqlProcessor.validate( parsed );
             RelRoot logicalRoot = sqlProcessor.translate( validated.left );
+            RelDataType parameterRowType = sqlProcessor.getParameterRowType( validated.left );
 
             // Prepare
-            signature = connection.getCurrentOrCreateNewTransaction().getQueryProcessor().prepareQuery( logicalRoot );
+            signature = connection.getCurrentOrCreateNewTransaction().getQueryProcessor().prepareQuery( logicalRoot, parameterRowType );
         }
 
         // Build response

--- a/rest-interface/src/test/java/org/polypheny/db/restapi/RequestParserTest.java
+++ b/rest-interface/src/test/java/org/polypheny/db/restapi/RequestParserTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.CatalogTable;
-import org.polypheny.db.catalog.entity.CatalogUser;
 import org.polypheny.db.catalog.exceptions.GenericCatalogException;
 import org.polypheny.db.catalog.exceptions.UnknownTableException;
 import org.polypheny.db.restapi.exception.UnauthorizedAccessException;

--- a/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
+++ b/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
@@ -17,13 +17,6 @@
 package org.polypheny.db.webui;
 
 
-import static spark.Spark.before;
-import static spark.Spark.get;
-import static spark.Spark.options;
-import static spark.Spark.port;
-import static spark.Spark.post;
-import static spark.Spark.webSocket;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.BufferedReader;
@@ -38,7 +31,6 @@ import org.polypheny.db.iface.Authenticator;
 import org.polypheny.db.iface.QueryInterface;
 import org.polypheny.db.transaction.TransactionManager;
 import spark.Service;
-import spark.Spark;
 
 
 /**


### PR DESCRIPTION
This PR introduces a caching system for query plans. It allows to cache the planning & optimization step and the implementation step. Both caching options can be enabled and disabled individually.

The implementation introduced with this PR is limited to caching read-only queries. Caching DML queries is not yet supported.