### PR TITLE
Add support to refer tables with alias

### DIFF
--- a/core/src/main/java/org/polypheny/db/algebra/constant/Kind.java
+++ b/core/src/main/java/org/polypheny/db/algebra/constant/Kind.java
@@ -1126,6 +1126,11 @@ public enum Kind {
     CREATE_TABLE,
 
     /**
+     * {@code CREATE ALIAS} DDL statement.
+     */
+    CREATE_ALIAS,
+
+    /**
      * {@code TRUNCATE} DDL statement
      */
     TRUNCATE,
@@ -1134,6 +1139,11 @@ public enum Kind {
      * {@code ALTER TABLE} DDL statement.
      */
     ALTER_TABLE,
+
+    /**
+     * {@code DROP ALIAS} DDL statement.
+     */
+    DROP_ALIAS,
 
     /**
      * {@code DROP TABLE} DDL statement.
@@ -1403,7 +1413,7 @@ public enum Kind {
             CREATE_SCHEMA,
             CREATE_FOREIGN_SCHEMA,
             DROP_SCHEMA,
-            CREATE_TABLE,
+            CREATE_ALIAS,
             ALTER_TABLE,
             DROP_TABLE,
             CREATE_VIEW,
@@ -1423,6 +1433,8 @@ public enum Kind {
             SET_OPTION,
             TRUNCATE,
             ALTER_SCHEMA,
+            CREATE_TABLE,
+            DROP_ALIAS,
             OTHER_DDL );
 
     /**

--- a/core/src/main/java/org/polypheny/db/algebra/constant/Kind.java
+++ b/core/src/main/java/org/polypheny/db/algebra/constant/Kind.java
@@ -1126,11 +1126,6 @@ public enum Kind {
     CREATE_TABLE,
 
     /**
-     * {@code CREATE ALIAS} DDL statement.
-     */
-    CREATE_ALIAS,
-
-    /**
      * {@code TRUNCATE} DDL statement
      */
     TRUNCATE,
@@ -1139,11 +1134,6 @@ public enum Kind {
      * {@code ALTER TABLE} DDL statement.
      */
     ALTER_TABLE,
-
-    /**
-     * {@code DROP ALIAS} DDL statement.
-     */
-    DROP_ALIAS,
 
     /**
      * {@code DROP TABLE} DDL statement.
@@ -1234,6 +1224,16 @@ public enum Kind {
      * {@code DROP FUNCTION} DDL statement.
      */
     DROP_FUNCTION,
+
+    /**
+     * {@code CREATE ALIAS} DDL statement.
+     */
+    CREATE_ALIAS,
+
+    /**
+     * {@code DROP ALIAS} DDL statement.
+     */
+    DROP_ALIAS,
 
     /**
      * DDL statement not handled above.
@@ -1413,7 +1413,7 @@ public enum Kind {
             CREATE_SCHEMA,
             CREATE_FOREIGN_SCHEMA,
             DROP_SCHEMA,
-            CREATE_ALIAS,
+            CREATE_TABLE,
             ALTER_TABLE,
             DROP_TABLE,
             CREATE_VIEW,
@@ -1433,7 +1433,7 @@ public enum Kind {
             SET_OPTION,
             TRUNCATE,
             ALTER_SCHEMA,
-            CREATE_TABLE,
+            CREATE_ALIAS,
             DROP_ALIAS,
             OTHER_DDL );
 

--- a/core/src/main/java/org/polypheny/db/catalog/Catalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/Catalog.java
@@ -482,6 +482,57 @@ public abstract class Catalog implements ExtensionPoint {
      */
     public abstract CatalogTable getTableFromPartition( long partitionId );
 
+
+
+
+
+
+    /**
+     * Check if a given name is an alias
+     *
+     * @param name The given name
+     * @return boolean
+     */
+    public abstract boolean isAlias( String name );
+
+    /**
+     * Add an alias
+     *
+     * @param name alias name
+     * @param table, the Object[] array
+     */
+    public abstract void addAlias( String name, Object[] table );
+
+    /**
+     * remove an alias by name(key)
+     *
+     * @param name alias name
+     */
+    public abstract void removeAlias( String name );
+
+    /**
+     * remove an alias by table(value)
+     *
+     * @param table table array
+     */
+    public abstract void removeAliases( Object[] table );
+
+    /**
+     * update aliases mappings, this will be called when we rename a table
+     *
+     * @param oldTable table array
+     * @param newTable change to
+     */
+    public abstract void updateAliases( Object[] oldTable, Object[] newTable );
+
+    /**
+     * return a table array
+     *
+     * @param name The given name
+     * @return the table array
+     */
+    public abstract Object[] getTableNameFromAlias( String name );
+
     /**
      * Adds a table to a specified schema.
      *

--- a/core/src/test/java/org/polypheny/db/catalog/MockCatalog.java
+++ b/core/src/test/java/org/polypheny/db/catalog/MockCatalog.java
@@ -346,6 +346,37 @@ public abstract class MockCatalog extends Catalog {
         throw new NotImplementedException();
     }
 
+    @Override
+    public boolean isAlias( String name ) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void updateAliases( Object[] oldTable, Object[] newTable ) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void addAlias( String name, Object[] table ) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void removeAlias( String name ) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void removeAliases( Object[] table ) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Object[] getTableNameFromAlias( String name ) {
+        throw new NotImplementedException();
+    }
+
+
 
     @Override
     public long addTable( String name, long namespaceId, int ownerId, EntityType entityType, boolean modifiable ) {

--- a/plugins/sql-language/src/main/codegen/config.fmpp
+++ b/plugins/sql-language/src/main/codegen/config.fmpp
@@ -146,6 +146,7 @@ data: {
             "ADD"
             "ADMIN"
             "AFTER"
+            "ALIAS"
             "ALWAYS"
             "APPLY"
             "ASC"
@@ -496,6 +497,7 @@ data: {
             "SqlCreateView"
             "SqlCreateMaterializedView"
             "SqlCreateFunction"
+            "SqlCreateAlias"
         ]
 
         # List of methods for parsing extensions to "DROP" calls. Each must accept arguments "(SqlParserPos pos)".
@@ -506,6 +508,7 @@ data: {
             "SqlDropView"
             "SqlDropMaterializedView"
             "SqlDropFunction"
+            "SqlDropAlias"
         ]
 
         # List of files in @includes directory that have parser method implementations for parsing custom SQL statements, literals or types

--- a/plugins/sql-language/src/main/codegen/includes/ddlParser.ftl
+++ b/plugins/sql-language/src/main/codegen/includes/ddlParser.ftl
@@ -261,6 +261,21 @@ SqlCreate SqlCreateType(Span s, boolean replace) :
     }
 }
 
+SqlCreate SqlCreateAlias(Span s, boolean replace) :
+{
+        final SqlIdentifier name;
+        final SqlIdentifier alias;
+}
+{
+        <ALIAS>
+        name = CompoundIdentifier()
+        <AS>
+        alias = CompoundIdentifier()
+        {
+            return SqlDdlNodes.createAlias(s.end(this), replace, name, alias);
+        }
+}
+
 SqlCreate SqlCreateTable(Span s, boolean replace) :
 {
     final boolean ifNotExists;
@@ -502,14 +517,27 @@ SqlDrop SqlDropType(Span s, boolean replace) :
     }
 }
 
+SqlDrop SqlDropAlias(Span s, boolean replace) :
+{
+        final boolean ifExists;
+        final SqlIdentifier alias;
+}
+{
+        <ALIAS> ifExists = IfExistsOpt() alias = CompoundIdentifier() {
+            return SqlDdlNodes.dropAlias(s.end(this), ifExists, alias);
+        }
+}
+
+
 SqlDrop SqlDropTable(Span s, boolean replace) :
 {
     final boolean ifExists;
     final SqlIdentifier id;
+    boolean isAlias = false;
 }
 {
-    <TABLE> ifExists = IfExistsOpt() id = CompoundIdentifier() {
-        return SqlDdlNodes.dropTable(s.end(this), ifExists, id);
+    <TABLE> ifExists = IfExistsOpt() [ <ALIAS> { isAlias = true; } ] id = CompoundIdentifier() {
+        return SqlDdlNodes.dropTable(s.end(this), ifExists, id, isAlias);
     }
 }
 
@@ -546,4 +574,5 @@ SqlDrop SqlDropFunction(Span s, boolean replace) :
         return SqlDdlNodes.dropFunction(s.end(this), ifExists, id);
     }
 }
+
 

--- a/plugins/sql-language/src/main/codegen/templates/Parser.jj
+++ b/plugins/sql-language/src/main/codegen/templates/Parser.jj
@@ -987,6 +987,7 @@ SqlSelect SqlSelect() :
     final SqlNode having;
     final SqlNodeList windowDecls;
     final Span s;
+    boolean isTableAlias = false;
 }
 {
     <SELECT>
@@ -1012,7 +1013,7 @@ SqlSelect SqlSelect() :
     }
     selectList = SelectList()
     (
-        <FROM> fromClause = FromClause()
+        <FROM> [ <ALIAS> { isTableAlias = true; } ] fromClause = FromClause()
         where = WhereOpt()
         groupBy = GroupByOpt()
         having = HavingOpt()
@@ -1029,7 +1030,7 @@ SqlSelect SqlSelect() :
     {
         return new SqlSelect(s.end(this), keywordList,
             new SqlNodeList(selectList, Span.of(selectList).pos()),
-            fromClause, where, groupBy, having, windowDecls, null, null, null);
+            fromClause, where, groupBy, having, windowDecls, null, null, null, isTableAlias);
     }
 }
 
@@ -1258,6 +1259,7 @@ SqlNode SqlInsert() :
     SqlNode source;
     SqlNodeList columnList = null;
     final Span s;
+    boolean isTableAlias = false;
 }
 {
     (
@@ -1269,7 +1271,7 @@ SqlNode SqlInsert() :
     SqlInsertKeywords(keywords) {
         keywordList = new SqlNodeList(keywords, s.addAll(keywords).pos());
     }
-    <INTO> table = CompoundIdentifier()
+    <INTO> [ <ALIAS> { isTableAlias = true; } ] table = CompoundIdentifier()
     [
         LOOKAHEAD(5)
         [ <EXTEND> ]
@@ -1290,7 +1292,7 @@ SqlNode SqlInsert() :
         }
     ]
     source = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY) {
-        return new SqlInsert(s.end(source), keywordList, table, source, columnList);
+        return new SqlInsert(s.end(source), keywordList, table, source, columnList, isTableAlias);
     }
 }
 
@@ -1312,12 +1314,13 @@ SqlNode SqlDelete() :
     SqlIdentifier alias = null;
     final SqlNode condition;
     final Span s;
+    boolean isTableAlias = false;
 }
 {
     <DELETE> {
         s = span();
     }
-    <FROM> table = CompoundIdentifier()
+    <FROM> [ <ALIAS> { isTableAlias = true; } ] table = CompoundIdentifier()
     [
         [ <EXTEND> ]
         extendList = ExtendList() {
@@ -1327,7 +1330,7 @@ SqlNode SqlDelete() :
     [ [ <AS> ] alias = SimpleIdentifier() ]
     condition = WhereOpt()
     {
-        return new SqlDelete(s.add(table).addIf(extendList).addIf(alias).addIf(condition).pos(), table, condition, null, alias);
+        return new SqlDelete(s.add(table).addIf(extendList).addIf(alias).addIf(condition).pos(), table, condition, null, alias, isTableAlias);
     }
 }
 
@@ -1345,9 +1348,11 @@ SqlNode SqlUpdate() :
     SqlIdentifier id;
     SqlNode exp;
     final Span s;
+    boolean isTableAlias = false;
 }
 {
     <UPDATE> { s = span(); }
+    [ <ALIAS> { isTableAlias = true; } ]
     table = CompoundIdentifier() {
         targetColumnList = new SqlNodeList(s.pos());
         sourceExpressionList = new SqlNodeList(s.pos());
@@ -1379,7 +1384,7 @@ SqlNode SqlUpdate() :
     )*
     condition = WhereOpt()
     {
-        return new SqlUpdate(s.addAll(targetColumnList.getSqlList()).addAll(sourceExpressionList.getSqlList()).addIf(condition).pos(), table, targetColumnList, sourceExpressionList, condition, null, alias);
+        return new SqlUpdate(s.addAll(targetColumnList.getSqlList()).addAll(sourceExpressionList.getSqlList()).addIf(condition).pos(), table, targetColumnList, sourceExpressionList, condition, null, alias, isTableAlias);
     }
 }
 
@@ -6043,6 +6048,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < ALLOCATE: "ALLOCATE" >
 |   < ALLOW: "ALLOW" >
 |   < ALTER: "ALTER" >
+|   < ALIAS: "ALIAS" >
 |   < ALWAYS: "ALWAYS" >
 |   < AND: "AND" >
 |   < ANY: "ANY" >

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDelete.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDelete.java
@@ -48,6 +48,18 @@ public class SqlDelete extends SqlCall {
         this.alias = alias;
     }
 
+    public SqlDelete( ParserPos pos, SqlNode targetTable, SqlNode condition, SqlSelect sourceSelect, SqlIdentifier alias, boolean isTableAlias ) {
+        super( pos );
+        if (isTableAlias) {
+            this.targetTable = replaceTableNameIfIsAlias( targetTable );
+        } else {
+            this.targetTable = targetTable;
+        }
+        this.condition = condition;
+        this.sourceSelect = sourceSelect;
+        this.alias = alias;
+    }
+
 
     @Override
     public Kind getKind() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlInsert.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlInsert.java
@@ -51,6 +51,19 @@ public class SqlInsert extends SqlCall {
         assert keywords != null;
     }
 
+    public SqlInsert( ParserPos pos, SqlNodeList keywords, SqlNode targetTable, SqlNode source, SqlNodeList columnList, boolean isTableAlias ) {
+        super( pos );
+        this.keywords = keywords;
+        if (isTableAlias) {
+            this.targetTable = replaceTableNameIfIsAlias( targetTable );
+        } else {
+            this.targetTable = targetTable;
+        }
+        this.source = source;
+        this.columnList = columnList;
+        assert keywords != null;
+    }
+
 
     @Override
     public Kind getKind() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlSelect.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlSelect.java
@@ -84,6 +84,44 @@ public class SqlSelect extends SqlCall implements Select {
         this.fetch = fetch;
     }
 
+    public SqlSelect(
+            ParserPos pos,
+            SqlNodeList keywordList,
+            SqlNodeList selectList,
+            SqlNode from,
+            SqlNode where,
+            SqlNodeList groupBy,
+            SqlNode having,
+            SqlNodeList windowDecls,
+            SqlNodeList orderBy,
+            SqlNode offset,
+            SqlNode fetch,
+            boolean isTableAlias) {
+        super( pos );
+
+        if(isTableAlias) {
+            this.from = replaceTableNameIfIsAlias(from);
+        } else {
+            this.from = from;
+        }
+
+        this.keywordList = Objects.requireNonNull(
+                keywordList != null
+                        ? keywordList
+                        : new SqlNodeList( pos ) );
+        this.selectList = selectList;
+        this.where = where;
+        this.groupBy = groupBy;
+        this.having = having;
+        this.windowDecls = Objects.requireNonNull(
+                windowDecls != null
+                        ? windowDecls
+                        : new SqlNodeList( pos ) );
+        this.orderBy = orderBy;
+        this.offset = offset;
+        this.fetch = fetch;
+    }
+
 
     @Override
     public Operator getOperator() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlUpdate.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlUpdate.java
@@ -54,6 +54,21 @@ public class SqlUpdate extends SqlCall {
         this.alias = alias;
     }
 
+    public SqlUpdate( ParserPos pos, SqlNode targetTable, SqlNodeList targetColumnList, SqlNodeList sourceExpressionList, SqlNode condition, SqlSelect sourceSelect, SqlIdentifier alias, boolean isTableAlias ) {
+        super( pos );
+        if (isTableAlias) {
+            this.targetTable = replaceTableNameIfIsAlias( targetTable );
+        } else {
+            this.targetTable = targetTable;
+        }
+        this.targetColumnList = targetColumnList;
+        this.sourceExpressionList = sourceExpressionList;
+        this.condition = condition;
+        this.sourceSelect = sourceSelect;
+        assert sourceExpressionList.size() == targetColumnList.size();
+        this.alias = alias;
+    }
+
 
     @Override
     public Kind getKind() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateAlias.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateAlias.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019-2023 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.sql.language.ddl;
+
+
+import org.polypheny.db.algebra.constant.Kind;
+import org.polypheny.db.catalog.Catalog;
+import org.polypheny.db.catalog.exceptions.UnknownDatabaseException;
+import org.polypheny.db.catalog.exceptions.UnknownSchemaException;
+import org.polypheny.db.ddl.DdlManager;
+import org.polypheny.db.languages.ParserPos;
+import org.polypheny.db.languages.QueryParameters;
+import org.polypheny.db.nodes.ExecutableStatement;
+import org.polypheny.db.nodes.Node;
+import org.polypheny.db.prepare.Context;
+import org.polypheny.db.sql.language.*;
+import org.polypheny.db.transaction.Statement;
+import org.polypheny.db.util.CoreUtil;
+import org.polypheny.db.util.ImmutableNullableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.polypheny.db.util.Static.RESOURCE;
+
+
+/**
+ * Parse tree for {@code CREATE ALIAS} statement.
+ */
+public class SqlCreateAlias extends SqlCreate implements ExecutableStatement {
+
+    private final SqlIdentifier name;
+    private final SqlIdentifier alias;
+
+    private static final SqlOperator OPERATOR = new SqlSpecialOperator( "CREATE ALIAS", Kind.CREATE_ALIAS );
+
+
+    /**
+     * Creates a SqlCreateType.
+     */
+    SqlCreateAlias(ParserPos pos, boolean replace, SqlIdentifier name, SqlIdentifier alias ) {
+        super( OPERATOR, pos, replace, false );
+        this.name = Objects.requireNonNull( name );
+        this.alias = Objects.requireNonNull( alias );
+    }
+
+
+    @Override
+    public void execute( Context context, Statement statement, QueryParameters parameters ) {
+        Catalog catalog = Catalog.getInstance();
+        String tableName;
+        String aliasName;
+        long schemaId;
+
+        try {
+            // Cannot use getTable() here since table does not yet exist
+            if ( name.names.size() == 3 ) { // DatabaseName.SchemaName.TableName
+                schemaId = catalog.getSchema( name.names.get( 0 ), name.names.get( 1 ) ).id;
+                tableName = name.names.get( 2 );
+            } else if ( name.names.size() == 2 ) { // SchemaName.TableName
+                schemaId = catalog.getSchema( context.getDatabaseId(), name.names.get( 0 ) ).id;
+                tableName = name.names.get( 1 );
+            } else { // TableName
+                schemaId = catalog.getSchema( context.getDatabaseId(), context.getDefaultSchemaName() ).id;
+                tableName = name.names.get( 0 );
+            }
+        } catch ( UnknownDatabaseException e ) {
+            throw CoreUtil.newContextException( name.getPos(), RESOURCE.databaseNotFound( name.toString() ) );
+        } catch ( UnknownSchemaException e ) {
+            throw CoreUtil.newContextException( name.getPos(), RESOURCE.schemaNotFound( name.toString() ) );
+        }
+
+        if ( alias.names.size() != 1 ) {
+            throw new RuntimeException("Currently only a simple alias name is allowed");
+        }
+
+        aliasName = alias.names.get(0);
+
+        if(!replace && catalog.isAlias(aliasName)) {
+            throw new RuntimeException("Alias name " + aliasName + " already exists");
+        }
+
+        Object[] value = new Object[]{ catalog.getSchema(schemaId).databaseId, schemaId, tableName };
+        catalog.addAlias(aliasName, value);
+
+    }
+
+
+    @Override
+    public List<Node> getOperandList() {
+        return ImmutableNullableList.of( name, alias );
+    }
+
+
+    @Override
+    public List<SqlNode> getSqlOperandList() {
+        return ImmutableNullableList.of( name, alias );
+    }
+
+
+    @Override
+    public void unparse( SqlWriter writer, int leftPrec, int rightPrec ) {
+        if ( getReplace() ) {
+            writer.keyword( "CREATE OR REPLACE" );
+        } else {
+            writer.keyword( "CREATE" );
+        }
+        writer.keyword( "ALIAS" );
+        name.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "AS" );
+        alias.unparse( writer, 0, 0 );
+    }
+
+}
+

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlDdlNodes.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlDdlNodes.java
@@ -55,6 +55,13 @@ public class SqlDdlNodes {
         return new SqlCreateType( pos, replace, name, attributeList, dataTypeSpec );
     }
 
+    /**
+     * Creates a CREATE ALIAS.
+     */
+    public static SqlCreateAlias createAlias( ParserPos pos, boolean replace, SqlIdentifier name, SqlIdentifier alias ) {
+        return new SqlCreateAlias( pos, replace, name, alias );
+    }
+
 
     /**
      * Creates a CREATE TABLE.
@@ -103,12 +110,25 @@ public class SqlDdlNodes {
         return new SqlDropType( pos, ifExists, name );
     }
 
+    /**
+     * Creates a DROP ALIAS.
+     */
+    public static SqlDropAlias dropAlias( ParserPos pos, boolean ifExists, SqlIdentifier name ) {
+        return new SqlDropAlias( pos, ifExists, name );
+    }
 
     /**
      * Creates a DROP TABLE.
      */
     public static SqlDropTable dropTable( ParserPos pos, boolean ifExists, SqlIdentifier name ) {
         return new SqlDropTable( pos, ifExists, name );
+    }
+
+    /**
+     * Creates a DROP TABLE.
+     */
+    public static SqlDropTable dropTable( ParserPos pos, boolean ifExists, SqlIdentifier name, boolean isAlias ) {
+        return new SqlDropTable( pos, ifExists, name, isAlias );
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlDropAlias.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlDropAlias.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019-2023 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.db.sql.language.ddl;
+
+
+
+
+import org.polypheny.db.algebra.constant.Kind;
+import org.polypheny.db.catalog.Catalog;
+import org.polypheny.db.ddl.DdlManager;
+import org.polypheny.db.languages.ParserPos;
+import org.polypheny.db.languages.QueryParameters;
+import org.polypheny.db.prepare.Context;
+import org.polypheny.db.sql.language.SqlIdentifier;
+import org.polypheny.db.sql.language.SqlOperator;
+import org.polypheny.db.sql.language.SqlSpecialOperator;
+import org.polypheny.db.transaction.Statement;
+
+import static org.polypheny.db.util.Static.RESOURCE;
+
+
+/**
+ * Parse tree for {@code DROP TABLE} statement.
+ */
+public class SqlDropAlias extends SqlDropObject {
+
+    private static final SqlOperator OPERATOR = new SqlSpecialOperator( "DROP ALIAS", Kind.DROP_ALIAS );
+
+
+    /**
+     * Creates a SqlDropTable.
+     */
+    SqlDropAlias(ParserPos pos, boolean ifExists, SqlIdentifier name ) {
+        super( OPERATOR, pos, ifExists, name );
+    }
+
+
+    @Override
+    public void execute( Context context, Statement statement, QueryParameters parameters ) {
+        Catalog catalog = Catalog.getInstance();
+
+        if( name.names.size() != 1 || !catalog.isAlias(name.names.get(0))) {
+            throw new RuntimeException(name.toString() + " is not a known alias name");
+        }
+
+        catalog.removeAlias(name.names.get(0));
+
+    }
+
+}
+

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlTruncate.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlTruncate.java
@@ -54,6 +54,16 @@ public class SqlTruncate extends SqlDdl implements ExecutableStatement {
         this.name = name;
     }
 
+    public SqlTruncate( ParserPos pos, SqlIdentifier name, boolean isAlias ) {
+        super( OPERATOR, pos );
+        if (isAlias) {
+            this.name = (SqlIdentifier) replaceTableNameIfIsAlias( name );
+        } else {
+            this.name = name;
+        }
+    }
+
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterSourceTableAddColumn.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterSourceTableAddColumn.java
@@ -72,6 +72,28 @@ public class SqlAlterSourceTableAddColumn extends SqlAlterTable {
         this.afterColumnName = afterColumnName;
     }
 
+    public SqlAlterSourceTableAddColumn(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlIdentifier columnPhysical,
+            SqlIdentifier columnLogical,
+            SqlNode defaultValue,
+            SqlIdentifier beforeColumnName,
+            SqlIdentifier afterColumnName,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.columnPhysical = Objects.requireNonNull( columnPhysical );
+        this.columnLogical = Objects.requireNonNull( columnLogical );
+        this.defaultValue = defaultValue;
+        this.beforeColumnName = beforeColumnName;
+        this.afterColumnName = afterColumnName;
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddColumn.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddColumn.java
@@ -77,6 +77,30 @@ public class SqlAlterTableAddColumn extends SqlAlterTable {
         this.afterColumnName = afterColumnName;
     }
 
+    public SqlAlterTableAddColumn(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlIdentifier column,
+            SqlDataTypeSpec type,
+            boolean nullable,
+            SqlNode defaultValue,
+            SqlIdentifier beforeColumnName,
+            SqlIdentifier afterColumnName,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.column = Objects.requireNonNull( column );
+        this.type = Objects.requireNonNull( type );
+        this.nullable = nullable;
+        this.defaultValue = defaultValue;
+        this.beforeColumnName = beforeColumnName;
+        this.afterColumnName = afterColumnName;
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddForeignKey.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddForeignKey.java
@@ -72,6 +72,27 @@ public class SqlAlterTableAddForeignKey extends SqlAlterTable {
         }
     }
 
+    public SqlAlterTableAddForeignKey( ParserPos pos, SqlIdentifier table, SqlIdentifier constraintName, SqlNodeList columnList, SqlIdentifier referencesTable, SqlNodeList referencesList, String onUpdate, String onDelete, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.constraintName = Objects.requireNonNull( constraintName );
+        this.columnList = Objects.requireNonNull( columnList );
+        this.referencesTable = Objects.requireNonNull( referencesTable );
+        this.referencesList = Objects.requireNonNull( referencesList );
+        try {
+            this.onUpdate = onUpdate != null ? ForeignKeyOption.parse( onUpdate ) : ForeignKeyOption.RESTRICT;
+            this.onDelete = onDelete != null ? ForeignKeyOption.parse( onDelete ) : ForeignKeyOption.RESTRICT;
+        } catch ( UnknownForeignKeyOptionException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddIndex.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddIndex.java
@@ -82,6 +82,28 @@ public class SqlAlterTableAddIndex extends SqlAlterTable {
         this.storeName = storeName;
     }
 
+    public SqlAlterTableAddIndex(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlNodeList columnList,
+            boolean unique,
+            SqlIdentifier indexMethod,
+            SqlIdentifier indexName,
+            SqlIdentifier storeName,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.columnList = Objects.requireNonNull( columnList );
+        this.unique = unique;
+        this.indexName = indexName;
+        this.indexMethod = indexMethod;
+        this.storeName = storeName;
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPartitions.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPartitions.java
@@ -90,6 +90,32 @@ public class SqlAlterTableAddPartitions extends SqlAlterTable {
         this.rawPartitionInformation = rawPartitionInformation;
     }
 
+    public SqlAlterTableAddPartitions(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlIdentifier partitionColumn,
+            SqlIdentifier partitionType,
+            int numPartitionGroups,
+            int numPartitions,
+            List<SqlIdentifier> partitionGroupNamesList,
+            List<List<SqlNode>> partitionQualifierList,
+            RawPartitionInformation rawPartitionInformation,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.partitionType = Objects.requireNonNull( partitionType );
+        this.partitionColumn = Objects.requireNonNull( partitionColumn );
+        this.numPartitionGroups = numPartitionGroups; //May be empty
+        this.numPartitions = numPartitions; //May be empty
+        this.partitionGroupNamesList = partitionGroupNamesList; //May be null and can only be used in association with PARTITION BY and PARTITIONS
+        this.partitionQualifierList = partitionQualifierList;
+        this.rawPartitionInformation = rawPartitionInformation;
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPlacement.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPlacement.java
@@ -73,6 +73,27 @@ public class SqlAlterTableAddPlacement extends SqlAlterTable {
 
     }
 
+    public SqlAlterTableAddPlacement(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlNodeList columnList,
+            SqlIdentifier storeName,
+            List<Integer> partitionGroupsList,
+            List<SqlIdentifier> partitionGroupNamesList,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.columnList = Objects.requireNonNull( columnList );
+        this.storeName = Objects.requireNonNull( storeName );
+        this.partitionGroupsList = partitionGroupsList;
+        this.partitionGroupNamesList = partitionGroupNamesList;
+
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPrimaryKey.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPrimaryKey.java
@@ -55,6 +55,16 @@ public class SqlAlterTableAddPrimaryKey extends SqlAlterTable {
         this.columnList = Objects.requireNonNull( columnList );
     }
 
+    public SqlAlterTableAddPrimaryKey( ParserPos pos, SqlIdentifier table, SqlNodeList columnList, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.columnList = Objects.requireNonNull( columnList );
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddUniqueConstraint.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddUniqueConstraint.java
@@ -61,6 +61,22 @@ public class SqlAlterTableAddUniqueConstraint extends SqlAlterTable {
         this.columnList = Objects.requireNonNull( columnList );
     }
 
+    public SqlAlterTableAddUniqueConstraint(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlIdentifier constraintName,
+            SqlNodeList columnList,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.constraintName = Objects.requireNonNull( constraintName );
+        this.columnList = Objects.requireNonNull( columnList );
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropColumn.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropColumn.java
@@ -53,6 +53,16 @@ public class SqlAlterTableDropColumn extends SqlAlterTable {
         this.column = Objects.requireNonNull( column );
     }
 
+    public SqlAlterTableDropColumn( ParserPos pos, SqlIdentifier table, SqlIdentifier column, boolean isAlias ) {
+        super( pos );
+        if( isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.column = Objects.requireNonNull( column );
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropConstraint.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropConstraint.java
@@ -53,6 +53,17 @@ public class SqlAlterTableDropConstraint extends SqlAlterTable {
         this.constraintName = Objects.requireNonNull( constraintName );
     }
 
+    public SqlAlterTableDropConstraint( ParserPos pos, SqlIdentifier table, SqlIdentifier constraintName, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.constraintName = Objects.requireNonNull( constraintName );
+    }
+
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropForeignKey.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropForeignKey.java
@@ -53,6 +53,17 @@ public class SqlAlterTableDropForeignKey extends SqlAlterTable {
         this.foreignKeyName = Objects.requireNonNull( foreignKeyName );
     }
 
+    public SqlAlterTableDropForeignKey( ParserPos pos, SqlIdentifier table, SqlIdentifier foreignKeyName, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.foreignKeyName = Objects.requireNonNull( foreignKeyName );
+    }
+
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropIndex.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropIndex.java
@@ -53,6 +53,16 @@ public class SqlAlterTableDropIndex extends SqlAlterTable {
         this.indexName = Objects.requireNonNull( indexName );
     }
 
+    public SqlAlterTableDropIndex( ParserPos pos, SqlIdentifier table, SqlIdentifier indexName, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.indexName = Objects.requireNonNull( indexName );
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropPlacement.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropPlacement.java
@@ -55,6 +55,16 @@ public class SqlAlterTableDropPlacement extends SqlAlterTable {
         this.storeName = Objects.requireNonNull( storeName );
     }
 
+    public SqlAlterTableDropPlacement( ParserPos pos, SqlIdentifier table, SqlIdentifier storeName, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.storeName = Objects.requireNonNull( storeName );
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropPrimaryKey.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableDropPrimaryKey.java
@@ -51,6 +51,15 @@ public class SqlAlterTableDropPrimaryKey extends SqlAlterTable {
         this.table = Objects.requireNonNull( table );
     }
 
+    public SqlAlterTableDropPrimaryKey( ParserPos pos, SqlIdentifier table, boolean isAlias ) {
+        super( pos );
+        if(isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+    }
+
 
     @Override
     public List<SqlNode> getSqlOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableMergePartitions.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableMergePartitions.java
@@ -57,6 +57,16 @@ public class SqlAlterTableMergePartitions extends SqlAlterTable {
         this.table = Objects.requireNonNull( table );
     }
 
+    public SqlAlterTableMergePartitions( ParserPos pos, SqlIdentifier table, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+    }
+
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyColumn.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyColumn.java
@@ -84,6 +84,34 @@ public class SqlAlterTableModifyColumn extends SqlAlterTable {
         this.dropDefault = dropDefault;
     }
 
+    public SqlAlterTableModifyColumn(
+            ParserPos pos,
+            @NonNull SqlIdentifier tableName,
+            @NonNull SqlIdentifier columnName,
+            SqlDataTypeSpec type,
+            Boolean nullable,
+            SqlIdentifier beforeColumn,
+            SqlIdentifier afterColumn,
+            String collation,
+            SqlNode defaultValue,
+            Boolean dropDefault,
+            boolean isAlias) {
+        super( pos );
+        if ( isAlias ) {
+            this.tableName = (SqlIdentifier) replaceTableNameIfIsAlias( tableName );
+        } else {
+            this.tableName = tableName;
+        }
+        this.columnName = columnName;
+        this.type = type;
+        this.nullable = nullable;
+        this.beforeColumn = beforeColumn;
+        this.afterColumn = afterColumn;
+        this.collation = collation;
+        this.defaultValue = defaultValue;
+        this.dropDefault = dropDefault;
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPartitions.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPartitions.java
@@ -70,6 +70,24 @@ public class SqlAlterTableModifyPartitions extends SqlAlterTable {
         this.partitionGroupNamesList = partitionGroupNamesList; //May be null and can only be used in association with PARTITION BY and PARTITIONS
     }
 
+    public SqlAlterTableModifyPartitions(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlIdentifier storeName,
+            List<Integer> partitionGroupList,
+            List<SqlIdentifier> partitionGroupNamesList,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.storeName = Objects.requireNonNull( storeName );
+        this.partitionGroupList = partitionGroupList;
+        this.partitionGroupNamesList = partitionGroupNamesList; //May be null and can only be used in association with PARTITION BY and PARTITIONS
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacement.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacement.java
@@ -72,6 +72,26 @@ public class SqlAlterTableModifyPlacement extends SqlAlterTable {
         this.partitionGroupNamesList = partitionGroupNamesList;
     }
 
+    public SqlAlterTableModifyPlacement(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlNodeList columnList,
+            SqlIdentifier storeName,
+            List<Integer> partitionGroupList,
+            List<SqlIdentifier> partitionGroupNamesList,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.columnList = Objects.requireNonNull( columnList );
+        this.storeName = Objects.requireNonNull( storeName );
+        this.partitionGroupList = partitionGroupList;
+        this.partitionGroupNamesList = partitionGroupNamesList;
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacementAddColumn.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacementAddColumn.java
@@ -63,6 +63,22 @@ public class SqlAlterTableModifyPlacementAddColumn extends SqlAlterTable {
         this.storeName = Objects.requireNonNull( storeName );
     }
 
+    public SqlAlterTableModifyPlacementAddColumn(
+            ParserPos pos,
+            SqlIdentifier table,
+            SqlIdentifier columnName,
+            SqlIdentifier storeName,
+            boolean isAlias) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.columnName = Objects.requireNonNull( columnName );
+        this.storeName = Objects.requireNonNull( storeName );
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacementDropColumn.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacementDropColumn.java
@@ -61,6 +61,18 @@ public class SqlAlterTableModifyPlacementDropColumn extends SqlAlterTable {
         this.storeName = Objects.requireNonNull( storeName );
     }
 
+    public SqlAlterTableModifyPlacementDropColumn( ParserPos pos, SqlIdentifier table, SqlIdentifier columnName, SqlIdentifier storeName, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.columnName = Objects.requireNonNull( columnName );
+        this.storeName = Objects.requireNonNull( storeName );
+    }
+
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableOwner.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableOwner.java
@@ -53,6 +53,16 @@ public class SqlAlterTableOwner extends SqlAlterTable {
         this.owner = Objects.requireNonNull( owner );
     }
 
+    public SqlAlterTableOwner( ParserPos pos, SqlIdentifier table, SqlIdentifier owner, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.owner = Objects.requireNonNull( owner );
+    }
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableRename.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableRename.java
@@ -52,6 +52,17 @@ public class SqlAlterTableRename extends SqlAlterTable {
         this.newName = Objects.requireNonNull( newName );
     }
 
+    public SqlAlterTableRename( ParserPos pos, SqlIdentifier oldName, SqlIdentifier newName, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.oldName = (SqlIdentifier) replaceTableNameIfIsAlias( oldName );
+        } else {
+            this.oldName = Objects.requireNonNull( oldName );
+        }
+        this.newName = Objects.requireNonNull( newName );
+    }
+
+
 
     @Override
     public List<Node> getOperandList() {

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableRenameColumn.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableRenameColumn.java
@@ -55,6 +55,17 @@ public class SqlAlterTableRenameColumn extends SqlAlterTable {
         this.columnNewName = Objects.requireNonNull( columnNewName );
     }
 
+    public SqlAlterTableRenameColumn( ParserPos pos, SqlIdentifier table, SqlIdentifier columnOldName, SqlIdentifier columnNewName, boolean isAlias ) {
+        super( pos );
+        if (isAlias) {
+            this.table = (SqlIdentifier) replaceTableNameIfIsAlias( Objects.requireNonNull( table ) );
+        } else {
+            this.table = Objects.requireNonNull( table );
+        }
+        this.columnOldName = Objects.requireNonNull( columnOldName );
+        this.columnNewName = Objects.requireNonNull( columnNewName );
+    }
+
 
     @Override
     public List<Node> getOperandList() {


### PR DESCRIPTION
<!--
Please fill in all headings that are applicable to your pull request and make sure to label this it accordingly.
-->

## Summary

This PR implements an alias feature for table names that can be used with SQL statement, in a controlled manner.

### Changes

- Introduced a new keyword ALIAS.
- Added a sub-command `CREATE ALIAS` to `CREATE`.
- Added a sub-command `DROP ALIAS` to `DROP`.
- Changed `DROP TABLE`.
- Added an optional `ALIAS` keyword to `SELECT`, `ALTER TABLE`, `UPDATE`, `DROP TABLE`, `INSERT`, `DELETE`.


### Features

- Create an alias. `CREATE ALIAS <TABLE> AS <ALIAS>`.
- Remove an alias. `DROP ALIAS <ALIAS>`.
- Drop a table will remove all it's aliases. `DROP TABLE <TABLE>` or `DROP TABLE ALIAS <ALIAS>`.
- Rename a table will update the alias mapping. `ALTER TABLE <TABLE> RENAME TO <NEW>`.
- CRUD with alias. E.g., `SELECT * FROM ALIAS <ALIAS>; `


### Tests

<TODO>

---

### ToDo

<!-- For WIP PR add meaningful todos -->

- [ ] Add native test cases

