### PR TITLE
Improve query routing for partitioned scenarios

### DIFF
--- a/core/src/main/java/org/polypheny/db/sql/ddl/SqlDropTable.java
+++ b/core/src/main/java/org/polypheny/db/sql/ddl/SqlDropTable.java
@@ -128,7 +128,9 @@ public class SqlDropTable extends SqlDropObject {
                 statement.getRouter().dropPlacements( catalog.getColumnPlacementsOnStore( storeId, table.id ) );
                 // Delete column placement in catalog
                 for ( Long columnId : table.columnIds ) {
-                    catalog.deleteColumnPlacement( storeId, columnId );
+                    if ( catalog.checkIfExistsColumnPlacement( storeId, columnId ) ) {
+                        catalog.deleteColumnPlacement( storeId, columnId );
+                    }
                 }
             }
         } catch ( GenericCatalogException e ) {

--- a/dbms/src/main/java/org/polypheny/db/router/AbstractRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/router/AbstractRouter.java
@@ -356,6 +356,9 @@ public abstract class AbstractRouter implements Router {
             builder = handleValues( (LogicalValues) node, builder );
             if ( catalogTable.columnIds.size() == placements.size() ) { // full placement, no additional checks required
                 return builder;
+            } else if ( node.getRowType().toString().equals( "RecordType(INTEGER ZERO)" ) ) {
+                // This is a prepared statement. Actual values are in the project. Do nothing
+                return builder;
             } else { // partitioned, add additional project
                 ArrayList<RexNode> rexNodes = new ArrayList<>();
                 for ( CatalogColumnPlacement ccp : placements ) {
@@ -367,16 +370,25 @@ public abstract class AbstractRouter implements Router {
             if ( catalogTable.columnIds.size() == placements.size() ) { // full placement, generic handling is sufficient
                 return handleGeneric( node, builder );
             } else { // partitioned, adjust project
-                ArrayList<RexNode> rexNodes = new ArrayList<>();
-                for ( CatalogColumnPlacement ccp : placements ) {
-                    rexNodes.add( builder.field( ccp.getLogicalColumnName() ) );
-                }
-                for ( RexNode rexNode : ((LogicalProject) node).getProjects() ) {
-                    if ( !(rexNode instanceof RexInputRef) ) {
-                        rexNodes.add( rexNode );
+                if ( ((LogicalProject) node).getInput().getRowType().toString().equals( "RecordType(INTEGER ZERO)" ) ) {
+                    builder.push( node.copy( node.getTraitSet(), ImmutableList.of( builder.peek( 0 ) ) ) );
+                    ArrayList<RexNode> rexNodes = new ArrayList<>();
+                    for ( CatalogColumnPlacement ccp : placements ) {
+                        rexNodes.add( builder.field( ccp.getLogicalColumnName() ) );
                     }
+                    return builder.project( rexNodes );
+                } else {
+                    ArrayList<RexNode> rexNodes = new ArrayList<>();
+                    for ( CatalogColumnPlacement ccp : placements ) {
+                        rexNodes.add( builder.field( ccp.getLogicalColumnName() ) );
+                    }
+                    for ( RexNode rexNode : ((LogicalProject) node).getProjects() ) {
+                        if ( !(rexNode instanceof RexInputRef) ) {
+                            rexNodes.add( rexNode );
+                        }
+                    }
+                    return builder.project( rexNodes );
                 }
-                return builder.project( rexNodes );
             }
         } else if ( node instanceof LogicalFilter ) {
             if ( catalogTable.columnIds.size() != placements.size() ) { // partitioned, check if there is a illegal condition

--- a/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/router/IcarusRouter.java
@@ -273,7 +273,7 @@ public class IcarusRouter extends AbstractRouter {
             if ( placements.size() != table.columnIds.size() ) {
                 throw new RuntimeException( "The data store '" + selectedStoreId + "' does not contain a full table placement!" );
             }
-            return Catalog.getInstance().getColumnPlacementsOnStore( selectedStoreId );
+            return placements;
         }
         throw new RuntimeException( "The previously selected store does not contain a placement of this table. Store ID: " + selectedStoreId );
     }

--- a/dbms/src/test/java/org/polypheny/db/jdbc/JdbcDmlTest.java
+++ b/dbms/src/test/java/org/polypheny/db/jdbc/JdbcDmlTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019-2020 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.jdbc;
+
+
+import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.polypheny.db.TestHelper;
+import org.polypheny.db.TestHelper.JdbcConnection;
+
+
+@SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
+@Slf4j
+public class JdbcDmlTest {
+
+
+    @BeforeClass
+    public static void start() {
+        // Ensures that Polypheny-DB is running
+        //noinspection ResultOfMethodCallIgnored
+        TestHelper.getInstance();
+    }
+
+
+    @Test
+    public void multiInsertTest() throws SQLException {
+        try ( JdbcConnection polyphenyDbConnection = new JdbcConnection( true ) ) {
+            Connection connection = polyphenyDbConnection.getConnection();
+            try ( Statement statement = connection.createStatement() ) {
+                statement.executeUpdate( "CREATE TABLE multiinserttest( "
+                        + "tprimary INTEGER NOT NULL, "
+                        + "tinteger INTEGER NULL, "
+                        + "tvarchar VARCHAR(20) NULL, "
+                        + "PRIMARY KEY (tprimary) )" );
+                statement.executeUpdate( "INSERT INTO multiinserttest VALUES (1,1,'foo'), (2,5,'bar'), (3,7,'foobar')" );
+                statement.executeUpdate( "INSERT INTO multiinserttest(tprimary,tinteger,tvarchar) VALUES (4,6,'hans'), (5,3,'georg'), (6,2,'jack')" );
+
+                // Checks
+                TestHelper.checkResultSet(
+                        statement.executeQuery( "SELECT * FROM multiinserttest" ),
+                        ImmutableList.of(
+                                new Object[]{ 1, 1, "foo" },
+                                new Object[]{ 2, 5, "bar" },
+                                new Object[]{ 3, 7, "foobar" },
+                                new Object[]{ 4, 6, "hans" },
+                                new Object[]{ 5, 3, "georg" },
+                                new Object[]{ 6, 2, "jack" } ) );
+
+                // Drop table
+                statement.executeUpdate( "DROP TABLE multiinserttest" );
+            }
+        }
+    }
+
+
+}

--- a/dbms/src/test/java/org/polypheny/db/misc/VerticalPartitioningTest.java
+++ b/dbms/src/test/java/org/polypheny/db/misc/VerticalPartitioningTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019-2020 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.misc;
+
+import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.polypheny.db.TestHelper;
+import org.polypheny.db.TestHelper.JdbcConnection;
+
+@SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
+public class VerticalPartitioningTest {
+
+
+    @BeforeClass
+    public static void start() {
+        // Ensures that Polypheny-DB is running
+        //noinspection ResultOfMethodCallIgnored
+        TestHelper.getInstance();
+    }
+
+
+    @Test
+    public void basicTest() throws SQLException {
+        try ( JdbcConnection polyphenyDbConnection = new JdbcConnection( true ) ) {
+            Connection connection = polyphenyDbConnection.getConnection();
+            try ( Statement statement = connection.createStatement() ) {
+                statement.executeUpdate( "CREATE TABLE partitioningtest( "
+                        + "tprimary INTEGER NOT NULL, "
+                        + "tinteger INTEGER NULL, "
+                        + "tvarchar VARCHAR(20) NULL, "
+                        + "PRIMARY KEY (tprimary) )" );
+
+                // Deploy additional store
+                statement.executeUpdate( "ALTER STORES ADD \"store1\" USING 'org.polypheny.db.adapter.jdbc.stores.HsqldbStore'"
+                        + " WITH '{maxConnections:\"25\",path:., trxControlMode:locks,trxIsolationLevel:read_committed,type:Memory,tableType:Memory}'" );
+
+                // Add placement
+                statement.executeUpdate( "ALTER TABLE \"partitioningtest\" ADD PLACEMENT (tvarchar) ON STORE \"store1\"" );
+
+                // Change placement on intial store
+                statement.executeUpdate( "ALTER TABLE \"partitioningtest\" MODIFY PLACEMENT (tinteger) ON STORE \"hsqldb\"" );
+
+                // Insert data
+                statement.executeUpdate( "INSERT INTO partitioningtest VALUES (1,5,'foo')" );
+                statement.executeUpdate( "INSERT INTO partitioningtest VALUES (2,22,'bar'),(3,69,'xyz')" );
+
+                // Update data
+                statement.executeUpdate( "UPDATE partitioningtest SET tinteger = 33 WHERE tprimary = 1" );
+                statement.executeUpdate( "UPDATE partitioningtest SET tprimary = 4 WHERE tprimary = 2" );
+
+                // Delete data
+                statement.executeUpdate( "DELETE FROM partitioningtest WHERE tprimary = 3" );
+
+                // Checks
+                TestHelper.checkResultSet(
+                        statement.executeQuery( "SELECT * FROM partitioningtest ORDER BY tprimary" ),
+                        ImmutableList.of(
+                                new Object[]{ 1, 33, "foo" },
+                                new Object[]{ 4, 22, "bar" } ) );
+                // Drop table and store
+                statement.executeUpdate( "DROP TABLE partitioningtest" );
+                statement.executeUpdate( "ALTER STORES DROP \"store1\"" );
+            }
+        }
+    }
+
+
+    @Test
+    public void preparedBatchTest() throws SQLException {
+        try ( JdbcConnection polyphenyDbConnection = new JdbcConnection( true ) ) {
+            Connection connection = polyphenyDbConnection.getConnection();
+            try ( Statement statement = connection.createStatement() ) {
+                statement.executeUpdate( "CREATE TABLE partitioningtest( "
+                        + "tprimary INTEGER NOT NULL, "
+                        + "tinteger INTEGER NULL, "
+                        + "tvarchar VARCHAR(20) NULL, "
+                        + "PRIMARY KEY (tprimary) )" );
+
+                // Deploy additional store
+                statement.executeUpdate( "ALTER STORES ADD \"store1\" USING 'org.polypheny.db.adapter.jdbc.stores.HsqldbStore'"
+                        + " WITH '{maxConnections:\"25\",path:., trxControlMode:locks,trxIsolationLevel:read_committed,type:Memory,tableType:Memory}'" );
+
+                // Add placement
+                statement.executeUpdate( "ALTER TABLE \"partitioningtest\" ADD PLACEMENT (tvarchar) ON STORE \"store1\"" );
+
+                // Change placement on intial store
+                statement.executeUpdate( "ALTER TABLE \"partitioningtest\" MODIFY PLACEMENT (tinteger) ON STORE \"hsqldb\"" );
+
+                // Insert Data
+                PreparedStatement preparedInsert = connection.prepareStatement( "INSERT INTO partitioningtest VALUES (?, ?, ?)" );
+                preparedInsert.setInt( 1, 1 );
+                preparedInsert.setInt( 2, 33 );
+                preparedInsert.setString( 3, "foo" );
+                preparedInsert.addBatch();
+                preparedInsert.setInt( 1, 2 );
+                preparedInsert.setInt( 2, 22 );
+                preparedInsert.setString( 3, "bar" );
+                preparedInsert.addBatch();
+                preparedInsert.setInt( 1, 3 );
+                preparedInsert.setInt( 2, 69 );
+                preparedInsert.setString( 3, "foobar" );
+                preparedInsert.addBatch();
+                preparedInsert.executeBatch();
+
+                // Checks
+                TestHelper.checkResultSet(
+                        statement.executeQuery( "SELECT * FROM partitioningtest ORDER BY tprimary" ),
+                        ImmutableList.of(
+                                new Object[]{ 1, 33, "foo" },
+                                new Object[]{ 2, 22, "bar" },
+                                new Object[]{ 3, 69, "foobar" } ) );
+
+                // Drop table and store
+                statement.executeUpdate( "DROP TABLE partitioningtest" );
+                statement.executeUpdate( "ALTER STORES DROP \"store1\"" );
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR fixes the following issues with the query routing for partitioned tables:
- A bug in the placement selection of Icarus routing which lead to unrouteable plans.
- An issue with dropping partitioned tables
- An issue with batch inserts into vertically partitioned tables

Furthermore, this PR adds additional tests.