### PR TITLE
Fix remote connections to PostgreSQL and MonetDB

### DIFF
--- a/plugins/monetdb-adapter/src/main/java/org/polypheny/db/adapter/monetdb/stores/MonetdbStore.java
+++ b/plugins/monetdb-adapter/src/main/java/org/polypheny/db/adapter/monetdb/stores/MonetdbStore.java
@@ -86,7 +86,7 @@ public class MonetdbStore extends AbstractJdbcStore {
         DockerManager.Container container = new ContainerBuilder( getAdapterId(), "polypheny/monet", getUniqueName(), dockerInstanceId )
                 .withMappedPort( 50000, Integer.parseInt( settings.get( "port" ) ) )
                 .withEnvironmentVariables( Arrays.asList( "MONETDB_PASSWORD=" + settings.get( "password" ), "MONET_DATABASE=monetdb" ) )
-                .withReadyTest( this::testConnection, 15000 )
+                .withReadyTest( this::testDockerConnection, 15000 )
                 .build();
 
         this.container = container;
@@ -330,19 +330,23 @@ public class MonetdbStore extends AbstractJdbcStore {
         return String.format( "jdbc:monetdb://%s:%d/%s", dbHostname, dbPort, dbName );
     }
 
-
-    private boolean testConnection() {
-        ConnectionFactory connectionFactory = null;
-        ConnectionHandler handler = null;
-
+    private boolean testDockerConnection() {
         if ( container == null ) {
             return false;
         }
+
         container.updateIpAddress();
         this.host = container.getIpAddress();
         if ( this.host == null ) {
             return false;
         }
+
+        return testConnection();
+    }
+
+    private boolean testConnection() {
+        ConnectionFactory connectionFactory = null;
+        ConnectionHandler handler = null;
 
         try {
             connectionFactory = createConnectionFactory();

--- a/plugins/postgres-adapter/src/main/java/org/polypheny/db/adapter/postgres/store/PostgresqlStore.java
+++ b/plugins/postgres-adapter/src/main/java/org/polypheny/db/adapter/postgres/store/PostgresqlStore.java
@@ -98,7 +98,7 @@ public class PostgresqlStore extends AbstractJdbcStore {
         DockerManager.Container container = new ContainerBuilder( getAdapterId(), "polypheny/postgres", getUniqueName(), instanceId )
                 .withMappedPort( 5432, Integer.parseInt( settings.get( "port" ) ) )
                 .withEnvironmentVariable( "POSTGRES_PASSWORD=" + settings.get( "password" ) )
-                .withReadyTest( this::testConnection, 15000 )
+                .withReadyTest( this::testDockerConnection, 15000 )
                 .build();
 
         this.container = container;
@@ -376,19 +376,23 @@ public class PostgresqlStore extends AbstractJdbcStore {
         return String.format( "jdbc:postgresql://%s:%d/%s", dbHostname, dbPort, dbName );
     }
 
-
-    private boolean testConnection() {
-        ConnectionFactory connectionFactory = null;
-        ConnectionHandler handler = null;
-
+    private boolean testDockerConnection() {
         if ( container == null ) {
             return false;
         }
+
         container.updateIpAddress();
         this.host = container.getIpAddress();
         if ( this.host == null ) {
             return false;
         }
+
+        return testConnection();
+    }
+
+    private boolean testConnection() {
+        ConnectionFactory connectionFactory = null;
+        ConnectionHandler handler = null;
 
         try {
             connectionFactory = createConnectionFactory();


### PR DESCRIPTION
## Summary

In the MonetDB and PostgreSQL adapters the method `testConnection` assumed a docker container, which of course is not present when connecting to a remote instance.  With this change remote connections to PostgreSQL and MonetDB are possible again.  The name `testDockerConnection` was stolen from the Cassandra adapter.

### Tests

![adapters](https://user-images.githubusercontent.com/41197811/231436884-00ce3ff8-dd74-42a9-8142-e474804a2e09.png)
