### PR TITLE
Heading for version 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.8.1 (November 3, 2022)
+
+* Fixing support for Java 19
+* Fix an issue with the status handling for Docker containers that lead to the wrong status of a container being reported
+* Extend connection options for Docker containers
+
+
 ## 0.8.0 (October 23, 2022)
 
 * Add support for the labeled property graph data model

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 
 versionMajor = 0
 versionMinor = 8
-versionMicro = 1
+versionMicro = 2
 isRelease = false
 
 # org.gradle.parallel = true


### PR DESCRIPTION
This PR prepares for the next development cycle.

Changes

* Set version number to `0.8.2-SNAPSHOT`
* Update the changelog file
