### PR TITLE
New validation on wildcard was added to AbstractJdbcSource.java,

### DIFF
--- a/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/sources/AbstractJdbcSource.java
+++ b/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/sources/AbstractJdbcSource.java
@@ -205,7 +205,11 @@ public abstract class AbstractJdbcSource extends DataSource<RelAdapterCatalog> i
             Connection connection = statement.getConnection();
             DatabaseMetaData dbmd = connection.getMetaData();
 
-            String[] tables = settings.get( "tables" ).split( "," );
+            String tablesString = settings.get("tables");
+            if ("*".equals(tablesString)) {
+                throw new GenericRuntimeException("Wildcard '*' is not allowed for table names.");
+            }
+            String[] tables = tablesString.split(",");
             for ( String str : tables ) {
                 String[] names = str.split( "\\." );
                 if ( names.length == 0 || names.length > 2 || (requiresSchema() && names.length == 1) ) {


### PR DESCRIPTION
## Summary
This change introduces a check during the parsing of settings to determine whether the value associated with the "tables" key is a wildcard character "*". If it is, an exception will be thrown.
**Fixes:** #477 
---

### Changes

Implemented a validation mechanism within the settings parser that checks for the presence of a wildcard character "*" as the value for the "tables" key. Prior to this change, the parser did not restrict the use of wildcard characters, which could lead to ambiguous or unintended behavior.

---

### Features

Wildcard ‘*’ Validation


### Bug Fixes

Adding Data Source Tables containing wildcards '*' breaks schema 

---

### Tests
1.use '*' to select tables
<img width="1392" alt="截屏2024-03-17 13 34 00" src="https://github.com/polypheny/Polypheny-DB/assets/102225947/51c8199c-a32e-44b4-83df-a7a3f1d209da">
2.web UI prompts 'unable to add
<img width="1392" alt="截屏2024-03-17 13 33 49" src="https://github.com/polypheny/Polypheny-DB/assets/102225947/08c23456-3f97-4454-8992-a1ce4d73f32f">
3.The exception output appears in the console section of the IDE.
<img width="1440" alt="截屏2024-03-17 13 31 47" src="https://github.com/polypheny/Polypheny-DB/assets/102225947/85621eaa-43b2-4565-a8a6-0f05e1710d05">


---
### Further Contribution
If this solution is deemed viable, it will be necessary to implement the same validation check across the remaining five implementations. Ensuring this consistency will maintain the protection against using a wildcard character '*' as a table name across the entire codebase, which is critical for the comprehensive resolution of issue #477.
<img width="1011" alt="截屏2024-03-17 13 40 34" src="https://github.com/polypheny/Polypheny-DB/assets/102225947/7b53a51b-99e5-4570-b69f-922a0729f200">

