### PR TITLE
Add a way to specify a preferred store which should be used for queries

### DIFF
--- a/core/src/main/java/org/polypheny/db/plan/AlgOptTable.java
+++ b/core/src/main/java/org/polypheny/db/plan/AlgOptTable.java
@@ -135,6 +135,8 @@ public interface AlgOptTable extends Wrapper {
      */
     List<ColumnStrategy> getColumnStrategies();
 
+    void setPreferredPlacement( String placement );
+    String getPreferredPlacement();
 
     default Table getTable() {
         return null;

--- a/core/src/main/java/org/polypheny/db/prepare/AlgOptTableImpl.java
+++ b/core/src/main/java/org/polypheny/db/prepare/AlgOptTableImpl.java
@@ -100,6 +100,8 @@ public class AlgOptTableImpl extends Prepare.AbstractPreparingTable {
     private final transient Function<Class, Expression> expressionFunction;
     private final ImmutableList<String> names;
 
+    String preferredPlacement;
+
     /**
      * Estimate for the row count, or null.
      * <p>
@@ -121,6 +123,7 @@ public class AlgOptTableImpl extends Prepare.AbstractPreparingTable {
         this.table = table; // may be null
         this.expressionFunction = expressionFunction; // may be null
         this.rowCount = rowCount; // may be null
+	this.preferredPlacement = null;
     }
 
 
@@ -400,6 +403,18 @@ public class AlgOptTableImpl extends Prepare.AbstractPreparingTable {
     @Override
     public AccessType getAllowedAccess() {
         return AccessType.ALL;
+    }
+
+
+    @Override
+    public void setPreferredPlacement( String placement ) {
+	preferredPlacement = placement;
+    }
+
+
+    @Override
+    public String getPreferredPlacement() {
+	return preferredPlacement;
     }
 
 

--- a/core/src/main/java/org/polypheny/db/processing/LogicalAlgAnalyzeShuttle.java
+++ b/core/src/main/java/org/polypheny/db/processing/LogicalAlgAnalyzeShuttle.java
@@ -292,7 +292,7 @@ public class LogicalAlgAnalyzeShuttle extends AlgShuttleImpl {
 
     @Override
     public AlgNode visit( Scan scan ) {
-        hashBasis.add( "Scan#" + scan.getTable().getQualifiedName() );
+        hashBasis.add( "Scan#" + scan.getTable().getQualifiedName() + "@" + scan.getTable().getPreferredPlacement() );
         // get available columns for every table scan
         this.getAvailableColumns( scan );
 

--- a/core/src/test/java/org/polypheny/db/catalog/MockCatalogReader.java
+++ b/core/src/test/java/org/polypheny/db/catalog/MockCatalogReader.java
@@ -390,6 +390,17 @@ public abstract class MockCatalogReader extends PolyphenyDbCatalogReader {
         }
 
 
+	@Override
+	public void setPreferredPlacement( String placement ) {
+	}
+
+
+	@Override
+	public String getPreferredPlacement() {
+	    return null;
+	}
+
+
         public static MockTable create( MockCatalogReader catalogReader, MockSchema schema, String name, boolean stream, double rowCount ) {
             return create( catalogReader, schema, name, stream, rowCount, null );
         }

--- a/dbms/src/main/java/org/polypheny/db/routing/routers/SimpleRouter.java
+++ b/dbms/src/main/java/org/polypheny/db/routing/routers/SimpleRouter.java
@@ -53,7 +53,7 @@ public class SimpleRouter extends AbstractDqlRouter {
     @Override
     protected List<RoutedAlgBuilder> handleNonePartitioning( AlgNode node, CatalogTable catalogTable, Statement statement, List<RoutedAlgBuilder> builders, AlgOptCluster cluster, LogicalQueryInformation queryInformation ) {
         // Get placements and convert into placement distribution
-        final Map<Long, List<CatalogColumnPlacement>> placements = selectPlacement( catalogTable );
+        final Map<Long, List<CatalogColumnPlacement>> placements = selectPlacementWithPreference( catalogTable );
 
         // Only one builder available
         builders.get( 0 ).addPhysicalInfo( placements );

--- a/plugins/sql-language/src/main/codegen/templates/Parser.jj
+++ b/plugins/sql-language/src/main/codegen/templates/Parser.jj
@@ -4262,7 +4262,8 @@ SqlIdentifier CompoundIdentifier() :
 {
     List<String> list = new ArrayList<String>();
     List<ParserPos> posList = new ArrayList<ParserPos>();
-    String p;
+    String p, at = null;
+    SqlIdentifier s;
     boolean star = false;
 }
 {
@@ -4286,12 +4287,18 @@ SqlIdentifier CompoundIdentifier() :
             posList.add(getPos());
         }
     )?
+    (
+	<ATSYMBOL>
+	at = Identifier()
+    )?
     {
         ParserPos pos = ParserPos.sum(posList);
         if (star) {
             return SqlIdentifier.star(list, pos, posList);
         }
-        return new SqlIdentifier(list, null, pos, posList);
+        s = new SqlIdentifier(list, null, pos, posList);
+	s.preferredPlacement = at;
+	return s;
     }
 }
 
@@ -6057,6 +6064,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < ASSIGNMENT: "ASSIGNMENT" >
 |   < ASYMMETRIC: "ASYMMETRIC" >
 |   < AT: "AT" >
+|   < ATSYMBOL: "@" >
 |   < ATOMIC: "ATOMIC" >
 |   < ATTRIBUTE: "ATTRIBUTE" >
 |   < ATTRIBUTES: "ATTRIBUTES" >

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlIdentifier.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlIdentifier.java
@@ -64,6 +64,8 @@ public class SqlIdentifier extends SqlNode implements Identifier {
     protected ImmutableList<ParserPos> componentPositions;
 
 
+    public String preferredPlacement;
+
     /**
      * Creates a compound identifier, for example <code>foo.bar</code>.
      *
@@ -314,6 +316,11 @@ public class SqlIdentifier extends SqlNode implements Identifier {
             }
             i++;
         }
+
+	if ( preferredPlacement != null ) {
+	    writer.print(" @ ");
+	    writer.identifier( preferredPlacement );
+	}
 
         if ( null != collation ) {
             collation.unparse( writer, leftPrec, rightPrec );

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/sql2alg/SqlToAlgConverter.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/sql2alg/SqlToAlgConverter.java
@@ -1969,6 +1969,7 @@ public class SqlToAlgConverter implements NodeToAlgConverter {
         final String datasetName = datasetStack.isEmpty() ? null : datasetStack.peek();
         final boolean[] usedDataset = { false };
         AlgOptTable table = SqlValidatorUtil.getAlgOptTable( fromNamespace, catalogReader, datasetName, usedDataset );
+	table.setPreferredPlacement( id.preferredPlacement );
         if ( extendedColumns != null && extendedColumns.size() > 0 ) {
             assert table != null;
             final ValidatorTable validatorTable = table.unwrap( ValidatorTable.class );


### PR DESCRIPTION
## Summary

This is a prototype on how users can influence the data store chosen by Polypheny.  At the moment it is only implemented for SQL queries and it operates on a table as a whole, this might very well be expanded to column level (hence why it is parsed as part of a compound identifier).  The handling of the preference inside the router is still not optimal.

## How to use

Let's assume we have a table orders that is placed on two stores with the unique names `p` and `q`. The store  `p` is very fast and `q` is slow.  For an interactive request the programmer can have Polypheny use the fast store with query like this:

```
    SELECT order_id, order_date, ... FROM orders @ p WHERE ...
```

But when running large scale analysis, where slower load times are acceptable, the query is routed to the slow store:

```
    SELECT order_id, order_date, ... FROM orders @ q WHERE ...
```

## Testing

Place a table on two stores.  Then query the table with the syntax above in the UI. In the routing tab on the left, it should show that the selected placement was used (or at least preferred when not all columns were present on the selected store).

## Bugs

 - Any identifier can be annotated.  No warnings or errors are given when this annotation has no effect.

 - No special error handling or warning when the placement does not exist.

 - Only implemented for the SimpleRouter so far.  Should be fairly easy to extend
   to the other routers as well.

 - Other placements are used if the preferred one does not have all the columns. (this might be a feature)
