### PR TITLE
Update Gradle JavaCC plugin to latest version (3.0.0)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,4 @@
-import ca.coglinc.gradle.plugins.javacc.CompileJavaccTask
+import org.javacc.plugin.gradle.javacc.CompileJavaccTask
 
 group "org.polypheny"
 
@@ -18,8 +18,8 @@ configurations {
 
 buildscript {
     dependencies {
-        // JavaCC (https://github.com/johnmartel/javaccPlugin)
-        classpath group: "gradle.plugin.ca.coglinc2", name: "javacc-gradle-plugin", version: javacc_plugin_version
+        // JavaCC (https://github.com/javacc/javaccPlugin)
+        classpath group: "org.javacc.plugin", name: "javacc-gradle-plugin", version: javacc_plugin_version
         // Fmpp
         classpath group: "net.sourceforge.fmpp", name: "fmpp", version: fmpp_plugin_version
         // Protobuf

--- a/plugins/cql-language/build.gradle
+++ b/plugins/cql-language/build.gradle
@@ -1,4 +1,4 @@
-import ca.coglinc.gradle.plugins.javacc.CompileJavaccTask
+import org.javacc.plugin.gradle.javacc.CompileJavaccTask
 
 group "org.polypheny"
 
@@ -12,7 +12,7 @@ configurations {
 
 buildscript {
     dependencies {
-        classpath group: "gradle.plugin.ca.coglinc2", name: "javacc-gradle-plugin", version: javacc_plugin_version
+        classpath group: "org.javacc.plugin", name: "javacc-gradle-plugin", version: javacc_plugin_version
     }
 }
 

--- a/plugins/cypher-language/build.gradle
+++ b/plugins/cypher-language/build.gradle
@@ -1,4 +1,4 @@
-import ca.coglinc.gradle.plugins.javacc.CompileJavaccTask
+import org.javacc.plugin.gradle.javacc.CompileJavaccTask
 
 group "org.polypheny"
 
@@ -12,7 +12,7 @@ configurations {
 
 buildscript {
     dependencies {
-        classpath group: "gradle.plugin.ca.coglinc2", name: "javacc-gradle-plugin", version: javacc_plugin_version
+        classpath group: "org.javacc.plugin", name: "javacc-gradle-plugin", version: javacc_plugin_version
     }
 }
 

--- a/plugins/mql-language/build.gradle
+++ b/plugins/mql-language/build.gradle
@@ -1,4 +1,4 @@
-import ca.coglinc.gradle.plugins.javacc.CompileJavaccTask
+import org.javacc.plugin.gradle.javacc.CompileJavaccTask
 
 group "org.polypheny"
 
@@ -13,8 +13,8 @@ configurations {
 
 buildscript {
     dependencies {
-        // JavaCC (https://github.com/johnmartel/javaccPlugin)
-        classpath group: "gradle.plugin.ca.coglinc2", name: "javacc-gradle-plugin", version: javacc_plugin_version
+        // JavaCC (https://github.com/javacc/javaccPlugin)
+        classpath group: "org.javacc.plugin", name: "javacc-gradle-plugin", version: javacc_plugin_version
         // Fmpp
         classpath group: "net.sourceforge.fmpp", name: "fmpp", version: fmpp_plugin_version
     }

--- a/plugins/pig-language/build.gradle
+++ b/plugins/pig-language/build.gradle
@@ -1,4 +1,4 @@
-import ca.coglinc.gradle.plugins.javacc.CompileJavaccTask
+import org.javacc.plugin.gradle.javacc.CompileJavaccTask
 
 group "org.polypheny"
 
@@ -10,8 +10,8 @@ configurations {
 
 buildscript {
     dependencies {
-        // JavaCC (https://github.com/johnmartel/javaccPlugin)
-        classpath group: 'ca.coglinc2.javacc', name: 'ca.coglinc2.javacc.gradle.plugin', version: javacc_plugin_version
+        // JavaCC (https://github.com/javacc/javaccPlugin)
+        classpath group: 'org.javacc.plugin', name: 'javacc-gradle-plugin', version: javacc_plugin_version
     }
 }
 

--- a/plugins/sql-language/build.gradle
+++ b/plugins/sql-language/build.gradle
@@ -1,4 +1,4 @@
-import ca.coglinc.gradle.plugins.javacc.CompileJavaccTask
+import org.javacc.plugin.gradle.javacc.CompileJavaccTask
 
 group "org.polypheny"
 
@@ -13,8 +13,8 @@ configurations {
 
 buildscript {
     dependencies {
-        // JavaCC (https://github.com/johnmartel/javaccPlugin)
-        classpath group: "gradle.plugin.ca.coglinc2", name: "javacc-gradle-plugin", version: javacc_plugin_version
+        // JavaCC (https://github.com/javacc/javaccPlugin)
+        classpath group: "org.javacc.plugin", name: "javacc-gradle-plugin", version: javacc_plugin_version
         // Fmpp
         classpath group: "net.sourceforge.fmpp", name: "fmpp", version: fmpp_plugin_version
     }


### PR DESCRIPTION
<!--
Please fill in all headings that are applicable to your pull request and make sure to label this it accordingly.
-->

## Summary

New version of the JavaCC plugin is out: [release notes](https://github.com/javacc/javaccPlugin/releases/tag/javacc-gradle-plugin-3.0.0). Because the plugin ID changed, it won't be found by usual dependency update mechanisms, so I'm making  PRs manually to update all the major projects on GitHub that are using an older version of the plugin.

The new version should make compilation of the parser a bit faster and improve compatibility with future releases of Gradle.

I locally checked that `./gradlew test -Dstore.default=file` is successful with this change, but have not done any other testing.

### Changes

* Update Gradle JavaCC plugin to latest version (3.0.0)