### PR TITLE
Allow to specify colors for information graphs

### DIFF
--- a/dbms/src/main/java/org/polypheny/db/information/JavaInformation.java
+++ b/dbms/src/main/java/org/polypheny/db/information/JavaInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 The Polypheny Project
+ * Copyright 2019-2022 The Polypheny Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dbms/src/main/java/org/polypheny/db/information/JavaInformation.java
+++ b/dbms/src/main/java/org/polypheny/db/information/JavaInformation.java
@@ -18,6 +18,7 @@ package org.polypheny.db.information;
 
 
 import java.util.Arrays;
+import java.util.List;
 import org.polypheny.db.information.InformationGraph.GraphData;
 import org.polypheny.db.information.InformationGraph.GraphType;
 import org.polypheny.db.util.background.BackgroundTask.TaskPriority;
@@ -54,6 +55,7 @@ public class JavaInformation {
                 GraphType.DOUGHNUT,
                 new String[]{ "Current", "Maximum", "Free" }
         );
+        heapInfoGraph.colorList( List.of( GraphColor.PASTEL_RED, GraphColor.BATTERY_CHARGED_BLUE, GraphColor.LIME ) );
         im.registerInformation( heapInfoGraph );
 
         InformationTable heapInfoTable = new InformationTable(

--- a/information/src/main/java/org/polypheny/db/information/GraphColor.java
+++ b/information/src/main/java/org/polypheny/db/information/GraphColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The Polypheny Project
+ * Copyright 2019-2022 The Polypheny Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/information/src/main/java/org/polypheny/db/information/GraphColor.java
+++ b/information/src/main/java/org/polypheny/db/information/GraphColor.java
@@ -24,15 +24,24 @@ import com.google.gson.annotations.SerializedName;
  */
 public enum GraphColor {
 
-    // TODO: values
-    @SerializedName("#000000")
-    BLUE,
-    @SerializedName("#000011")
-    LIGHTBLUE,
-    @SerializedName("#000022")
-    YELLOW,
-    @SerializedName("#000033")
-    RED,
-    @SerializedName("#000044")
-    GREEN
+    @SerializedName("#F86C6B")
+    PASTEL_RED,
+    @SerializedName("#20A8d8")
+    BATTERY_CHARGED_BLUE,
+    @SerializedName("#FFC107")
+    MIKADO_YELLOW,
+    @SerializedName("#21576A")
+    POLICE_BLUE,
+    @SerializedName("#814848")
+    TUSCAN_RED,
+    @SerializedName("#88BB9A")
+    DARK_SEE_GREEN,
+    @SerializedName("#3A7C96")
+    JELLY_BEAN_BLUE,
+    @SerializedName("#914661")
+    TWILIGHT_LAVENDER,
+    @SerializedName("#BFA0AB")
+    SILVER_PINK,
+    @SerializedName("#BAD80A")
+    LIME
 }

--- a/information/src/main/java/org/polypheny/db/information/GraphColor.java
+++ b/information/src/main/java/org/polypheny/db/information/GraphColor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2020 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.information;
+
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Possible colors for an InformationGraph
+ */
+public enum GraphColor {
+
+    // TODO: values
+    @SerializedName("#000000")
+    BLUE,
+    @SerializedName("#000011")
+    LIGHTBLUE,
+    @SerializedName("#000022")
+    YELLOW,
+    @SerializedName("#000033")
+    RED,
+    @SerializedName("#000044")
+    GREEN
+}

--- a/information/src/main/java/org/polypheny/db/information/InformationGraph.java
+++ b/information/src/main/java/org/polypheny/db/information/InformationGraph.java
@@ -58,7 +58,8 @@ public class InformationGraph extends Information {
     private int maxY;
 
     @Setter
-    private List<GraphColor> colorList = List.of(GraphColor.BLUE, GraphColor.LIGHTBLUE, GraphColor.YELLOW);
+    private List<GraphColor> colorList = List.of(GraphColor.POLICE_BLUE, GraphColor.MIKADO_YELLOW, GraphColor.PASTEL_RED, GraphColor.TUSCAN_RED,
+            GraphColor.DARK_SEE_GREEN, GraphColor.SILVER_PINK, GraphColor.TWILIGHT_LAVENDER );
 
     /**
      * Constructor

--- a/information/src/main/java/org/polypheny/db/information/InformationGraph.java
+++ b/information/src/main/java/org/polypheny/db/information/InformationGraph.java
@@ -58,8 +58,8 @@ public class InformationGraph extends Information {
     private int maxY;
 
     @Setter
-    private List<GraphColor> colorList = List.of( GraphColor.POLICE_BLUE, GraphColor.MIKADO_YELLOW, GraphColor.PASTEL_RED, GraphColor.TUSCAN_RED,
-            GraphColor.DARK_SEE_GREEN, GraphColor.SILVER_PINK, GraphColor.TWILIGHT_LAVENDER );
+    @SuppressWarnings("unused")
+    private List<GraphColor> colorList = List.of( GraphColor.PASTEL_RED, GraphColor.BATTERY_CHARGED_BLUE, GraphColor.MIKADO_YELLOW, GraphColor.POLICE_BLUE, GraphColor.TUSCAN_RED, GraphColor.DARK_SEE_GREEN, GraphColor.JELLY_BEAN_BLUE, GraphColor.TWILIGHT_LAVENDER, GraphColor.SILVER_PINK, GraphColor.LIME );
 
 
     /**

--- a/information/src/main/java/org/polypheny/db/information/InformationGraph.java
+++ b/information/src/main/java/org/polypheny/db/information/InformationGraph.java
@@ -20,6 +20,7 @@ package org.polypheny.db.information;
 import com.google.gson.annotations.SerializedName;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Setter;
@@ -56,6 +57,8 @@ public class InformationGraph extends Information {
     @SerializedName("max")
     private int maxY;
 
+    @Setter
+    private List<GraphColor> colorList = List.of(GraphColor.BLUE, GraphColor.LIGHTBLUE, GraphColor.YELLOW);
 
     /**
      * Constructor

--- a/information/src/main/java/org/polypheny/db/information/InformationGraph.java
+++ b/information/src/main/java/org/polypheny/db/information/InformationGraph.java
@@ -58,8 +58,9 @@ public class InformationGraph extends Information {
     private int maxY;
 
     @Setter
-    private List<GraphColor> colorList = List.of(GraphColor.POLICE_BLUE, GraphColor.MIKADO_YELLOW, GraphColor.PASTEL_RED, GraphColor.TUSCAN_RED,
+    private List<GraphColor> colorList = List.of( GraphColor.POLICE_BLUE, GraphColor.MIKADO_YELLOW, GraphColor.PASTEL_RED, GraphColor.TUSCAN_RED,
             GraphColor.DARK_SEE_GREEN, GraphColor.SILVER_PINK, GraphColor.TWILIGHT_LAVENDER );
+
 
     /**
      * Constructor


### PR DESCRIPTION
## Summary
[Related PR for the UI.](https://github.com/polypheny/Polypheny-UI/pull/74)

**Fixes:** [Allow to specifiy colors for graphs #284](https://github.com/polypheny/Polypheny-DB/issues/284)

### Changes

- GraphColor Enum added
- Informationgraph extended by colorList (List of GraphColor Enum) erweitert. 
### Features

- This set method of the colorList overrides the default list of colors. This avoids changing the signature of the constructor and makes setting a custom order of columns optional.

### ToDo

<!-- For WIP PR add meaningful todos -->

- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
- [ ] ...

