### PR TITLE
Ignore order mode for TestHelper

### DIFF
--- a/dbms/src/test/java/org/polypheny/db/TestHelper.java
+++ b/dbms/src/test/java/org/polypheny/db/TestHelper.java
@@ -140,7 +140,7 @@ public class TestHelper {
             while ( j < expectedRow.length ) {
                 if ( expectedRow.length >= j + 1 ) {
                     int columnType = resultSet.getMetaData().getColumnType( j + 1 );
-                    if ( resultSet.getMetaData().getColumnType( j + 1 ) == Types.BINARY ) {
+                    if ( columnType == Types.BINARY ) {
                         if ( expectedRow[j] == null ) {
                             Assert.assertNull( "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "': ", resultSet.getBytes( j + 1 ) );
                         } else {

--- a/dbms/src/test/java/org/polypheny/db/TestHelper.java
+++ b/dbms/src/test/java/org/polypheny/db/TestHelper.java
@@ -24,8 +24,11 @@ import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -129,72 +132,82 @@ public class TestHelper {
     }
 
 
+    public static void checkResultSet( ResultSet resultSet, List<Object[]> expected, boolean ignoreOrderOfResultRows ) throws SQLException {
+        checkResultSet( resultSet, expected, ignoreOrderOfResultRows, false );
+    }
+
+
     // isConvertingDecimals should only(!) be set to true if a decimal value is the result of a type conversion (e.g., when change the type of column to decimal)
-    public static void checkResultSet( ResultSet resultSet, List<Object[]> expected, boolean isConvertingDecimals ) throws SQLException {
+    public static void checkResultSet( ResultSet resultSet, List<Object[]> expected, boolean ignoreOrderOfResultRows, boolean isConvertingDecimals ) throws SQLException {
+        List<Object[]> received = convertResultSetToList( resultSet );
+        if ( ignoreOrderOfResultRows ) {
+            expected = orderResultList( expected );
+            received = orderResultList( received );
+        }
+        ResultSetMetaData rsmd = resultSet.getMetaData();
         int i = 0;
-        while ( resultSet.next() ) {
+        for ( Object[] row : received ) {
             Assert.assertTrue( "Result set has more rows than expected", i < expected.size() );
             Object[] expectedRow = expected.get( i++ );
-            Assert.assertEquals( "Wrong number of columns", expectedRow.length, resultSet.getMetaData().getColumnCount() );
+            Assert.assertEquals( "Wrong number of columns", expectedRow.length, rsmd.getColumnCount() );
             int j = 0;
             while ( j < expectedRow.length ) {
                 if ( expectedRow.length >= j + 1 ) {
-                    int columnType = resultSet.getMetaData().getColumnType( j + 1 );
+                    int columnType = rsmd.getColumnType( j + 1 );
                     if ( columnType == Types.BINARY ) {
                         if ( expectedRow[j] == null ) {
-                            Assert.assertNull( "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "': ", resultSet.getBytes( j + 1 ) );
+                            Assert.assertNull( "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "': ", row[j] );
                         } else {
-                            Assert.assertEquals( "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "'",
+                            Assert.assertEquals( "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "'",
                                     new String( (byte[]) expectedRow[j] ),
-                                    new String( resultSet.getBytes( j + 1 ) ) );
+                                    new String( (byte[]) row[j] ) );
                         }
                     } else if ( columnType != Types.ARRAY ) {
                         if ( expectedRow[j] != null ) {
                             if ( columnType == Types.FLOAT || columnType == Types.REAL ) {
-                                float diff = Math.abs( (float) expectedRow[j] - resultSet.getFloat( j + 1 ) );
+                                float diff = Math.abs( (float) expectedRow[j] - (float) row[j] );
                                 Assert.assertTrue(
-                                        "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "': The difference between the expected float and the received float exceeds the epsilon. Difference: " + (diff - EPSILON),
+                                        "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "': The difference between the expected float and the received float exceeds the epsilon. Difference: " + (diff - EPSILON),
                                         diff < EPSILON );
                             } else if ( columnType == Types.DOUBLE ) {
-                                double diff = Math.abs( (double) expectedRow[j] - resultSet.getDouble( j + 1 ) );
+                                double diff = Math.abs( (double) expectedRow[j] - (double) row[j] );
                                 Assert.assertTrue(
-                                        "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "': The difference between the expected double and the received double exceeds the epsilon. Difference: " + (diff - EPSILON),
+                                        "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "': The difference between the expected double and the received double exceeds the epsilon. Difference: " + (diff - EPSILON),
                                         diff < EPSILON );
                             } else if ( columnType == Types.DECIMAL ) { // Decimals are exact // but not for calculations?
                                 BigDecimal expectedResult = (BigDecimal) expectedRow[j];
-                                BigDecimal result = resultSet.getBigDecimal( j + 1 );
-                                double diff = Math.abs( expectedResult.doubleValue() - result.doubleValue() );
+                                double diff = Math.abs( expectedResult.doubleValue() - ((BigDecimal) row[j]).doubleValue() );
                                 if ( isConvertingDecimals ) {
                                     Assert.assertTrue(
-                                            "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "': The difference between the expected decimal and the received decimal exceeds the epsilon. Difference: " + (diff - EPSILON),
+                                            "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "': The difference between the expected decimal and the received decimal exceeds the epsilon. Difference: " + (diff - EPSILON),
                                             diff < EPSILON );
                                 } else {
-                                    Assert.assertEquals( "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "'", 0, expectedResult.doubleValue() - result.doubleValue(), 0.0 );
+                                    Assert.assertEquals( "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "'", 0, expectedResult.doubleValue() - ((BigDecimal) row[j]).doubleValue(), 0.0 );
                                 }
                             } else {
                                 Assert.assertEquals(
-                                        "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "'",
+                                        "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "'",
                                         expectedRow[j],
-                                        resultSet.getObject( j + 1 )
+                                        row[j]
                                 );
                             }
                         } else {
                             Assert.assertEquals(
-                                    "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "'",
+                                    "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "'",
                                     expectedRow[j],
-                                    resultSet.getObject( j + 1 )
+                                    row[j]
                             );
                         }
 
                     } else {
-                        List resultList = SqlFunctions.deepArrayToList( resultSet.getArray( j + 1 ) );
+                        List resultList = (List) row[j];
                         Object[] expectedArray = (Object[]) expectedRow[j];
                         if ( expectedArray == null ) {
-                            Assert.assertNull( "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "': ", resultList );
+                            Assert.assertNull( "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "': ", resultList );
                         } else {
                             for ( int k = 0; k < expectedArray.length; k++ ) {
                                 Assert.assertEquals(
-                                        "Unexpected data in column '" + resultSet.getMetaData().getColumnName( j + 1 ) + "' at position: " + k + 1,
+                                        "Unexpected data in column '" + rsmd.getColumnName( j + 1 ) + "' at position: " + k + 1,
                                         expectedArray[k],
                                         resultList.get( k ) );
                             }
@@ -207,6 +220,52 @@ public class TestHelper {
             }
         }
         Assert.assertEquals( "Wrong number of rows in the result set", expected.size(), i );
+    }
+
+
+    private static List<Object[]> convertResultSetToList( ResultSet resultSet ) throws SQLException {
+        ResultSetMetaData md = resultSet.getMetaData();
+        int columns = md.getColumnCount();
+        List<Object[]> list = new ArrayList<>();
+        while ( resultSet.next() ) {
+            Object[] row = new Object[columns];
+            for ( int i = 1; i <= columns; ++i ) {
+                int columnType = resultSet.getMetaData().getColumnType( i );
+                if ( columnType == Types.BINARY ) {
+                    row[i - 1] = resultSet.getBytes( i );
+                } else if ( columnType != Types.ARRAY ) {
+                    if ( resultSet.getObject( i ) != null ) {
+                        if ( columnType == Types.FLOAT || columnType == Types.REAL ) {
+                            row[i - 1] = resultSet.getFloat( i );
+                        } else if ( columnType == Types.DOUBLE ) {
+                            row[i - 1] = resultSet.getDouble( i );
+                        } else if ( columnType == Types.DECIMAL ) {
+                            row[i - 1] = resultSet.getBigDecimal( i );
+                        } else {
+                            row[i - 1] = resultSet.getObject( i );
+                        }
+                    } else {
+                        row[i - 1] = resultSet.getObject( i );
+                    }
+                } else {
+                    row[i - 1] = SqlFunctions.deepArrayToList( resultSet.getArray( i ) );
+                }
+            }
+            list.add( row );
+        }
+        return list;
+    }
+
+
+    private static List<Object[]> orderResultList( List<Object[]> result ) {
+        List<Object[]> list = new ArrayList<>( result );
+        list.sort( ( lhs, rhs ) -> {
+            String lhsStr = Arrays.toString( lhs );
+            String rhsStr = Arrays.toString( rhs );
+            // -1 - less than, 1 - greater than, 0 - equal, all inversed for descending
+            return lhsStr.compareTo( rhsStr );
+        } );
+        return list;
     }
 
 

--- a/dbms/src/test/java/org/polypheny/db/jdbc/JdbcDdlTest.java
+++ b/dbms/src/test/java/org/polypheny/db/jdbc/JdbcDdlTest.java
@@ -552,6 +552,7 @@ public class JdbcDdlTest {
                     TestHelper.checkResultSet(
                             statement.executeQuery( "SELECT tdouble FROM ddltest" ),
                             ImmutableList.of( new Object[]{ BigDecimal.valueOf( (double) DDLTEST_DATA[4] ) } ),
+                            false,
                             true );
 
                     // Real --> Double

--- a/dbms/src/test/java/org/polypheny/db/jdbc/JdbcPreparedStatementsTest.java
+++ b/dbms/src/test/java/org/polypheny/db/jdbc/JdbcPreparedStatementsTest.java
@@ -138,13 +138,14 @@ public class JdbcPreparedStatementsTest {
                     preparedInsert.executeBatch();
                     connection.commit();
 
-                    PreparedStatement preparedSelect = connection.prepareStatement( "SELECT tinteger,tvarchar FROM pstest WHERE tinteger >= ? ORDER BY tinteger" );
+                    PreparedStatement preparedSelect = connection.prepareStatement( "SELECT tinteger,tvarchar FROM pstest WHERE tinteger >= ?" );
                     preparedSelect.setInt( 1, 1 );
                     TestHelper.checkResultSet(
                             preparedSelect.executeQuery(),
                             ImmutableList.of(
                                     new Object[]{ 1, "Foo" },
-                                    new Object[]{ 2, "Bar" } ) );
+                                    new Object[]{ 2, "Bar" } ),
+                            true );
 
                 } finally {
                     statement.executeUpdate( "DROP TABLE pstest" );
@@ -173,12 +174,13 @@ public class JdbcPreparedStatementsTest {
                     preparedInsert.executeBatch();
                     connection.commit();
 
-                    PreparedStatement preparedSelect = connection.prepareStatement( "SELECT tinteger,tvarchar FROM pstest ORDER BY tinteger" );
+                    PreparedStatement preparedSelect = connection.prepareStatement( "SELECT tinteger,tvarchar FROM pstest" );
                     TestHelper.checkResultSet(
                             preparedSelect.executeQuery(),
                             ImmutableList.of(
                                     new Object[]{ 1, "hans" },
-                                    new Object[]{ 2, "hans" } ) );
+                                    new Object[]{ 2, "hans" } ),
+                            true );
                 } finally {
                     statement.executeUpdate( "DROP TABLE pstest" );
                 }

--- a/dbms/src/test/java/org/polypheny/db/jdbc/JdbcPreparedStatementsTest.java
+++ b/dbms/src/test/java/org/polypheny/db/jdbc/JdbcPreparedStatementsTest.java
@@ -138,7 +138,7 @@ public class JdbcPreparedStatementsTest {
                     preparedInsert.executeBatch();
                     connection.commit();
 
-                    PreparedStatement preparedSelect = connection.prepareStatement( "SELECT tinteger,tvarchar FROM pstest WHERE tinteger >= ?" );
+                    PreparedStatement preparedSelect = connection.prepareStatement( "SELECT tinteger,tvarchar FROM pstest WHERE tinteger >= ? ORDER BY tinteger" );
                     preparedSelect.setInt( 1, 1 );
                     TestHelper.checkResultSet(
                             preparedSelect.executeQuery(),
@@ -173,7 +173,7 @@ public class JdbcPreparedStatementsTest {
                     preparedInsert.executeBatch();
                     connection.commit();
 
-                    PreparedStatement preparedSelect = connection.prepareStatement( "SELECT tinteger,tvarchar FROM pstest" );
+                    PreparedStatement preparedSelect = connection.prepareStatement( "SELECT tinteger,tvarchar FROM pstest ORDER BY tinteger" );
                     TestHelper.checkResultSet(
                             preparedSelect.executeQuery(),
                             ImmutableList.of(

--- a/dbms/src/test/java/org/polypheny/db/sql/view/ViewTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/view/ViewTest.java
@@ -110,12 +110,13 @@ public class ViewTest {
                             )
                     );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewTestEmpDep ORDER BY firstName" ),
+                            statement.executeQuery( "SELECT * FROM viewTestEmpDep" ),
                             ImmutableList.of(
-                                    new Object[]{ "Elsa", "HR" },
+                                    new Object[]{ "Max", "IT" },
                                     new Object[]{ "Ernst", "Sales" },
-                                    new Object[]{ "Max", "IT" }
-                            )
+                                    new Object[]{ "Elsa", "HR" }
+                            ),
+                            true
                     );
                     connection.commit();
                 } finally {
@@ -145,23 +146,26 @@ public class ViewTest {
                     statement.executeUpdate( "ALTER VIEW viewTestEmp RENAME COLUMN depId TO departmentId" );
 
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT employeeId FROM viewTestEmp ORDER BY employeeId" ),
+                            statement.executeQuery( "SELECT employeeId FROM viewTestEmp" ),
                             ImmutableList.of(
                                     new Object[]{ 1 },
                                     new Object[]{ 2 },
-                                    new Object[]{ 3 } ) );
+                                    new Object[]{ 3 } ),
+                            true );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT fName FROM viewTestEmp ORDER BY fname" ),
+                            statement.executeQuery( "SELECT fName FROM viewTestEmp" ),
                             ImmutableList.of(
-                                    new Object[]{ "Elsa" },
+                                    new Object[]{ "Max" },
                                     new Object[]{ "Ernst" },
-                                    new Object[]{ "Max" } ) );
+                                    new Object[]{ "Elsa" } ),
+                            true );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT lName FROM viewTestEmp ORDER BY lName" ),
+                            statement.executeQuery( "SELECT lName FROM viewTestEmp" ),
                             ImmutableList.of(
                                     new Object[]{ "Kuster" },
                                     new Object[]{ "Muster" },
-                                    new Object[]{ "Walter" } ) );
+                                    new Object[]{ "Walter" } ),
+                            true );
                     TestHelper.checkResultSet(
                             statement.executeQuery( "SELECT departmentId FROM viewTestEmp ORDER BY departmentId" ),
                             ImmutableList.of(
@@ -204,12 +208,13 @@ public class ViewTest {
                             )
                     );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewRenameDepTest ORDER BY depid" ),
+                            statement.executeQuery( "SELECT * FROM viewRenameDepTest" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "IT", 1 },
                                     new Object[]{ 2, "Sales", 2 },
                                     new Object[]{ 3, "HR", 3 }
-                            )
+                            ),
+                            true
                     );
                     connection.commit();
                 } finally {
@@ -350,12 +355,13 @@ public class ViewTest {
                     statement.executeUpdate( "CREATE VIEW viewTestEmp AS SELECT * FROM viewTestEmpTable" );
                     statement.executeUpdate( "CREATE VIEW viewTestDep AS SELECT * FROM viewTestDepTable" );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewTestEmp, viewTestDep WHERE depname = 'IT' ORDER BY empid" ),
+                            statement.executeQuery( "SELECT * FROM viewTestEmp, viewTestDep WHERE depname = 'IT'" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "Max", "Muster", 1, 1, "IT", 1 },
                                     new Object[]{ 2, "Ernst", "Walter", 2, 1, "IT", 1 },
                                     new Object[]{ 3, "Elsa", "Kuster", 3, 1, "IT", 1 }
-                            )
+                            ),
+                            true
                     );
 
                     connection.commit();
@@ -385,12 +391,13 @@ public class ViewTest {
                     statement.executeUpdate( "CREATE VIEW viewTestDep AS SELECT * FROM viewTestDepTable" );
                     statement.executeUpdate( "Create view viewFromView as Select * FROM viewTestEmp, viewTestDep WHERE depname = 'IT'" );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewFromView ORDER BY empid" ),
+                            statement.executeQuery( "SELECT * FROM viewFromView" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "Max", "Muster", 1, 1, "IT", 1 },
                                     new Object[]{ 2, "Ernst", "Walter", 2, 1, "IT", 1 },
                                     new Object[]{ 3, "Elsa", "Kuster", 3, 1, "IT", 1 }
-                            )
+                            ),
+                            true
                     );
 
                     connection.commit();

--- a/dbms/src/test/java/org/polypheny/db/sql/view/ViewTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/view/ViewTest.java
@@ -94,7 +94,7 @@ public class ViewTest {
                     statement.executeUpdate( "CREATE VIEW viewTestEmp AS SELECT * FROM viewTestEmpTable" );
                     statement.executeUpdate( "CREATE VIEW viewTestEmpDep AS SELECT viewTestEmpTable.firstName, viewTestDepTable.depName FROM viewTestEmpTable INNER JOIN viewTestDepTable ON viewTestEmpTable.depId = viewTestDepTable.depId" );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewTestEmp" ),
+                            statement.executeQuery( "SELECT * FROM viewTestEmp ORDER BY empid" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "Max", "Muster", 1 },
                                     new Object[]{ 2, "Ernst", "Walter", 2 },
@@ -102,19 +102,19 @@ public class ViewTest {
                             )
                     );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT viewTestEmp.firstName FROM viewTestEmp" ),
+                            statement.executeQuery( "SELECT viewTestEmp.firstName FROM viewTestEmp ORDER BY viewTestEmp.firstName" ),
                             ImmutableList.of(
-                                    new Object[]{ "Max" },
+                                    new Object[]{ "Elsa" },
                                     new Object[]{ "Ernst" },
-                                    new Object[]{ "Elsa" }
+                                    new Object[]{ "Max" }
                             )
                     );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewTestEmpDep" ),
+                            statement.executeQuery( "SELECT * FROM viewTestEmpDep ORDER BY firstName" ),
                             ImmutableList.of(
-                                    new Object[]{ "Max", "IT" },
+                                    new Object[]{ "Elsa", "HR" },
                                     new Object[]{ "Ernst", "Sales" },
-                                    new Object[]{ "Elsa", "HR" }
+                                    new Object[]{ "Max", "IT" }
                             )
                     );
                     connection.commit();
@@ -145,25 +145,25 @@ public class ViewTest {
                     statement.executeUpdate( "ALTER VIEW viewTestEmp RENAME COLUMN depId TO departmentId" );
 
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT employeeId FROM viewTestEmp" ),
+                            statement.executeQuery( "SELECT employeeId FROM viewTestEmp ORDER BY employeeId" ),
                             ImmutableList.of(
                                     new Object[]{ 1 },
                                     new Object[]{ 2 },
                                     new Object[]{ 3 } ) );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT fName FROM viewTestEmp" ),
+                            statement.executeQuery( "SELECT fName FROM viewTestEmp ORDER BY fname" ),
                             ImmutableList.of(
-                                    new Object[]{ "Max" },
+                                    new Object[]{ "Elsa" },
                                     new Object[]{ "Ernst" },
-                                    new Object[]{ "Elsa" } ) );
+                                    new Object[]{ "Max" } ) );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT lName FROM viewTestEmp" ),
+                            statement.executeQuery( "SELECT lName FROM viewTestEmp ORDER BY lName" ),
                             ImmutableList.of(
+                                    new Object[]{ "Kuster" },
                                     new Object[]{ "Muster" },
-                                    new Object[]{ "Walter" },
-                                    new Object[]{ "Kuster" } ) );
+                                    new Object[]{ "Walter" } ) );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT departmentId FROM viewTestEmp" ),
+                            statement.executeQuery( "SELECT departmentId FROM viewTestEmp ORDER BY departmentId" ),
                             ImmutableList.of(
                                     new Object[]{ 1 },
                                     new Object[]{ 2 },
@@ -196,7 +196,7 @@ public class ViewTest {
                     statement.executeUpdate( "ALTER TABLE viewTestDep RENAME TO viewRenameDepTest" );
 
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewRenameEmpTest" ),
+                            statement.executeQuery( "SELECT * FROM viewRenameEmpTest ORDER BY empid" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "Max", "Muster", 1 },
                                     new Object[]{ 2, "Ernst", "Walter", 2 },
@@ -204,7 +204,7 @@ public class ViewTest {
                             )
                     );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewRenameDepTest" ),
+                            statement.executeQuery( "SELECT * FROM viewRenameDepTest ORDER BY depid" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "IT", 1 },
                                     new Object[]{ 2, "Sales", 2 },
@@ -317,7 +317,7 @@ public class ViewTest {
                 try {
                     statement.executeUpdate( "CREATE VIEW viewTestEmp AS SELECT * FROM viewTestEmpTable" );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewTestEmp, viewTestDepTable WHERE depname = 'IT'" ),
+                            statement.executeQuery( "SELECT * FROM viewTestEmp, viewTestDepTable WHERE depname = 'IT' ORDER BY empid" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "Max", "Muster", 1, 1, "IT", 1 },
                                     new Object[]{ 2, "Ernst", "Walter", 2, 1, "IT", 1 },
@@ -350,7 +350,7 @@ public class ViewTest {
                     statement.executeUpdate( "CREATE VIEW viewTestEmp AS SELECT * FROM viewTestEmpTable" );
                     statement.executeUpdate( "CREATE VIEW viewTestDep AS SELECT * FROM viewTestDepTable" );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewTestEmp, viewTestDep WHERE depname = 'IT'" ),
+                            statement.executeQuery( "SELECT * FROM viewTestEmp, viewTestDep WHERE depname = 'IT' ORDER BY empid" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "Max", "Muster", 1, 1, "IT", 1 },
                                     new Object[]{ 2, "Ernst", "Walter", 2, 1, "IT", 1 },
@@ -385,7 +385,7 @@ public class ViewTest {
                     statement.executeUpdate( "CREATE VIEW viewTestDep AS SELECT * FROM viewTestDepTable" );
                     statement.executeUpdate( "Create view viewFromView as Select * FROM viewTestEmp, viewTestDep WHERE depname = 'IT'" );
                     TestHelper.checkResultSet(
-                            statement.executeQuery( "SELECT * FROM viewFromView" ),
+                            statement.executeQuery( "SELECT * FROM viewFromView ORDER BY empid" ),
                             ImmutableList.of(
                                     new Object[]{ 1, "Max", "Muster", 1, 1, "IT", 1 },
                                     new Object[]{ 2, "Ernst", "Walter", 2, 1, "IT", 1 },


### PR DESCRIPTION
This PR extends the TestHelper and adds a mode in which the order of the rows is ignored. This allows to check multi-row result sets without a ORDER BY clause.