### PR TITLE
Fix issue with filter operations on REST interface

### DIFF
--- a/rest-interface/src/main/java/org/polypheny/db/restapi/RequestParser.java
+++ b/rest-interface/src/main/java/org/polypheny/db/restapi/RequestParser.java
@@ -601,18 +601,18 @@ public class RequestParser {
 
         SqlOperator callOperator;
         String rightHandSide;
-        if ( filterString.startsWith( "<" ) ) {
-            callOperator = SqlStdOperatorTable.LESS_THAN;
-            rightHandSide = filterString.substring( 1, filterString.length() );
-        } else if ( filterString.startsWith( "<=" ) ) {
+        if ( filterString.startsWith( "<=" ) ) {
             callOperator = SqlStdOperatorTable.LESS_THAN_OR_EQUAL;
             rightHandSide = filterString.substring( 2, filterString.length() );
-        } else if ( filterString.startsWith( ">" ) ) {
-            callOperator = SqlStdOperatorTable.GREATER_THAN;
+        } else if ( filterString.startsWith( "<" ) ) {
+            callOperator = SqlStdOperatorTable.LESS_THAN;
             rightHandSide = filterString.substring( 1, filterString.length() );
         } else if ( filterString.startsWith( ">=" ) ) {
             callOperator = SqlStdOperatorTable.GREATER_THAN_OR_EQUAL;
             rightHandSide = filterString.substring( 2, filterString.length() );
+        } else if ( filterString.startsWith( ">" ) ) {
+            callOperator = SqlStdOperatorTable.GREATER_THAN;
+            rightHandSide = filterString.substring( 1, filterString.length() );
         } else if ( filterString.startsWith( "=" ) ) {
             callOperator = SqlStdOperatorTable.EQUALS;
             rightHandSide = filterString.substring( 1, filterString.length() );

--- a/rest-interface/src/main/java/org/polypheny/db/restapi/RequestParser.java
+++ b/rest-interface/src/main/java/org/polypheny/db/restapi/RequestParser.java
@@ -596,6 +596,7 @@ public class RequestParser {
     }
 
 
+    @VisibleForTesting
     Pair<SqlOperator, String> parseFilterOperation( String filterString ) throws ParserException {
         log.debug( "Starting to parse filter operation. Value: {}.", filterString );
 

--- a/rest-interface/src/test/java/org/polypheny/db/restapi/RequestParserTest.java
+++ b/rest-interface/src/test/java/org/polypheny/db/restapi/RequestParserTest.java
@@ -75,7 +75,7 @@ public class RequestParserTest {
         RequestParser requestParser = new RequestParser( mockedCatalog, null, null, "testdb", "username" );
         HashMap<String, Pair<SqlOperator, String>> operationMap = new HashMap<>();
         operationMap.put( ">=10", new Pair<>( SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, "10" ) );
-        operationMap.put( ">10", new Pair<>( SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, "10" ) );
+        operationMap.put( ">10", new Pair<>( SqlStdOperatorTable.GREATER_THAN, "10" ) );
         operationMap.put( "<=10", new Pair<>( SqlStdOperatorTable.LESS_THAN_OR_EQUAL, "10" ) );
         operationMap.put( "<10", new Pair<>( SqlStdOperatorTable.LESS_THAN, "10" ) );
         operationMap.put( "=10", new Pair<>( SqlStdOperatorTable.EQUALS, "10" ) );
@@ -85,7 +85,7 @@ public class RequestParserTest {
 
         operationMap.forEach( ( k, v ) -> {
             Pair<SqlOperator, String> operationPair = requestParser.parseFilterOperation( k );
-            assertEquals( "", operationPair, v );
+            assertEquals( v, operationPair );
         } );
     }
 

--- a/rest-interface/src/test/java/org/polypheny/db/restapi/RequestParserTest.java
+++ b/rest-interface/src/test/java/org/polypheny/db/restapi/RequestParserTest.java
@@ -42,20 +42,22 @@ public class RequestParserTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+
     @Test
     public void testBasicAuthorizationDecoding() {
         Pair<String, String> unibasDbis = RequestParser.decodeBasicAuthorization( "Basic dW5pYmFzOmRiaXM=" );
-        assertEquals("Username was decoded incorrectly.", "unibas", unibasDbis.left );
-        assertEquals("Password was decoded incorrectly.", "dbis", unibasDbis.right );
+        assertEquals( "Username was decoded incorrectly.", "unibas", unibasDbis.left );
+        assertEquals( "Password was decoded incorrectly.", "dbis", unibasDbis.right );
     }
+
 
     @Test
     public void testBasicAuthorizationDecodingGarbageHeader() {
         thrown.expect( UnauthorizedAccessException.class );
         thrown.expectMessage( "Basic Authorization header is not properly encoded." );
         Pair<String, String> unibasDbis = RequestParser.decodeBasicAuthorization( "Basic dW5pY!mFzOmRi!" );
-        assertEquals("Username was decoded incorrectly.", "unibas", unibasDbis.left );
-        assertEquals("Password was decoded incorrectly.", "dbis", unibasDbis.right );
+        assertEquals( "Username was decoded incorrectly.", "unibas", unibasDbis.left );
+        assertEquals( "Password was decoded incorrectly.", "dbis", unibasDbis.right );
     }
 
 

--- a/rest-interface/src/test/java/org/polypheny/db/restapi/RequestParserTest.java
+++ b/rest-interface/src/test/java/org/polypheny/db/restapi/RequestParserTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -31,6 +32,8 @@ import org.polypheny.db.catalog.exceptions.UnknownDatabaseException;
 import org.polypheny.db.catalog.exceptions.UnknownSchemaException;
 import org.polypheny.db.catalog.exceptions.UnknownTableException;
 import org.polypheny.db.restapi.exception.UnauthorizedAccessException;
+import org.polypheny.db.sql.SqlOperator;
+import org.polypheny.db.sql.fun.SqlStdOperatorTable;
 import org.polypheny.db.util.Pair;
 
 
@@ -63,6 +66,27 @@ public class RequestParserTest {
         RequestParser requestParser = new RequestParser( mockedCatalog, null, null, "testdb", "username" );
         CatalogTable table = requestParser.parseCatalogTableName( "schema1.table1." );
         verify( mockedCatalog ).getTable( "testdb", "schema1", "table1" );
+    }
+
+
+    @Test
+    public void testParseFilterOperation() {
+        Catalog mockedCatalog = mock( Catalog.class );
+        RequestParser requestParser = new RequestParser( mockedCatalog, null, null, "testdb", "username" );
+        HashMap<String, Pair<SqlOperator, String>> operationMap = new HashMap<>();
+        operationMap.put( ">=10", new Pair<>( SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, "10" ) );
+        operationMap.put( ">10", new Pair<>( SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, "10" ) );
+        operationMap.put( "<=10", new Pair<>( SqlStdOperatorTable.LESS_THAN_OR_EQUAL, "10" ) );
+        operationMap.put( "<10", new Pair<>( SqlStdOperatorTable.LESS_THAN, "10" ) );
+        operationMap.put( "=10", new Pair<>( SqlStdOperatorTable.EQUALS, "10" ) );
+        operationMap.put( "!=10", new Pair<>( SqlStdOperatorTable.NOT_EQUALS, "10" ) );
+        operationMap.put( "%10", new Pair<>( SqlStdOperatorTable.LIKE, "10" ) );
+        operationMap.put( "!%10", new Pair<>( SqlStdOperatorTable.NOT_LIKE, "10" ) );
+
+        operationMap.forEach( ( k, v ) -> {
+            Pair<SqlOperator, String> operationPair = requestParser.parseFilterOperation( k );
+            assertEquals( "", operationPair, v );
+        } );
     }
 
 }


### PR DESCRIPTION
The `RequestParser.parseFilterOperation` method checked for `filterString` that begin with `<` and `>` before `<=` and `>=`. This might cause filter operations for `>=` or `<=` to be falsely associated with the `>` and `<` operator and might cause an exception (For example, `public.emps.empid=>=100`. Here the operator will be falsely identified as `>` and the operand as `=10`, which will later cause a parse exception since it cannot be parsed to an integer.

This PR solves this issue.