### PR TITLE
Monitoring threads

### DIFF
--- a/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringQueueImpl.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringQueueImpl.java
@@ -154,7 +154,7 @@ public class MonitoringQueueImpl implements MonitoringQueue {
             if (this.threadCount != this.getPoolSize()) {
                 this.threadCount = this.getPoolSize();
                 if (log.isDebugEnabled()) {
-                    log.debug("Thread count for monitoring service: {}", this.threadCount);
+                    log.debug("Thread count for monitoring queue: {}", this.threadCount);
                 }
             }
             super.beforeExecute(t, r);
@@ -166,7 +166,7 @@ public class MonitoringQueueImpl implements MonitoringQueue {
             if (this.threadCount != this.getPoolSize()){
                 this.threadCount = this.getPoolSize();
                 if (log.isDebugEnabled()) {
-                    log.debug("Thread count for monitoring service: {}", this.threadCount);
+                    log.debug("Thread count for monitoring queue: {}", this.threadCount);
                 }
             }
         }

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringQueueImpl.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringQueueImpl.java
@@ -16,7 +16,9 @@
 
 package org.polypheny.db.monitoring.core;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -74,7 +76,8 @@ public class MonitoringQueueImpl implements MonitoringQueue {
             RuntimeConfig.MONITORING_MAXIMUM_POOL_SIZE.setRequiresRestart( true );
             RuntimeConfig.MONITORING_POOL_KEEP_ALIVE_TIME.setRequiresRestart( true );
 
-            threadPoolWorkers = new MonitoringThreadPoolExecutor( CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME, TimeUnit.SECONDS, eventQueue );
+            threadPoolWorkers = new MonitoringThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME,
+                    TimeUnit.SECONDS, eventQueue);
         }
     }
 
@@ -142,31 +145,35 @@ public class MonitoringQueueImpl implements MonitoringQueue {
      * and logs new thread count if there is a change.
      */
     class MonitoringThreadPoolExecutor extends ThreadPoolExecutor {
+
         private int threadCount;
-        public MonitoringThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
-                                            BlockingQueue<Runnable> workQueue) {
-            super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+
+        public MonitoringThreadPoolExecutor( int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+                BlockingQueue<Runnable> workQueue ) {
+            super( corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue );
             this.threadCount = this.getPoolSize();
         }
 
         @Override
-        protected void beforeExecute(Thread t, Runnable r){
-            if (this.threadCount != this.getPoolSize()) {
+        protected void beforeExecute( Thread t, Runnable r ){
+            if ( this.threadCount != this.getPoolSize() ) {
                 this.threadCount = this.getPoolSize();
-                if (log.isDebugEnabled()) {
-                    log.debug("Thread count for monitoring queue: {}", this.threadCount);
+                if ( log.isDebugEnabled() ) {
+                    log.debug( "Thread count for monitoring queue: {}", this.threadCount );
                 }
             }
-            super.beforeExecute(t, r);
+
+            super.beforeExecute( t, r );
         }
 
         @Override
-        protected void afterExecute(Runnable r, Throwable t) {
-            super.afterExecute(r, t);
-            if (this.threadCount != this.getPoolSize()){
+        protected void afterExecute( Runnable r, Throwable t ) {
+            super.afterExecute( r, t );
+
+            if ( this.threadCount != this.getPoolSize() ){
                 this.threadCount = this.getPoolSize();
-                if (log.isDebugEnabled()) {
-                    log.debug("Thread count for monitoring queue: {}", this.threadCount);
+                if ( log.isDebugEnabled() ) {
+                    log.debug( "Thread count for monitoring queue: {}", this.threadCount );
                 }
             }
         }

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringQueueImpl.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringQueueImpl.java
@@ -140,19 +140,23 @@ public class MonitoringQueueImpl implements MonitoringQueue {
         return threadPoolWorkers.getCompletedTaskCount();
     }
 
+
     /**
      * Overrides beforeExecute and afterExecute of ThreadPoolExecutor to check the number of threads
      * and logs new thread count if there is a change.
      */
     class MonitoringThreadPoolExecutor extends ThreadPoolExecutor {
 
+
         private int threadCount;
+
 
         public MonitoringThreadPoolExecutor( int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
                 BlockingQueue<Runnable> workQueue ) {
             super( corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue );
             this.threadCount = this.getPoolSize();
         }
+
 
         @Override
         protected void beforeExecute( Thread t, Runnable r ){
@@ -166,6 +170,7 @@ public class MonitoringQueueImpl implements MonitoringQueue {
             super.beforeExecute( t, r );
         }
 
+
         @Override
         protected void afterExecute( Runnable r, Throwable t ) {
             super.afterExecute( r, t );
@@ -178,6 +183,7 @@ public class MonitoringQueueImpl implements MonitoringQueue {
             }
         }
     }
+
 
     class MonitoringWorker implements Runnable {
 

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringQueueImpl.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringQueueImpl.java
@@ -152,7 +152,7 @@ public class MonitoringQueueImpl implements MonitoringQueue {
 
 
     @Override
-    public long getNumberOfProcessedEvents() {
+    public synchronized long getNumberOfProcessedEvents() {
         return threadPoolWorkers.getCompletedTaskCount();
     }
 
@@ -194,50 +194,5 @@ public class MonitoringQueueImpl implements MonitoringQueue {
                 }
             }
         }
-
     }
-
-    /*
-    class ThreadMonitor implements Runnable{
-        private int corePoolThreadsCount;
-        private int threadCount;
-        private ThreadPoolExecutor monitoredThread;
-
-        public ThreadMonitor(ThreadPoolExecutor t) {
-            super();
-            this.monitoredThread = t;
-            this.corePoolThreadsCount = t.getCorePoolSize();
-            this.threadCount = t.getPoolSize();
-        }
-
-        public void run() {
-            while (true) {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    log.error("Thread Monitor wasn't able to sleep");
-                }
-
-                log.info("The guard is monitoring the threats.");
-
-                int newCorePoolCount = monitoredThread.getCorePoolSize();
-                int newThreadCount = monitoredThread.getPoolSize();
-
-                if (newCorePoolCount != this.corePoolThreadsCount) {
-                    this.corePoolThreadsCount = newCorePoolCount;
-                    log.info("new core pool thread count is = {}", this.corePoolThreadsCount);
-                }
-
-                if (newThreadCount != this.threadCount) {
-                    this.threadCount = newThreadCount;
-                    log.info("new thread count is = {}", this.threadCount);
-                }
-            }
-        }
-
-
-
-    }
-     */
-
 }


### PR DESCRIPTION
**Change**: added the monitoring of threads by logging the new number of threads whenever there is a change (fixes #395)

**Implementation**:
Incorporated another thread in `MonitoringQueueImpl.java` which checks the change in number of threads every 500 milliseconds, and logs the info whenever there is a change as necessary.

**Possible points of concern:**
- I created a separate thread which uses getters from ThreadPoolExecutor, so I had to lock all methods which used ThreadPoolExecutor, which may affect performance.
- All changes are nested into main() since it is fairly short, so further refactoring may be necessary.
- Changing 500 ms into other periods, or perhaps using another solution altogether. Since there is no hook for ThreadPoolExecutor to see when threads change, I currently think this is the best method. 