### PR TITLE
Configured Swagger in the project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ allprojects {
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots/"
         }
+        maven{
+            url "https://maven.reposilite.com/releases/"
+        }
     }
 
     configurations.configureEach {

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -455,6 +455,8 @@ public class PolyphenyDb {
         log.info( "                Polypheny-DB successfully started and ready to process your queries!" );
         log.info( "                              The UI is waiting for you on port {}:", RuntimeConfig.WEBUI_SERVER_PORT.getInteger() );
         log.info( "                                       http://localhost:{}", RuntimeConfig.WEBUI_SERVER_PORT.getInteger() );
+        log.info( "                                    For Swagger documentation:" );
+        log.info( "                                   http://localhost:{}/swagger", RuntimeConfig.WEBUI_SERVER_PORT.getInteger() );
         log.info( "****************************************************************************************************" );
         isReady = true;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -99,3 +99,4 @@ slf4j_api_version = 2.0.12
 typesafe_config_version = 1.2.1
 unirest_version = 3.14.5
 web3j_version = 5.0.0
+openapi = 1.1.7

--- a/webui/build.gradle
+++ b/webui/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     implementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: jackson_core_version // Apache 2.0
     implementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: jackson_annotations_version // Apache 2.0
 
+    annotationProcessor group: "io.javalin-rfc", name: "openapi-annotation-processor", version: openapi
+    
+    implementation group: "io.javalin-rfc", name: "javalin-openapi-plugin", version: openapi
+    implementation group: "io.javalin-rfc", name: "javalin-swagger-plugin", version: openapi
 
     // --- Test Compile ---
     testImplementation project(path: ":core", configuration: "tests")

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -67,6 +67,10 @@ import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.Part;
+import io.javalin.openapi.HttpMethod;
+import io.javalin.openapi.OpenApi;
+import io.javalin.openapi.OpenApiContent;
+import io.javalin.openapi.OpenApiRequestBody;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -2058,6 +2062,13 @@ public class Crud implements InformationObserver, PropertyChangeListener {
     /**
      * Deploy a new adapter
      */
+    @OpenApi(
+            path = "/createAdapter",
+            summary = "Deploy a new adapter",
+            tags = { "Adapter" },
+            methods = {HttpMethod.POST},
+            requestBody = @OpenApiRequestBody(content = @OpenApiContent(from = AdapterModel.class))
+    )
     void addAdapter( final Context ctx ) {
         AdapterModel a = ctx.bodyAsClass( AdapterModel.class );
         Map<String, String> settings = new HashMap<>();

--- a/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
+++ b/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
@@ -24,6 +24,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
+import io.javalin.openapi.plugin.OpenApiConfiguration;
+import io.javalin.openapi.plugin.OpenApiPlugin;
+import io.javalin.openapi.plugin.swagger.SwaggerConfiguration;
+import io.javalin.openapi.plugin.swagger.SwaggerPlugin;
 import io.javalin.plugin.json.JavalinJackson;
 import io.javalin.websocket.WsConfig;
 import java.io.BufferedReader;
@@ -61,6 +65,7 @@ public class HttpServer implements Runnable {
     @Getter
     private WebSocket webSocketHandler;
 
+    String deprecatedDocsPath = "/swagger-docs";
 
     public static HttpServer getInstance() {
         if ( INSTANCE == null ) {
@@ -82,12 +87,30 @@ public class HttpServer implements Runnable {
             writerWithDefaultPrettyPrinter();
         }
     };
+    
+    
+    private OpenApiConfiguration getOpenApiConfiguration() {
+        OpenApiConfiguration openApiConfiguration = new OpenApiConfiguration();
+        openApiConfiguration.setTitle( "Polypheny-DB WebUI" );
+        openApiConfiguration.setDocumentationPath(deprecatedDocsPath); // by default it's /openapi
+        return openApiConfiguration;
+    }
+    
+    
+    private SwaggerConfiguration getSwaggerConfiguration() {
+        SwaggerConfiguration swaggerConfiguration = new SwaggerConfiguration();
+        swaggerConfiguration.setDocumentationPath(deprecatedDocsPath);
+        return swaggerConfiguration;
+    }
 
+    
     @Getter
     private final Javalin server = Javalin.create( config -> {
         config.jsonMapper( new JavalinJackson( mapper ) );
         config.enableCorsForAllOrigins();
         config.addStaticFiles( staticFileConfig -> staticFileConfig.directory = "webapp/" );
+        config.registerPlugin( new OpenApiPlugin( getOpenApiConfiguration() ) );
+        config.registerPlugin( new SwaggerPlugin( getSwaggerConfiguration() ) );
     } ).start( RuntimeConfig.WEBUI_SERVER_PORT.getInteger() );
     private Crud crud;
 


### PR DESCRIPTION
<!--
Please fill in all headings that apply to your pull request and make sure to label this accordingly.
-->

## Summary

The Swagger plugin for Javalin is used to configure Swagger. However the annotated endpoints are shown in the Swagger UI but annotations are unable to access any user-defined class in the annotation, as a result, the request format is not shown properly.

**Fixes:** #478 

### Changes

The Javalin Openapi plugin is used to generate endpoints' documentation. However the plugin is for Javalin 5 or more, and their documentation suggests to use the javalin-rfc openapi plugin for versions below Javalin 5.
ref: https://github.com/javalin/javalin-openapi/wiki/1.-Installation

For installation this documentation is followed: 
https://github.com/javalin/javalin-openapi/tree/99fe1f8eb1df46a1687653bf433d082d7115d426

But the javalin-rfc plugins are located at Reposilite repo. So the build.gradle file in the root is configured to search the Reposilite repo for plugins (ref: https://mvnrepository.com/artifact/io.javalin-rfc/openapi-annotation-processor/1.1.7).

And  the OpenApi annotation is used in the request handler to generate docs. However, the annotation is unable to access any user-defiend class in the annotation. As a result, the request format is not generated properly. With further modifications this can be improved. Currently, only the '/createAdapter' endpoint's docs has been created to verify.



### ToDo

<!-- For WIP PR add meaningful todos -->

- [ ] Add the request format
- [ ] Add the response format if possible
- [ ] Add annotations for each endpoint
- [ ] ...

