### PR TITLE
Added testConnection feature in CSV adapter.   Issue #450

### DIFF
--- a/core/src/main/java/org/polypheny/db/adapter/DataSource.java
+++ b/core/src/main/java/org/polypheny/db/adapter/DataSource.java
@@ -116,4 +116,7 @@ public abstract class DataSource extends Adapter implements ExtensionPoint {
         return AdapterType.SOURCE;
     }
 
+
+    public void testConnection(){}
+
 }

--- a/plugins/csv-adapter/src/main/java/org/polypheny/db/adapter/csv/CsvSource.java
+++ b/plugins/csv-adapter/src/main/java/org/polypheny/db/adapter/csv/CsvSource.java
@@ -345,4 +345,35 @@ public class CsvSource extends DataSource {
         }
     }
 
+
+    public void testConnection(){
+        File directory = new File(csvDir.getPath());
+
+        // Check if the directory exists
+        if (!directory.exists() ) {
+            throw new Error("The specified path is not a valid directory.");
+        }
+
+        // List all files in the directory
+        File[] files = directory.listFiles();
+        if(files == null)
+            throw new Error("THERE IS NO CSV FILE TO UPLOAD. ");
+
+        int badFiles = 0;
+        if (files != null) {
+            // Check each file if it has a .csv extension
+            for (File file : files) {
+                System.out.println(file.getName());
+                if (!file.isFile() || !file.getName().toLowerCase().endsWith(".csv"))
+                    badFiles++;
+
+            }
+        }
+
+        if(badFiles==files.length)
+            throw new Error("NO VALID CSV FILE FOUND. ");
+
+
+    }
+
 }


### PR DESCRIPTION
<!--
Please fill in all headings that are applicable to your pull request and make sure to label this it accordingly.
-->

## Summary

I added a method called testConnection in the DataSource abstarct in order to test the connection of a specific Data Source.
The method could be abstract so that every class has to provide it implementation but for now it is not a priority.The CSV adaptor was not checking whether the uploaded file is a valid CSV file or not ,so I added this in the testConnection method.I tested and the CSV adaptor will not add invalid CSV files.This has to be done also for all the classes that extends the DataSource abstract class.I need somebody to guide how to do so in the other DataSources: Ethereum,Excel,Qfs,GoogleSheet,AbstarctJdbc



### Changes
Adde the testConnection method in the DataSource and CsvSource classes.

---

### ToDo

<!-- For WIP PR add meaningful todos -->

- [ ] Add testConnection to Excel
- [ ] Add testConnection to GoogleSheet
- [ ] Add testConnection to Qfs
- [ ] Add testConnection to AbstarctJdbc
- [ ] Add testConnection to Ethereum


