### PR TITLE
Lock the Polypheny Home Directory

### DIFF
--- a/config/src/main/java/org/polypheny/db/util/PolyphenyHomeDirManager.java
+++ b/config/src/main/java/org/polypheny/db/util/PolyphenyHomeDirManager.java
@@ -46,7 +46,7 @@ public class PolyphenyHomeDirManager {
     private File home;
     private final List<File> dirs = new ArrayList<>();
     private final List<File> deleteOnExit = new ArrayList<>();
-    private final FileLock lock;
+    private final FileLock lock; // Reference so the lock is not released
     @Getter
     private static RunMode mode;
 

--- a/config/src/main/java/org/polypheny/db/util/PolyphenyHomeDirManager.java
+++ b/config/src/main/java/org/polypheny/db/util/PolyphenyHomeDirManager.java
@@ -119,16 +119,16 @@ public class PolyphenyHomeDirManager {
     }
 
 
-    private boolean probeCreatingFolder( File file ) {
+    private static boolean probeCreatingFolder( File file ) {
         if ( file.isFile() ) {
             return false;
         }
 
         boolean couldCreate = true;
-        if ( !home.exists() ) {
-            couldCreate = home.mkdirs();
+        if ( !file.exists() ) {
+            couldCreate = file.mkdirs();
         }
-        return couldCreate && home.canWrite();
+        return couldCreate && file.canWrite();
     }
 
 

--- a/config/src/main/java/org/polypheny/db/util/PolyphenyHomeDirManager.java
+++ b/config/src/main/java/org/polypheny/db/util/PolyphenyHomeDirManager.java
@@ -19,7 +19,10 @@ package org.polypheny.db.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -39,10 +42,11 @@ public class PolyphenyHomeDirManager {
 
     private static PolyphenyHomeDirManager INSTANCE = null;
 
-    private File root;
+    private final File root;
     private File home;
     private final List<File> dirs = new ArrayList<>();
     private final List<File> deleteOnExit = new ArrayList<>();
+    private final FileLock lock;
     @Getter
     private static RunMode mode;
 
@@ -73,6 +77,18 @@ public class PolyphenyHomeDirManager {
             }
         }
 
+        File lockFile = registerNewFile( ".lock" );
+        try {
+            FileChannel fileChannel = FileChannel.open( lockFile.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE );
+            Optional<FileLock> fileLock = Optional.ofNullable( fileChannel.tryLock() );
+            if ( fileLock.isPresent() ) {
+                lock = fileLock.get();
+            } else {
+                throw new RuntimeException( "There is already another Polypheny instance running in this directory" ); // TODO: Somehow get access to GenericRuntimeException
+            }
+        } catch ( IOException e ) {
+            throw new RuntimeException( "Failed to open lockfile", e ); // TODO: Somehow get access to GenericRuntimeException
+        }
         Runtime.getRuntime().addShutdownHook( new Thread( () -> {
             for ( File file : deleteOnExit ) {
                 if ( file.exists() ) {

--- a/config/src/main/java/org/polypheny/db/util/PolyphenyHomeDirManager.java
+++ b/config/src/main/java/org/polypheny/db/util/PolyphenyHomeDirManager.java
@@ -84,10 +84,10 @@ public class PolyphenyHomeDirManager {
             if ( fileLock.isPresent() ) {
                 lock = fileLock.get();
             } else {
-                throw new RuntimeException( "There is already another Polypheny instance running in this directory" ); // TODO: Somehow get access to GenericRuntimeException
+                throw new RuntimeException( "There is already another Polypheny instance running in this directory" );
             }
         } catch ( IOException e ) {
-            throw new RuntimeException( "Failed to open lockfile", e ); // TODO: Somehow get access to GenericRuntimeException
+            throw new RuntimeException( "Failed to open lockfile", e );
         }
         Runtime.getRuntime().addShutdownHook( new Thread( () -> {
             for ( File file : deleteOnExit ) {

--- a/core/src/main/java/org/polypheny/db/adapter/DataSource.java
+++ b/core/src/main/java/org/polypheny/db/adapter/DataSource.java
@@ -92,7 +92,7 @@ public abstract class DataSource<S extends AdapterCatalog> extends Adapter<S> im
             jsonSource.addProperty( "uniqueName", src.getUniqueName() );
             jsonSource.addProperty( "adapterName", src.getAdapterName() );
             jsonSource.add( "adapterSettings", context.serialize( AbstractAdapterSetting.serializeSettings( src.getAvailableSettings( src.getClass() ), src.getCurrentSettings() ) ) );
-            jsonSource.add( "currentSettings", context.serialize( src.getCurrentSettings() ) );
+            jsonSource.add( "settings", context.serialize( src.getCurrentSettings() ) );
             jsonSource.add( "dataReadOnly", context.serialize( src.isDataReadOnly() ) );
             jsonSource.addProperty( "type", src.getAdapterType().name() );
             return jsonSource;

--- a/core/src/main/java/org/polypheny/db/adapter/DataStore.java
+++ b/core/src/main/java/org/polypheny/db/adapter/DataStore.java
@@ -78,7 +78,7 @@ public abstract class DataStore<S extends AdapterCatalog> extends Adapter<S> imp
             JsonObject jsonStore = new JsonObject();
             jsonStore.addProperty( "adapterId", src.getAdapterId() );
             jsonStore.add( "adapterSettings", context.serialize( AbstractAdapterSetting.serializeSettings( src.getAvailableSettings( src.getClass() ), src.getCurrentSettings() ) ) );
-            jsonStore.add( "currentSettings", context.serialize( src.getCurrentSettings() ) );
+            jsonStore.add( "settings", context.serialize( src.getCurrentSettings() ) );
             jsonStore.addProperty( "adapterName", src.getAdapterName() );
             jsonStore.addProperty( "uniqueName", src.getUniqueName() );
             jsonStore.addProperty( "type", src.getAdapterType().name() );

--- a/core/src/main/java/org/polypheny/db/adapter/index/Index.java
+++ b/core/src/main/java/org/polypheny/db/adapter/index/Index.java
@@ -97,7 +97,7 @@ public abstract class Index {
         }
         final AlgNode scan = builder
                 .relScan( table )
-                .project( cols.stream().map( builder::field ).collect( Collectors.toList() ) )
+                .project( cols.stream().map( builder::field ).toList() )
                 .build();
         final QueryProcessor processor = statement.getQueryProcessor();
         final PolyImplementation implementation = processor.prepareQuery( AlgRoot.of( scan, Kind.SELECT ), false );

--- a/core/src/main/java/org/polypheny/db/adapter/index/Index.java
+++ b/core/src/main/java/org/polypheny/db/adapter/index/Index.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import org.polypheny.db.PolyImplementation;
 import org.polypheny.db.ResultIterator;

--- a/core/src/main/java/org/polypheny/db/adapter/index/IndexManager.java
+++ b/core/src/main/java/org/polypheny/db/adapter/index/IndexManager.java
@@ -223,7 +223,7 @@ public class IndexManager {
     public List<Index> getIndices( LogicalNamespace schema, LogicalTable table ) {
         return this.indexById.values().stream()
                 .filter( index -> index.schema.equals( schema ) && index.table.equals( table ) )
-                .collect( Collectors.toList() );
+                .toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/adapter/index/IndexManager.java
+++ b/core/src/main/java/org/polypheny/db/adapter/index/IndexManager.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 import org.polypheny.db.adapter.DataStore.IndexMethodModel;
 import org.polypheny.db.adapter.index.Index.IndexFactory;
 import org.polypheny.db.catalog.Catalog;

--- a/core/src/main/java/org/polypheny/db/algebra/core/document/DocumentProject.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/document/DocumentProject.java
@@ -92,8 +92,8 @@ public abstract class DocumentProject extends SingleAlg implements DocumentAlg {
         // null key is replaceRoot
         nodes.add(
                 builder.makeLiteral(
-                        PolyList.copyOf( includes.keySet().stream().filter( Objects::nonNull ).map( v -> PolyList.copyOf( Arrays.stream( v.split( "\\." ) ).map( PolyString::of ).collect( Collectors.toList() ) ) )
-                                .collect( Collectors.toList() ) ),
+                        PolyList.copyOf( includes.keySet().stream().filter( Objects::nonNull ).map( v -> PolyList.copyOf( Arrays.stream( v.split( "\\." ) ).map( PolyString::of ).toList() ) )
+                                .toList() ),
                         builder.getTypeFactory().createArrayType( builder.getTypeFactory().createPolyType( PolyType.CHAR, 255 ), -1 ), PolyType.ARRAY ) );
         nodes.addAll( includes.entrySet().stream().filter( o -> Objects.nonNull( o.getKey() ) ).map( Entry::getValue ).toList() );
 
@@ -115,7 +115,7 @@ public abstract class DocumentProject extends SingleAlg implements DocumentAlg {
                             builder.getTypeFactory().createArrayType(
                                     builder.getTypeFactory().createArrayType( builder.getTypeFactory().createPolyType( PolyType.CHAR, 255 ), -1 ),
                                     -1 ),
-                            excludes.stream().map( value -> PolyList.of( Arrays.stream( value.split( "\\." ) ).map( PolyString::of ).collect( Collectors.toList() ) ) ).collect( Collectors.toList() ) ) );
+                            excludes.stream().map( value -> PolyList.of( Arrays.stream( value.split( "\\." ) ).map( PolyString::of ).toList() ) ).collect( Collectors.toList() ) ) );
         }
 
         return doc;

--- a/core/src/main/java/org/polypheny/db/algebra/core/lpg/LpgMatch.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/lpg/LpgMatch.java
@@ -18,7 +18,6 @@ package org.polypheny.db.algebra.core.lpg;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import org.polypheny.db.algebra.AlgNode;
 import org.polypheny.db.algebra.SingleAlg;

--- a/core/src/main/java/org/polypheny/db/algebra/core/lpg/LpgMatch.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/lpg/LpgMatch.java
@@ -85,12 +85,12 @@ public abstract class LpgMatch extends SingleAlg implements LpgAlg {
 
     @Override
     public AlgNode accept( RexShuttle shuttle ) {
-        List<RexNode> exp = this.matches.stream().map( m -> (RexNode) m ).collect( Collectors.toList() );
+        List<RexNode> exp = this.matches.stream().map( m -> (RexNode) m ).toList();
         List<RexNode> exps = shuttle.apply( exp );
         if ( exp == exps ) {
             return this;
         }
-        return new LogicalLpgMatch( getCluster(), traitSet, input, exps.stream().map( e -> (RexCall) e ).collect( Collectors.toList() ), names );
+        return new LogicalLpgMatch( getCluster(), traitSet, input, exps.stream().map( e -> (RexCall) e ).toList(), names );
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/algebra/core/lpg/LpgProject.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/lpg/LpgProject.java
@@ -89,7 +89,7 @@ public abstract class LpgProject extends SingleAlg implements LpgAlg {
 
     @Override
     public AlgNode accept( RexShuttle shuttle ) {
-        List<RexNode> exp = this.projects.stream().map( p -> (RexNode) p ).collect( Collectors.toList() );
+        List<RexNode> exp = this.projects.stream().map( p -> (RexNode) p ).toList();
         List<RexNode> exps = shuttle.apply( exp );
         if ( exp == exps ) {
             return this;

--- a/core/src/main/java/org/polypheny/db/algebra/core/lpg/LpgProject.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/lpg/LpgProject.java
@@ -18,7 +18,6 @@ package org.polypheny.db.algebra.core.lpg;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import org.polypheny.db.algebra.AlgNode;
 import org.polypheny.db.algebra.SingleAlg;

--- a/core/src/main/java/org/polypheny/db/algebra/core/relational/RelScan.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/relational/RelScan.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.NonNull;
 import org.polypheny.db.algebra.AlgInput;

--- a/core/src/main/java/org/polypheny/db/algebra/core/relational/RelScan.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/relational/RelScan.java
@@ -92,7 +92,7 @@ public abstract class RelScan<E extends Entity> extends Scan<E> implements RelAl
      * Returns an identity projection for the given table.
      */
     public static ImmutableList<Integer> identity( Entity entity ) {
-        return ImmutableList.copyOf( IntStream.range( 0, entity.getTupleType().getFieldCount() ).boxed().collect( Collectors.toList() ) );
+        return ImmutableList.copyOf( IntStream.range( 0, entity.getTupleType().getFieldCount() ).boxed().toList() );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/algebra/enumerable/EnumerableAlgImplementor.java
+++ b/core/src/main/java/org/polypheny/db/algebra/enumerable/EnumerableAlgImplementor.java
@@ -140,7 +140,7 @@ public class EnumerableAlgImplementor extends JavaAlgImplementor {
         if ( contextCounter < 0 ) {
             // If the context was not set by ContextSwitcher we only need the initial one
             Statement assign = Expressions.declare( Modifier.FINAL, DataContext.ROOT, DataContext.INITIAL_ROOT );
-            block = Expressions.block( Stream.concat( Stream.of( assign ), block.statements.stream() ).collect( Collectors.toList() ) );
+            block = Expressions.block( Stream.concat( Stream.of( assign ), block.statements.stream() ).toList() );
         }
 
         // add values

--- a/core/src/main/java/org/polypheny/db/algebra/enumerable/EnumerableAlgImplementor.java
+++ b/core/src/main/java/org/polypheny/db/algebra/enumerable/EnumerableAlgImplementor.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Getter;
 import org.apache.calcite.linq4j.Enumerable;
@@ -516,4 +515,3 @@ public class EnumerableAlgImplementor extends JavaAlgImplementor {
     }
 
 }
-

--- a/core/src/main/java/org/polypheny/db/algebra/enumerable/EnumerableStreamer.java
+++ b/core/src/main/java/org/polypheny/db/algebra/enumerable/EnumerableStreamer.java
@@ -91,7 +91,7 @@ public class EnumerableStreamer extends Streamer implements EnumerableAlg {
                 Expressions.constant( DataContext.ROOT ),
                 builder.append( builder.newName( "query" + System.nanoTime() ), query.block() ),
                 exp,
-                Expressions.constant( getLeft().getTupleType().getFields().stream().map( f -> f.getType().getPolyType() ).collect( Collectors.toList() ) ) );
+                Expressions.constant( getLeft().getTupleType().getFields().stream().map( f -> f.getType().getPolyType() ).toList() ) );
 
         builder.add( Expressions.return_( null, builder.append( "test", transformContext ) ) );
 

--- a/core/src/main/java/org/polypheny/db/algebra/enumerable/EnumerableStreamer.java
+++ b/core/src/main/java/org/polypheny/db/algebra/enumerable/EnumerableStreamer.java
@@ -19,7 +19,6 @@ package org.polypheny.db.algebra.enumerable;
 
 import java.lang.reflect.Modifier;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.function.Function;
 import org.apache.calcite.linq4j.function.Function0;

--- a/core/src/main/java/org/polypheny/db/catalog/Catalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/Catalog.java
@@ -132,7 +132,7 @@ public abstract class Catalog implements ExtensionPoint {
 
     public abstract AllocationGraphCatalog getAllocGraph( long namespaceId );
 
-    public abstract <S extends AdapterCatalog> Optional<S> getAdapterCatalog( long id );
+    public abstract Optional<AdapterCatalog> getAdapterCatalog( long id );
 
     public abstract void addStoreSnapshot( AdapterCatalog snapshot );
 

--- a/core/src/main/java/org/polypheny/db/catalog/IdBuilder.java
+++ b/core/src/main/java/org/polypheny/db/catalog/IdBuilder.java
@@ -28,9 +28,6 @@ public class IdBuilder {
     public AtomicLong snapshotId;
 
     @Serialize
-    public AtomicLong namespaceId;
-
-    @Serialize
     public AtomicLong entityId;
 
     @Serialize
@@ -99,14 +96,12 @@ public class IdBuilder {
                 new AtomicLong( 0 ),
                 new AtomicLong( 0 ),
                 new AtomicLong( 0 ),
-                new AtomicLong( 0 ),
                 new AtomicLong( 0 ) );
     }
 
 
     public IdBuilder(
             @Deserialize("snapshotId") AtomicLong snapshotId,
-            @Deserialize("namespaceId") AtomicLong namespaceId,
             @Deserialize("entityId") AtomicLong entityId,
             @Deserialize("fieldId") AtomicLong fieldId,
             @Deserialize("userId") AtomicLong userId,
@@ -122,7 +117,6 @@ public class IdBuilder {
             @Deserialize("partitionId") AtomicLong partitionId,
             @Deserialize("placementId") AtomicLong placementId ) {
         this.snapshotId = snapshotId;
-        this.namespaceId = namespaceId;
         this.entityId = entityId;
         this.fieldId = fieldId;
 
@@ -154,11 +148,6 @@ public class IdBuilder {
 
     public long getNewFieldId() {
         return fieldId.getAndIncrement();
-    }
-
-
-    public long getNewNamespaceId() {
-        return namespaceId.getAndIncrement();
     }
 
 
@@ -224,7 +213,6 @@ public class IdBuilder {
 
     public synchronized void restore( IdBuilder idBuilder ) {
         this.snapshotId.set( idBuilder.snapshotId.longValue() );
-        this.namespaceId.set( idBuilder.namespaceId.longValue() );
         this.entityId.set( idBuilder.entityId.longValue() );
         this.fieldId.set( idBuilder.fieldId.longValue() );
 

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/AdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/AdapterCatalog.java
@@ -33,7 +33,6 @@ import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.linq4j.tree.Expression;
-import org.apache.calcite.linq4j.tree.Expressions;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.allocation.AllocationEntity;
 import org.polypheny.db.catalog.entity.physical.PhysicalEntity;
@@ -90,7 +89,7 @@ public abstract class AdapterCatalog {
 
 
     public Expression asExpression() {
-        return Expressions.call( Catalog.CATALOG_EXPRESSION, "getAdapterCatalog", Expressions.constant( adapterId ) );
+        return Catalog.PHYSICAL_EXPRESSION.apply( adapterId );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
@@ -119,6 +119,7 @@ public class DocAdapterCatalog extends AdapterCatalog {
         return column;
     }
 
+
     public PhysicalTable createTable(
             String namespaceName,
             String tableName,

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.polypheny.db.catalog.IdBuilder;

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
@@ -128,7 +128,7 @@ public class DocAdapterCatalog extends AdapterCatalog {
             AllocationTableWrapper wrapper ) {
         AllocationTable allocation = wrapper.table;
         List<AllocationColumn> columns = wrapper.columns;
-        List<PhysicalColumn> pColumns = columns.stream().map( c -> new PhysicalColumn( columnNames.get( c.columnId ), logical.id, allocation.id, allocation.adapterId, c.position, logicalColumns.get( c.columnId ) ) ).collect( Collectors.toList() );
+        List<PhysicalColumn> pColumns = columns.stream().map( c -> new PhysicalColumn( columnNames.get( c.columnId ), logical.id, allocation.id, allocation.adapterId, c.position, logicalColumns.get( c.columnId ) ) ).toList();
         long physicalId = IdBuilder.getInstance().getNewPhysicalId();
         PhysicalTable table = new PhysicalTable( physicalId, allocation.id, allocation.logicalId, tableName, pColumns, logical.namespaceId, namespaceName, pkIds, allocation.adapterId );
         pColumns.forEach( this::addColumn );

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
@@ -55,7 +55,7 @@ public class DocAdapterCatalog extends AdapterCatalog {
         List<PhysicalColumn> updates = new ArrayList<>();
         for ( PhysicalField field : fields.values() ) {
             if ( field.id == id ) {
-                updates.add( field.unwrap( PhysicalColumn.class ).orElseThrow().toBuilder().logicalName( newFieldName ).build() );
+                updates.add( field.unwrapOrThrow( PhysicalColumn.class ).toBuilder().logicalName( newFieldName ).build() );
             }
         }
         for ( PhysicalColumn u : updates ) {
@@ -75,7 +75,7 @@ public class DocAdapterCatalog extends AdapterCatalog {
 
 
     public <T extends PhysicalEntity> T fromAllocation( long id, Class<T> clazz ) {
-        return getPhysicalsFromAllocs( id ).get( 0 ).unwrap( clazz ).orElseThrow();
+        return getPhysicalsFromAllocs( id ).get( 0 ).unwrapOrThrow( clazz );
     }
 
 
@@ -96,7 +96,7 @@ public class DocAdapterCatalog extends AdapterCatalog {
 
 
     public PhysicalColumn getColumn( long columnId, long allocId ) {
-        return fields.get( Pair.of( allocId, columnId ) ).unwrap( PhysicalColumn.class ).orElseThrow();
+        return fields.get( Pair.of( allocId, columnId ) ).unwrapOrThrow( PhysicalColumn.class );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/DocAdapterCatalog.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
 import org.polypheny.db.catalog.IdBuilder;
 import org.polypheny.db.catalog.entity.allocation.AllocationCollection;
@@ -41,7 +40,6 @@ import org.polypheny.db.catalog.entity.physical.PhysicalField;
 import org.polypheny.db.catalog.entity.physical.PhysicalTable;
 import org.polypheny.db.util.Pair;
 
-@Getter
 @EqualsAndHashCode(callSuper = true)
 @Value
 public class DocAdapterCatalog extends AdapterCatalog {

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/GraphAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/GraphAdapterCatalog.java
@@ -66,7 +66,7 @@ public class GraphAdapterCatalog extends AdapterCatalog {
         List<PhysicalColumn> updates = new ArrayList<>();
         for ( PhysicalField field : fields.values() ) {
             if ( field.id == id ) {
-                updates.add( field.unwrap( PhysicalColumn.class ).orElseThrow().toBuilder().logicalName( newFieldName ).build() );
+                updates.add( field.unwrapOrThrow( PhysicalColumn.class ).toBuilder().logicalName( newFieldName ).build() );
             }
         }
         for ( PhysicalColumn u : updates ) {
@@ -97,7 +97,7 @@ public class GraphAdapterCatalog extends AdapterCatalog {
 
 
     public <E extends PhysicalEntity> E fromAllocation( long id, Class<E> clazz ) {
-        return getPhysicalsFromAllocs( id ).get( 0 ).unwrap( clazz ).orElseThrow();
+        return getPhysicalsFromAllocs( id ).get( 0 ).unwrapOrThrow( clazz );
     }
 
 
@@ -144,7 +144,7 @@ public class GraphAdapterCatalog extends AdapterCatalog {
 
 
     public PhysicalColumn updateColumnType( long allocId, LogicalColumn newCol ) {
-        PhysicalColumn old = getField( newCol.id, allocId ).unwrap( PhysicalColumn.class ).orElseThrow();
+        PhysicalColumn old = getField( newCol.id, allocId ).unwrapOrThrow( PhysicalColumn.class );
         PhysicalColumn column = new PhysicalColumn( old.name, newCol.tableId, allocId, old.adapterId, old.position, newCol );
         addColumn( column );
         return column;

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/GraphAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/GraphAdapterCatalog.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.polypheny.db.catalog.IdBuilder;

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/GraphAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/GraphAdapterCatalog.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
 import org.polypheny.db.catalog.IdBuilder;
 import org.polypheny.db.catalog.entity.allocation.AllocationColumn;
@@ -42,7 +41,6 @@ import org.polypheny.db.catalog.entity.physical.PhysicalTable;
 import org.polypheny.db.util.Pair;
 
 
-@Getter
 @EqualsAndHashCode(callSuper = true)
 @Value
 public class GraphAdapterCatalog extends AdapterCatalog {

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/GraphAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/GraphAdapterCatalog.java
@@ -87,7 +87,7 @@ public class GraphAdapterCatalog extends AdapterCatalog {
         List<AllocationColumn> columns = wrapper.columns;
         List<PhysicalColumn> pColumns = columns.stream()
                 .map( c -> new PhysicalColumn( columnNames.get( c.columnId ), logical.id, allocation.id, allocation.adapterId, c.position, logicalColumns.get( c.columnId ) ) )
-                .collect( Collectors.toList() );
+                .toList();
         long physicalId = IdBuilder.getInstance().getNewPhysicalId();
         PhysicalTable table = new PhysicalTable( physicalId, allocation.id, logical.id, tableName, pColumns, logical.namespaceId, namespaceName, pkIds, allocation.adapterId );
         pColumns.forEach( this::addColumn );

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/LogicalRelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/LogicalRelationalCatalog.java
@@ -88,7 +88,7 @@ public interface LogicalRelationalCatalog extends LogicalCatalog {
     /**
      * Renames a table
      *
-     * @param tableId The if of the table to rename
+     * @param tableId The id of the table to rename
      * @param name New name of the table
      */
     void renameTable( long tableId, String name );
@@ -127,7 +127,7 @@ public interface LogicalRelationalCatalog extends LogicalCatalog {
     /**
      * Renames a column
      *
-     * @param columnId The if of the column to rename
+     * @param columnId The id of the column to rename
      * @param name New name of the column
      */
     void renameColumn( long columnId, String name );
@@ -206,7 +206,7 @@ public interface LogicalRelationalCatalog extends LogicalCatalog {
      *
      * @param tableId The id of the table
      * @param columnIds The id of the columns which are part of the foreign key
-     * @param referencesTableId The if of the referenced table
+     * @param referencesTableId The id of the referenced table
      * @param referencesIds The id of columns forming the key referenced by this key
      * @param constraintName The name of the constraint
      * @param onUpdate The option for updates

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/RelAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/RelAdapterCatalog.java
@@ -89,12 +89,12 @@ public class RelAdapterCatalog extends AdapterCatalog {
 
 
     public PhysicalTable getTable( long id ) {
-        return getPhysical( id ).unwrap( PhysicalTable.class ).orElseThrow();
+        return getPhysical( id ).unwrapOrThrow( PhysicalTable.class );
     }
 
 
     public PhysicalColumn getColumn( long id, long allocId ) {
-        return fields.get( Pair.of( allocId, id ) ).unwrap( PhysicalColumn.class ).orElseThrow();
+        return fields.get( Pair.of( allocId, id ) ).unwrapOrThrow( PhysicalColumn.class );
     }
 
 
@@ -137,12 +137,12 @@ public class RelAdapterCatalog extends AdapterCatalog {
         if ( allocs == null || allocs.isEmpty() ) {
             throw new GenericRuntimeException( "No physical table found for allocation with id %s", id );
         }
-        return allocs.get( 0 ).unwrap( PhysicalTable.class ).orElseThrow();
+        return allocs.get( 0 ).unwrapOrThrow( PhysicalTable.class );
     }
 
 
     public void dropColumn( long allocId, long columnId ) {
-        PhysicalColumn column = fields.get( Pair.of( allocId, columnId ) ).unwrap( PhysicalColumn.class ).orElseThrow();
+        PhysicalColumn column = fields.get( Pair.of( allocId, columnId ) ).unwrapOrThrow( PhysicalColumn.class );
         PhysicalTable table = fromAllocation( allocId );
         List<PhysicalColumn> pColumns = new ArrayList<>( table.columns );
         pColumns.remove( column );

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/RelAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/RelAdapterCatalog.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +43,6 @@ import org.polypheny.db.catalog.entity.physical.PhysicalTable;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.util.Pair;
 
-@Getter
 @EqualsAndHashCode(callSuper = true)
 @Value
 @Slf4j

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/RelAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/RelAdapterCatalog.java
@@ -158,5 +158,4 @@ public class RelAdapterCatalog extends AdapterCatalog {
     }
 
 
-
 }

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/RelAdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/RelAdapterCatalog.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SortedSet;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.experimental.NonFinal;
@@ -75,7 +74,7 @@ public class RelAdapterCatalog extends AdapterCatalog {
         }
         for ( PhysicalColumn u : updates ) {
             PhysicalTable table = fromAllocation( u.allocId );
-            List<PhysicalColumn> newColumns = table.columns.stream().filter( c -> c.id != id ).collect( Collectors.toList() );
+            List<PhysicalColumn> newColumns = new ArrayList<>( table.columns.stream().filter( c -> c.id != id ).toList() );
             newColumns.add( u );
             physicals.put( table.id, table.toBuilder().columns( ImmutableList.copyOf( newColumns ) ).build() );
             fields.put( Pair.of( u.allocId, u.id ), u );
@@ -101,7 +100,7 @@ public class RelAdapterCatalog extends AdapterCatalog {
     public PhysicalTable createTable( String namespaceName, String tableName, Map<Long, String> columnNames, LogicalTable logical, Map<Long, LogicalColumn> lColumns, List<Long> pkIds, AllocationTableWrapper wrapper ) {
         AllocationTable allocation = wrapper.table;
         List<AllocationColumn> columns = wrapper.columns;
-        List<PhysicalColumn> pColumns = Streams.mapWithIndex( columns.stream(), ( c, i ) -> new PhysicalColumn( columnNames.get( c.columnId ), logical.id, allocation.id, allocation.adapterId, (int) i, lColumns.get( c.columnId ) ) ).collect( Collectors.toList() );
+        List<PhysicalColumn> pColumns = Streams.mapWithIndex( columns.stream(), ( c, i ) -> new PhysicalColumn( columnNames.get( c.columnId ), logical.id, allocation.id, allocation.adapterId, (int) i, lColumns.get( c.columnId ) ) ).toList();
         PhysicalTable table = new PhysicalTable( IdBuilder.getInstance().getNewPhysicalId(), allocation.id, allocation.logicalId, tableName, pColumns, logical.namespaceId, namespaceName, pkIds, allocation.adapterId );
         pColumns.forEach( this::addColumn );
         addPhysical( allocation, table );
@@ -152,7 +151,7 @@ public class RelAdapterCatalog extends AdapterCatalog {
 
 
     public List<PhysicalColumn> getColumns( long allocId ) {
-        return fields.values().stream().map( p -> p.unwrap( PhysicalColumn.class ) ).filter( Optional::isPresent ).map( Optional::get ).filter( c -> c.allocId == allocId ).collect( Collectors.toList() );
+        return fields.values().stream().map( p -> p.unwrap( PhysicalColumn.class ) ).filter( Optional::isPresent ).map( Optional::get ).filter( c -> c.allocId == allocId ).toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
@@ -153,7 +153,7 @@ public abstract class Entity implements PolyObject, Wrapper, Serializable, Catal
         if ( !this.getClass().getSimpleName().equals( o.getClass().getSimpleName() ) ) {
             return -1;
         }
-        return Long.compare(this.id, o.id);
+        return Long.compare( this.id, o.id );
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
@@ -19,7 +19,6 @@ package org.polypheny.db.catalog.entity;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serializable;
 import java.util.List;
-import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.experimental.SuperBuilder;
@@ -41,7 +40,6 @@ import org.polypheny.db.schema.types.Typed;
 import org.polypheny.db.util.ImmutableBitSet;
 import org.polypheny.db.util.Wrapper;
 
-@Getter
 @SuperBuilder(toBuilder = true)
 @Value
 @NonFinal

--- a/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
@@ -153,7 +153,7 @@ public abstract class Entity implements PolyObject, Wrapper, Serializable, Catal
         if ( !this.getClass().getSimpleName().equals( o.getClass().getSimpleName() ) ) {
             return -1;
         }
-        return (int) (this.id - o.id);
+        return Long.compare(this.id, o.id);
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalAdapter.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalAdapter.java
@@ -27,8 +27,6 @@ import lombok.Value;
 import lombok.experimental.SuperBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.polypheny.db.adapter.DeployMode;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
 
 @Value
 @SuperBuilder(toBuilder = true)
@@ -70,13 +68,6 @@ public class LogicalAdapter implements PolyObject {
         this.settings = new HashMap<>( settings );
         this.adapterTypeName = getAdapterName();
         this.mode = mode;
-    }
-
-
-    // Used for creating ResultSets
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[]{ PolyString.of( uniqueName ) };
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalAdapter.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalAdapter.java
@@ -22,7 +22,6 @@ import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
@@ -31,7 +30,6 @@ import org.polypheny.db.adapter.DeployMode;
 import org.polypheny.db.type.entity.PolyString;
 import org.polypheny.db.type.entity.PolyValue;
 
-@EqualsAndHashCode
 @Value
 @SuperBuilder(toBuilder = true)
 public class LogicalAdapter implements PolyObject {

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalConstraint.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalConstraint.java
@@ -20,7 +20,6 @@ package org.polypheny.db.catalog.entity;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serializable;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +27,6 @@ import org.polypheny.db.catalog.entity.logical.LogicalKey;
 import org.polypheny.db.catalog.logistic.ConstraintType;
 
 
-@EqualsAndHashCode
 @Value
 public class LogicalConstraint implements Serializable, Comparable<LogicalConstraint> {
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
@@ -39,7 +39,7 @@ public class LogicalQueryInterface implements PolyObject {
     @Serialize
     public String name;
     @Serialize
-    public String interfaceName;
+    public String interfaceType;
     @Serialize
     public ImmutableMap<String, String> settings;
 
@@ -47,11 +47,11 @@ public class LogicalQueryInterface implements PolyObject {
     public LogicalQueryInterface(
             @Deserialize("id") final long id,
             @Deserialize("name") @NonNull final String uniqueName,
-            @Deserialize("interfaceName") @NonNull final String interfaceName,
+            @Deserialize("interfaceType") @NonNull final String interfaceType,
             @Deserialize("settings") @NonNull final Map<String, String> settings ) {
         this.id = id;
         this.name = uniqueName;
-        this.interfaceName = interfaceName;
+        this.interfaceType = interfaceType;
         this.settings = ImmutableMap.copyOf( settings );
     }
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
 
 
 @Value
@@ -56,13 +54,5 @@ public class LogicalQueryInterface implements PolyObject {
         this.interfaceName = interfaceName;
         this.settings = ImmutableMap.copyOf( settings );
     }
-
-
-    // Used for creating ResultSets
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[]{ PolyString.of( name ) };
-    }
-
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
@@ -22,7 +22,6 @@ import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
 import java.util.Map;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
@@ -30,7 +29,6 @@ import org.polypheny.db.type.entity.PolyString;
 import org.polypheny.db.type.entity.PolyValue;
 
 
-@EqualsAndHashCode
 @Value
 @SuperBuilder(toBuilder = true)
 public class LogicalQueryInterface implements PolyObject {

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
@@ -21,8 +21,6 @@ import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
 import lombok.Value;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
 
 
 @Value
@@ -43,13 +41,6 @@ public class LogicalUser implements PolyObject, Comparable<LogicalUser> {
         this.id = id;
         this.name = name;
         this.password = password;
-    }
-
-
-    // Used for creating ResultSets
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[]{ PolyString.of( name ) };
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
@@ -20,13 +20,11 @@ package org.polypheny.db.catalog.entity;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
-import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.polypheny.db.type.entity.PolyString;
 import org.polypheny.db.type.entity.PolyValue;
 
 
-@EqualsAndHashCode
 @Value
 public class LogicalUser implements PolyObject, Comparable<LogicalUser> {
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
@@ -58,7 +58,7 @@ public class LogicalUser implements PolyObject, Comparable<LogicalUser> {
     @Override
     public int compareTo( LogicalUser o ) {
         if ( o != null ) {
-            return Math.toIntExact( this.id - o.id );
+            return Long.compare( this.id, o.id );
         }
         return -1;
     }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/PolyObject.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/PolyObject.java
@@ -16,17 +16,9 @@
 
 package org.polypheny.db.catalog.entity;
 
-
 import java.io.Serializable;
-import org.polypheny.db.type.entity.PolyValue;
 
-
-/**
- *
- */
 public interface PolyObject extends Serializable {
-
-    PolyValue[] getParameterArray();
 
     default Visibility getVisibility() {
         return Visibility.EXTERNAL;

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationCollection.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationCollection.java
@@ -26,7 +26,6 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.Entity;
 import org.polypheny.db.catalog.logistic.DataModel;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -42,12 +41,6 @@ public class AllocationCollection extends AllocationEntity {
             @Deserialize("namespaceId") long namespaceId,
             @Deserialize("adapterId") long adapterId ) {
         super( id, placementId, partitionId, logicalId, namespaceId, adapterId, DataModel.DOCUMENT );
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
@@ -72,7 +72,6 @@ public class AllocationColumn implements PolyObject {
     }
 
 
-
     public String getLogicalColumnName() {
         return Catalog.snapshot().rel().getColumn( columnId ).orElseThrow().name;
     }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
@@ -18,7 +18,6 @@ package org.polypheny.db.catalog.entity.allocation;
 
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
@@ -31,7 +30,6 @@ import org.polypheny.db.type.entity.PolyString;
 import org.polypheny.db.type.entity.PolyValue;
 
 
-@EqualsAndHashCode
 @Value
 @SuperBuilder(toBuilder = true)
 public class AllocationColumn implements PolyObject {

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
@@ -26,8 +26,6 @@ import org.polypheny.db.algebra.type.AlgDataTypeFactory;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.PolyObject;
 import org.polypheny.db.catalog.logistic.PlacementType;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
 
 
 @Value
@@ -72,15 +70,6 @@ public class AllocationColumn implements PolyObject {
 
     public String getLogicalColumnName() {
         return Catalog.snapshot().rel().getColumn( columnId ).orElseThrow().name;
-    }
-
-
-    // Used for creating ResultSets
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[]{
-                PolyString.of( "alloc_" + columnId ),
-                PolyString.of( placementType.name() ) };
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationGraph.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationGraph.java
@@ -26,7 +26,6 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.Entity;
 import org.polypheny.db.catalog.logistic.DataModel;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -43,12 +42,6 @@ public class AllocationGraph extends AllocationEntity {
             @Deserialize("namespaceId") long namespaceId,
             @Deserialize("adapterId") long adapterId ) {
         super( id, placementId, partitionId, logicalId, namespaceId, adapterId, DataModel.GRAPH );
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartition.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartition.java
@@ -24,7 +24,6 @@ import io.activej.serializer.annotations.SerializeNullable;
 import java.io.Serial;
 import java.util.List;
 import javax.annotation.Nullable;
-import lombok.Getter;
 import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 import org.polypheny.db.catalog.entity.PolyObject;
@@ -52,7 +51,6 @@ public class AllocationPartition implements PolyObject {
     @Serialize
     public long groupId;
 
-    @Getter
     @Serialize
     @SerializeNullable
     public String name;

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartition.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartition.java
@@ -30,7 +30,6 @@ import org.polypheny.db.catalog.entity.PolyObject;
 import org.polypheny.db.catalog.logistic.DataPlacementRole;
 import org.polypheny.db.catalog.logistic.PartitionType;
 import org.polypheny.db.catalog.logistic.PlacementType;
-import org.polypheny.db.type.entity.PolyValue;
 
 
 /**
@@ -106,12 +105,6 @@ public class AllocationPartition implements PolyObject {
         this.isUnbound = isUnbound;
         this.name = name;
         this.qualifiers = qualifiers == null ? List.of() : ImmutableList.copyOf( qualifiers );
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartitionGroup.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartitionGroup.java
@@ -22,8 +22,6 @@ import io.activej.serializer.annotations.SerializeNullable;
 import lombok.Value;
 import org.jetbrains.annotations.Nullable;
 import org.polypheny.db.catalog.entity.PolyObject;
-import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
-import org.polypheny.db.type.entity.PolyValue;
 
 
 @Value
@@ -59,12 +57,6 @@ public class AllocationPartitionGroup implements PolyObject {
         this.namespaceId = namespaceId;
         this.partitionKey = partitionKey;
         this.isUnbound = isUnbound;
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        throw new GenericRuntimeException( "Not implemented" );
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartitionGroup.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartitionGroup.java
@@ -19,7 +19,6 @@ package org.polypheny.db.catalog.entity.allocation;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
-import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jetbrains.annotations.Nullable;
 import org.polypheny.db.catalog.entity.PolyObject;
@@ -27,7 +26,6 @@ import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.type.entity.PolyValue;
 
 
-@EqualsAndHashCode
 @Value
 public class AllocationPartitionGroup implements PolyObject {
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPlacement.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPlacement.java
@@ -20,7 +20,6 @@ import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import lombok.Value;
 import org.polypheny.db.catalog.entity.PolyObject;
-import org.polypheny.db.type.entity.PolyValue;
 
 @Value
 public class AllocationPlacement implements PolyObject {
@@ -44,12 +43,6 @@ public class AllocationPlacement implements PolyObject {
         this.namespaceId = namespaceId;
         this.logicalEntityId = logicalEntityId;
         this.id = id;
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationTable.java
@@ -77,7 +77,7 @@ public class AllocationTable extends AllocationEntity {
 
 
     public List<AllocationColumn> getColumns() {
-        return Catalog.snapshot().alloc().getColumns( placementId ).stream().sorted( Comparator.comparingLong( a -> a.position ) ).collect( Collectors.toList() );
+        return Catalog.snapshot().alloc().getColumns( placementId ).stream().sorted( Comparator.comparingLong( a -> a.position ) ).toList();
     }
 
 
@@ -87,7 +87,7 @@ public class AllocationTable extends AllocationEntity {
 
 
     public List<Long> getColumnIds() {
-        return getColumns().stream().map( c -> c.columnId ).collect( Collectors.toList() );
+        return getColumns().stream().map( c -> c.columnId ).toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationTable.java
@@ -33,8 +33,6 @@ import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.Entity;
 import org.polypheny.db.catalog.entity.logical.LogicalColumn;
 import org.polypheny.db.catalog.logistic.DataModel;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -64,12 +62,6 @@ public class AllocationTable extends AllocationEntity {
         }
 
         return AlgDataTypeImpl.proto( fieldInfo.build() ).apply( AlgDataTypeFactory.DEFAULT );
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyString[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalCollection.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalCollection.java
@@ -26,7 +26,6 @@ import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.PolyObject;
 import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.catalog.logistic.EntityType;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -43,12 +42,6 @@ public class LogicalCollection extends LogicalEntity implements PolyObject {
             @Deserialize("entityType") EntityType entityType,
             @Deserialize("modifiable") boolean modifiable ) {
         super( id, name, namespaceId, entityType, DataModel.DOCUMENT, modifiable );
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
@@ -32,9 +32,6 @@ import org.polypheny.db.catalog.entity.PolyObject;
 import org.polypheny.db.catalog.logistic.Collation;
 import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.type.PolyType;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
-import org.polypheny.db.type.entity.numerical.PolyInteger;
 
 
 @Value
@@ -156,31 +153,6 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
 
     public String getTableName() {
         return Catalog.snapshot().rel().getTable( tableId ).orElseThrow().name;
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[]{
-                PolyString.of( Catalog.DATABASE_NAME ),
-                PolyString.of( getNamespaceName() ),
-                PolyString.of( getTableName() ),
-                PolyString.of( name ),
-                PolyInteger.of( type.getJdbcOrdinal() ),
-                PolyString.of( type.name() ),
-                PolyInteger.of( length ),
-                null,
-                PolyInteger.of( scale ),
-                null,
-                PolyInteger.of( nullable ? 1 : 0 ),
-                PolyString.of( "" ),
-                PolyString.of( defaultValue == null ? null : defaultValue.value.toJson() ),
-                null,
-                null,
-                null,
-                PolyInteger.of( position ),
-                PolyString.of( nullable ? "YES" : "NO" ),
-                PolyString.of( PolyObject.getEnumNameOrNull( collation ) ) };
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
@@ -188,11 +188,11 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
 
     @Override
     public int compareTo( LogicalColumn o ) {
-        int comp = (int) (this.namespaceId - o.namespaceId);
+        int comp = Long.compare(this.namespaceId, o.namespaceId);
         if ( comp == 0 ) {
-            comp = (int) (this.tableId - o.tableId);
+            comp = Long.compare(this.tableId, o.tableId);
             if ( comp == 0 ) {
-                return (int) (this.id - o.id);
+                return Long.compare(this.id, o.id);
             } else {
                 return comp;
             }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
@@ -20,7 +20,6 @@ import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
 import java.io.Serial;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.NonFinal;
@@ -38,7 +37,6 @@ import org.polypheny.db.type.entity.PolyValue;
 import org.polypheny.db.type.entity.numerical.PolyInteger;
 
 
-@EqualsAndHashCode()
 @Value
 @SuperBuilder(toBuilder = true)
 @NonFinal

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
@@ -188,11 +188,11 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
 
     @Override
     public int compareTo( LogicalColumn o ) {
-        int comp = Long.compare(this.namespaceId, o.namespaceId);
+        int comp = Long.compare( this.namespaceId, o.namespaceId );
         if ( comp == 0 ) {
-            comp = Long.compare(this.tableId, o.tableId);
+            comp = Long.compare( this.tableId, o.tableId );
             if ( comp == 0 ) {
-                return Long.compare(this.id, o.id);
+                return Long.compare( this.id, o.id );
             } else {
                 return comp;
             }
@@ -214,7 +214,7 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
      * @param ordinalPosition position
      */
 
-    public record PrimitiveCatalogColumn(String tableCat, String tableSchem, String tableName, String columnName, int dataType, String typeName, Integer columnSize, Integer bufferLength, Integer decimalDigits, Integer numPrecRadix, int nullable, String remarks, String columnDef, Integer sqlDataType, Integer sqlDatetimeSub, Integer charOctetLength, int ordinalPosition, String isNullable, String collation) {
+    public record PrimitiveCatalogColumn( String tableCat, String tableSchem, String tableName, String columnName, int dataType, String typeName, Integer columnSize, Integer bufferLength, Integer decimalDigits, Integer numPrecRadix, int nullable, String remarks, String columnDef, Integer sqlDataType, Integer sqlDatetimeSub, Integer charOctetLength, int ordinalPosition, String isNullable, String collation ) {
 
     }
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalForeignKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalForeignKey.java
@@ -20,20 +20,14 @@ package org.polypheny.db.catalog.entity.logical;
 import com.google.common.collect.ImmutableList;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
-import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.polypheny.db.catalog.Catalog;
-import org.polypheny.db.catalog.entity.PolyObject;
 import org.polypheny.db.catalog.logistic.ForeignKeyOption;
 import org.polypheny.db.catalog.snapshot.Snapshot;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
-import org.polypheny.db.type.entity.numerical.PolyInteger;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -101,70 +95,6 @@ public class LogicalForeignKey extends LogicalKey {
             fieldsNames.add( snapshot.rel().getColumn( fieldId ).orElseThrow().name );
         }
         return fieldsNames;
-    }
-
-
-    // Used for creating ResultSets
-    public List<LogicalForeignKeyField> getCatalogForeignKeyFields() {
-        int i = 1;
-        List<LogicalForeignKeyField> list = new ArrayList<>();
-        List<String> referencedKeyFieldNames = getReferencedKeyFieldNames();
-        for ( String columnName : getFieldNames() ) {
-            list.add( new LogicalForeignKeyField( entityId, name, i, referencedKeyFieldNames.get( i - 1 ), columnName ) );
-            i++;
-        }
-        return list;
-    }
-
-
-    public PolyValue[] getParameterArray( String referencedKeyFieldName, String foreignKeyFieldName, int keySeq ) {
-        return new PolyValue[]{
-                PolyString.of( Catalog.DATABASE_NAME ),
-                PolyString.of( getReferencedKeyNamespaceName() ),
-                PolyString.of( getReferencedKeyEntityName() ),
-                PolyString.of( referencedKeyFieldName ),
-                PolyString.of( Catalog.DATABASE_NAME ),
-                PolyString.of( getSchemaName() ),
-                PolyString.of( getTableName() ),
-                PolyString.of( foreignKeyFieldName ),
-                PolyInteger.of( keySeq ),
-                PolyInteger.of( updateRule.getId() ),
-                PolyInteger.of( deleteRule.getId() ),
-                PolyString.of( name ),
-                null,
-                null };
-    }
-
-
-    // Used for creating ResultSets
-    @RequiredArgsConstructor
-    public static class LogicalForeignKeyField implements PolyObject {
-
-        @Serial
-        private static final long serialVersionUID = 3287177728197412000L;
-
-        private final long entityId;
-        private final String foreignKeyName;
-
-        private final int keySeq;
-        private final String referencedKeyFieldName;
-        private final String foreignKeyFieldName;
-
-
-        @Override
-        public PolyValue[] getParameterArray() {
-            return Catalog.snapshot()
-                    .rel()
-                    .getForeignKey( entityId, foreignKeyName )
-                    .orElseThrow()
-                    .getParameterArray( referencedKeyFieldName, foreignKeyFieldName, keySeq );
-        }
-
-
-        public record PrimitiveCatalogForeignKeyColumn( String pktableCat, String pktableSchem, String pktableName, String pkcolumnName, String fktableCat, String fktableSchem, String fktableName, String fkcolumnName, int keySeq, Integer updateRule, Integer deleteRule, String fkName, String pkName, Integer deferrability ) {
-
-        }
-
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalForeignKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalForeignKey.java
@@ -20,7 +20,6 @@ package org.polypheny.db.catalog.entity.logical;
 import com.google.common.collect.ImmutableList;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -90,11 +89,7 @@ public class LogicalForeignKey extends LogicalKey {
 
     public List<String> getReferencedKeyFieldNames() {
         Snapshot snapshot = Catalog.snapshot();
-        List<String> fieldsNames = new ArrayList<>();
-        for ( long fieldId : referencedKeyFieldIds ) {
-            fieldsNames.add( snapshot.rel().getColumn( fieldId ).orElseThrow().name );
-        }
-        return fieldsNames;
+        return referencedKeyFieldIds.stream().map( fieldId -> snapshot.rel().getColumn( fieldId ).orElseThrow().name ).toList();
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalGraph.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalGraph.java
@@ -29,7 +29,6 @@ import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.catalog.logistic.EntityType;
 import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -55,12 +54,6 @@ public class LogicalGraph extends LogicalEntity {
 
     public LogicalGraph( LogicalGraph graph ) {
         this( graph.id, graph.name, graph.modifiable, graph.caseSensitive );
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyString[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
@@ -126,7 +126,7 @@ public class LogicalIndex implements Serializable {
     // Used for creating ResultSets
 
 
-    public record LogicalIndexField(long indexId, int ordinalPosition, String fieldName, LogicalIndex index) implements PolyObject {
+    public record LogicalIndexField( long indexId, int ordinalPosition, String fieldName, LogicalIndex index ) implements PolyObject {
 
         @Serial
         private static final long serialVersionUID = -5596459769680478780L;
@@ -138,7 +138,7 @@ public class LogicalIndex implements Serializable {
         }
 
 
-        public record PrimitiveCatalogIndexColumn(String tableCat, String tableSchem, String tableName, boolean nonUnique, String indexQualifier, String indexName, int type, int ordinalPosition, String columnName, Integer ascOrDesc, int cardinality, String pages, String filterCondition, int location, int indexType) {
+        public record PrimitiveCatalogIndexColumn( String tableCat, String tableSchem, String tableName, boolean nonUnique, String indexQualifier, String indexName, int type, int ordinalPosition, String columnName, Integer ascOrDesc, int cardinality, String pages, String filterCondition, int location, int indexType ) {
 
         }
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
@@ -24,7 +24,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
@@ -38,7 +37,6 @@ import org.polypheny.db.type.entity.numerical.PolyInteger;
 import org.polypheny.db.type.entity.numerical.PolyLong;
 
 
-@EqualsAndHashCode(callSuper = false)
 @Value
 @SuperBuilder(toBuilder = true)
 public class LogicalIndex implements Serializable {

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
@@ -22,19 +22,10 @@ import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
-import org.polypheny.db.catalog.Catalog;
-import org.polypheny.db.catalog.entity.PolyObject;
 import org.polypheny.db.catalog.logistic.IndexType;
-import org.polypheny.db.type.entity.PolyBoolean;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
-import org.polypheny.db.type.entity.numerical.PolyInteger;
-import org.polypheny.db.type.entity.numerical.PolyLong;
 
 
 @Value
@@ -88,58 +79,6 @@ public class LogicalIndex implements Serializable {
         this.keyId = keyId;
         this.key = key;
         this.physicalName = physicalName;
-    }
-
-
-    // Used for creating ResultSets
-    public List<LogicalIndexField> getIndexFields() {
-        int i = 1;
-        List<LogicalIndexField> list = new ArrayList<>();
-        for ( String fieldName : key.getFieldNames() ) {
-            list.add( new LogicalIndexField( id, i++, fieldName, this ) );
-        }
-        return list;
-    }
-
-
-    public PolyValue[] getParameterArray( int ordinalPosition, String columnName ) {
-        return new PolyValue[]{
-                PolyString.of( Catalog.DATABASE_NAME ),
-                PolyString.of( key.getSchemaName() ),
-                PolyString.of( key.getTableName() ),
-                PolyBoolean.of( !unique ),
-                null,
-                PolyString.of( name ),
-                PolyInteger.of( 0 ),
-                PolyInteger.of( ordinalPosition ),
-                PolyString.of( columnName ),
-                null,
-                PolyInteger.of( -1 ),
-                null,
-                null,
-                PolyLong.of( location ),
-                PolyInteger.of( type.getId() ) };
-    }
-
-    // Used for creating ResultSets
-
-
-    public record LogicalIndexField( long indexId, int ordinalPosition, String fieldName, LogicalIndex index ) implements PolyObject {
-
-        @Serial
-        private static final long serialVersionUID = -5596459769680478780L;
-
-
-        @Override
-        public PolyValue[] getParameterArray() {
-            return index.getParameterArray( ordinalPosition, fieldName );
-        }
-
-
-        public record PrimitiveCatalogIndexColumn( String tableCat, String tableSchem, String tableName, boolean nonUnique, String indexQualifier, String indexName, int type, int ordinalPosition, String columnName, Integer ascOrDesc, int cardinality, String pages, String filterCondition, int location, int indexType ) {
-
-        }
-
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
@@ -28,9 +28,6 @@ import org.jetbrains.annotations.NotNull;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.PolyObject;
 import org.polypheny.db.catalog.snapshot.Snapshot;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
-import org.polypheny.db.type.entity.numerical.PolyLong;
 
 
 @Value
@@ -83,12 +80,6 @@ public abstract class LogicalKey implements PolyObject, Comparable<LogicalKey> {
             columnNames.add( snapshot.rel().getColumn( columnId ).orElseThrow().name );
         }
         return columnNames;
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[]{ PolyLong.of( id ), PolyLong.of( entityId ), PolyString.of( getTableName() ), PolyLong.of( namespaceId ), PolyString.of( getSchemaName() ), null, null };
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeClass;
 import java.io.Serial;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Value;
 import lombok.experimental.NonFinal;
@@ -75,11 +74,7 @@ public abstract class LogicalKey implements PolyObject, Comparable<LogicalKey> {
 
     public List<String> getFieldNames() {
         Snapshot snapshot = Catalog.snapshot();
-        List<String> columnNames = new ArrayList<>();
-        for ( long columnId : fieldIds ) {
-            columnNames.add( snapshot.rel().getColumn( columnId ).orElseThrow().name );
-        }
-        return columnNames;
+        return fieldIds.stream().map( columnId -> snapshot.rel().getColumn( columnId ).orElseThrow().name ).toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
@@ -22,7 +22,6 @@ import io.activej.serializer.annotations.SerializeClass;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import org.jetbrains.annotations.NotNull;
@@ -36,7 +35,6 @@ import org.polypheny.db.type.entity.numerical.PolyLong;
 
 @Value
 @NonFinal
-@EqualsAndHashCode
 @SerializeClass(subclasses = { LogicalGenericKey.class, LogicalPrimaryKey.class, LogicalForeignKey.class })
 public abstract class LogicalKey implements PolyObject, Comparable<LogicalKey> {
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
@@ -96,7 +96,7 @@ public abstract class LogicalKey implements PolyObject, Comparable<LogicalKey> {
 
     @Override
     public int compareTo( @NotNull LogicalKey o ) {
-        return (int) (this.id - o.id);
+        return Long.compare( this.id, o.id );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
@@ -25,11 +25,8 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.With;
 import lombok.experimental.NonFinal;
-import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.PolyObject;
 import org.polypheny.db.catalog.logistic.DataModel;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
 
 
 @With
@@ -60,17 +57,6 @@ public class LogicalNamespace implements PolyObject, Comparable<LogicalNamespace
         this.name = name;
         this.dataModel = dataModel;
         this.caseSensitive = caseSensitive;
-    }
-
-
-    // Used for creating ResultSets
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[]{
-                PolyString.of( name ),
-                PolyString.of( Catalog.DATABASE_NAME ),
-                PolyString.of( Catalog.USER_NAME ),
-                PolyString.of( PolyObject.getEnumNameOrNull( dataModel ) ) };
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
@@ -81,14 +81,14 @@ public class LogicalNamespace implements PolyObject, Comparable<LogicalNamespace
     @Override
     public int compareTo( LogicalNamespace o ) {
         if ( o != null ) {
-            return Long.compare(this.id, o.id);
+            return Long.compare( this.id, o.id );
         }
 
         return -1;
     }
 
 
-    public record PrimitiveCatalogSchema(String tableSchem, String tableCatalog, String owner, String schemaType) {
+    public record PrimitiveCatalogSchema( String tableSchem, String tableCatalog, String owner, String schemaType ) {
 
     }
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
@@ -21,7 +21,6 @@ import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.With;
@@ -33,7 +32,6 @@ import org.polypheny.db.type.entity.PolyString;
 import org.polypheny.db.type.entity.PolyValue;
 
 
-@EqualsAndHashCode(callSuper = false)
 @With
 @Value
 @NonFinal // for testing
@@ -45,10 +43,8 @@ public class LogicalNamespace implements PolyObject, Comparable<LogicalNamespace
     @Serialize
     public long id;
     @Serialize
-    @Getter
     public String name;
     @Serialize
-    @Getter
     @EqualsAndHashCode.Exclude
     public DataModel dataModel;
     @Serialize

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
@@ -81,7 +81,7 @@ public class LogicalNamespace implements PolyObject, Comparable<LogicalNamespace
     @Override
     public int compareTo( LogicalNamespace o ) {
         if ( o != null ) {
-            return (int) (this.id - o.id);
+            return Long.compare(this.id, o.id);
         }
 
         return -1;

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalPrimaryKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalPrimaryKey.java
@@ -19,18 +19,9 @@ package org.polypheny.db.catalog.entity.logical;
 
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
-import java.io.Serial;
-import java.util.LinkedList;
-import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import org.polypheny.db.catalog.Catalog;
-import org.polypheny.db.catalog.entity.PolyObject;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
-import org.polypheny.db.type.entity.numerical.PolyInteger;
 
 
 @Value
@@ -50,54 +41,6 @@ public class LogicalPrimaryKey extends LogicalKey {
                 EnforcementTime.ON_QUERY );
 
         this.key = key;
-    }
-
-
-    // Used for creating ResultSets
-    public List<LogicalPrimaryKeyField> getCatalogPrimaryKeyColumns() {
-        int i = 1;
-        List<LogicalPrimaryKeyField> list = new LinkedList<>();
-        for ( String columnName : getFieldNames() ) {
-            list.add( new LogicalPrimaryKeyField( id, i++, columnName ) );
-        }
-        return list;
-    }
-
-
-    public PolyValue[] getParameterArray( String columnName, int keySeq ) {
-        return new PolyValue[]{
-                PolyString.of( Catalog.DATABASE_NAME ),
-                PolyString.of( getSchemaName() ),
-                PolyString.of( getTableName() ),
-                PolyString.of( columnName ),
-                PolyInteger.of( keySeq ), null };
-    }
-
-
-    // Used for creating ResultSets
-    @RequiredArgsConstructor
-    public static class LogicalPrimaryKeyField implements PolyObject {
-
-        @Serial
-        private static final long serialVersionUID = -2669773639977732201L;
-
-        private final long pkId;
-
-        private final int keySeq;
-
-        private final String fieldName;
-
-
-        @Override
-        public PolyValue[] getParameterArray() {
-            return Catalog.snapshot().rel().getPrimaryKey( pkId ).orElseThrow().getParameterArray( fieldName, keySeq );
-        }
-
-
-        public record PrimitiveCatalogPrimaryKeyColumn( String tableCat, String tableSchem, String tableName, String columnName, int keySeq, String pkName ) {
-
-        }
-
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalPrimaryKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalPrimaryKey.java
@@ -94,7 +94,7 @@ public class LogicalPrimaryKey extends LogicalKey {
         }
 
 
-        public record PrimitiveCatalogPrimaryKeyColumn(String tableCat, String tableSchem, String tableName, String columnName, int keySeq, String pkName) {
+        public record PrimitiveCatalogPrimaryKeyColumn( String tableCat, String tableSchem, String tableName, String columnName, int keySeq, String pkName ) {
 
         }
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
@@ -91,7 +91,7 @@ public class LogicalTable extends LogicalEntity {
 
 
     public List<ColumnStrategy> getColumnStrategies() {
-        return getColumns().stream().map( c -> c.nullable ? ColumnStrategy.NULLABLE : ColumnStrategy.NOT_NULLABLE ).collect( Collectors.toList() );
+        return getColumns().stream().map( c -> c.nullable ? ColumnStrategy.NULLABLE : ColumnStrategy.NOT_NULLABLE ).toList();
     }
 
 
@@ -101,12 +101,12 @@ public class LogicalTable extends LogicalEntity {
 
 
     public List<Long> getColumnIds() {
-        return getColumns().stream().sorted( Comparator.comparingInt( a -> a.position ) ).map( c -> c.id ).collect( Collectors.toList() );
+        return getColumns().stream().sorted( Comparator.comparingInt( a -> a.position ) ).map( c -> c.id ).toList();
     }
 
 
     public List<String> getColumnNames() {
-        return getColumns().stream().map( c -> c.name ).collect( Collectors.toList() );
+        return getColumns().stream().map( c -> c.name ).toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
@@ -23,7 +23,6 @@ import io.activej.serializer.annotations.SerializeNullable;
 import java.io.Serial;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
@@ -40,8 +40,6 @@ import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.catalog.logistic.EntityType;
 import org.polypheny.db.schema.ColumnStrategy;
-import org.polypheny.db.type.entity.PolyString;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = false)
 @SuperBuilder(toBuilder = true)
@@ -70,26 +68,6 @@ public class LogicalTable extends LogicalEntity {
         if ( type == EntityType.ENTITY && !modifiable ) {
             throw new GenericRuntimeException( "Tables of table type TABLE must be modifiable!" );
         }
-    }
-
-
-    // Used for creating ResultSets
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[]{
-                PolyString.of( Catalog.DATABASE_NAME ),
-                PolyString.of( getNamespaceName() ),
-                PolyString.of( name ),
-                PolyString.of( entityType.name() ),
-                PolyString.of( "" ),
-                null,
-                null,
-                null,
-                null,
-                null,
-                PolyString.of( Catalog.USER_NAME )
-
-        };
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalCollection.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalCollection.java
@@ -26,7 +26,6 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.logistic.DataModel;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -43,12 +42,6 @@ public class PhysicalCollection extends PhysicalEntity {
             @Deserialize("namespaceName") String namespaceName,
             @Deserialize("adapterId") long adapterId ) {
         super( id, allocationId, logicalId, name, namespaceId, namespaceName, List.of(), DataModel.DOCUMENT, adapterId );
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalField.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalField.java
@@ -26,7 +26,6 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.polypheny.db.catalog.entity.Entity;
 import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.catalog.logistic.EntityType;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -62,12 +61,6 @@ public abstract class PhysicalField extends Entity {
         this.allocId = allocId;
         this.adapterId = adapterId;
         this.logicalName = logicalName;
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalGraph.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalGraph.java
@@ -25,7 +25,6 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.logistic.DataModel;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -39,12 +38,6 @@ public class PhysicalGraph extends PhysicalEntity {
             @Deserialize("name") String name,
             @Deserialize("adapterId") long adapterId ) {
         super( id, allocationId, logicalId, name, id, name, List.of(), DataModel.GRAPH, adapterId ); // for graph both name and namespaceName are the same
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalTable.java
@@ -35,7 +35,6 @@ import org.polypheny.db.algebra.type.AlgProtoDataType;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.catalogs.AdapterCatalog;
 import org.polypheny.db.catalog.logistic.DataModel;
-import org.polypheny.db.type.entity.PolyValue;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -78,12 +77,6 @@ public class PhysicalTable extends PhysicalEntity {
         }
 
         return AlgDataTypeImpl.proto( fieldInfo.build() );
-    }
-
-
-    @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalTable.java
@@ -21,7 +21,6 @@ import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.experimental.NonFinal;

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalTable.java
@@ -58,7 +58,7 @@ public class PhysicalTable extends PhysicalEntity {
             @Deserialize("uniqueFieldIds") List<Long> uniqueFieldIds,
             @Deserialize("adapterId") long adapterId ) {
         super( id, allocationId, logicalId, name, namespaceId, namespaceName, uniqueFieldIds, DataModel.RELATIONAL, adapterId );
-        this.columns = ImmutableList.copyOf( columns.stream().sorted( Comparator.comparingInt( a -> a.position ) ).collect( Collectors.toList() ) );
+        this.columns = ImmutableList.copyOf( columns.stream().sorted( Comparator.comparingInt( a -> a.position ) ).toList() );
     }
 
 
@@ -87,12 +87,12 @@ public class PhysicalTable extends PhysicalEntity {
 
 
     public List<String> getColumnNames() {
-        return columns.stream().map( c -> c.name ).collect( Collectors.toList() );
+        return columns.stream().map( c -> c.name ).toList();
     }
 
 
     public List<Long> getColumnIds() {
-        return columns.stream().map( c -> c.id ).collect( Collectors.toList() );
+        return columns.stream().map( c -> c.id ).toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/exceptions/CatalogRuntimeException.java
+++ b/core/src/main/java/org/polypheny/db/catalog/exceptions/CatalogRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The Polypheny Project
+ * Copyright 2019-2024 The Polypheny Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/polypheny/db/catalog/exceptions/CatalogRuntimeException.java
+++ b/core/src/main/java/org/polypheny/db/catalog/exceptions/CatalogRuntimeException.java
@@ -41,7 +41,7 @@ public class CatalogRuntimeException extends RuntimeException {
      * Constructs a new exception with the specified detail message and cause.  <p>Note that the detail message associated with {@code cause} is <i>not</i> automatically incorporated in this exception's detail message.
      *
      * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
-     * @param cause   the cause (which is saved for later retrieval by the {@link #getCause()} method).  (A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or unknown.)
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).  (A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or unknown.)
      * @since 1.4
      */
     protected CatalogRuntimeException( String message, Throwable cause ) {

--- a/core/src/main/java/org/polypheny/db/catalog/impl/AdapterRestore.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/AdapterRestore.java
@@ -48,9 +48,9 @@ public record AdapterRestore(
         physicals.forEach( ( allocId, physicals ) -> {
             AllocationEntity entity = allocations.get( allocId );
             switch ( entity.dataModel ) {
-                case RELATIONAL -> adapter.restoreTable( entity.unwrap( AllocationTable.class ).orElseThrow(), physicals, context );
-                case DOCUMENT -> adapter.restoreCollection( entity.unwrap( AllocationCollection.class ).orElseThrow(), physicals, context );
-                case GRAPH -> adapter.restoreGraph( entity.unwrap( AllocationGraph.class ).orElseThrow(), physicals, context );
+                case RELATIONAL -> adapter.restoreTable( entity.unwrapOrThrow( AllocationTable.class ), physicals, context );
+                case DOCUMENT -> adapter.restoreCollection( entity.unwrapOrThrow( AllocationCollection.class ), physicals, context );
+                case GRAPH -> adapter.restoreGraph( entity.unwrapOrThrow( AllocationGraph.class ), physicals, context );
             }
 
         } );

--- a/core/src/main/java/org/polypheny/db/catalog/impl/AdapterRestore.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/AdapterRestore.java
@@ -32,7 +32,7 @@ import org.polypheny.db.prepare.Context;
 public record AdapterRestore(
         long adapterId,
         Map<Long, List<PhysicalEntity>> physicals,
-        Map<Long, AllocationEntity> allocations) {
+        Map<Long, AllocationEntity> allocations ) {
 
     public AdapterRestore(
             long adapterId,

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -342,8 +342,8 @@ public class PolyCatalog extends Catalog implements PolySerializable {
 
 
     @Override
-    public <S extends AdapterCatalog> Optional<S> getAdapterCatalog( long id ) {
-        return Optional.ofNullable( (S) adapterCatalogs.get( id ) );
+    public Optional<AdapterCatalog> getAdapterCatalog( long id ) {
+        return Optional.ofNullable( adapterCatalogs.get( id ) );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -147,7 +147,6 @@ public class PolyCatalog extends Catalog implements PolySerializable {
                 Map.of(),
                 Map.of(),
                 IdBuilder.getInstance() );
-
     }
 
 
@@ -426,6 +425,8 @@ public class PolyCatalog extends Catalog implements PolySerializable {
 
     @Override
     public void dropAdapter( long id ) {
+        adapterCatalogs.remove( id );
+        adapterRestore.remove( id );
         adapters.remove( id );
         change();
     }

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocDocCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocDocCatalog.java
@@ -20,7 +20,6 @@ import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.beans.PropertyChangeSupport;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Value;
@@ -40,6 +39,8 @@ import org.polypheny.db.type.PolySerializable;
 @Value
 public class PolyAllocDocCatalog implements PolySerializable, AllocationDocumentCatalog {
 
+    public BinarySerializer<PolyAllocDocCatalog> serializer = PolySerializable.buildSerializer( PolyAllocDocCatalog.class );
+
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
@@ -54,9 +55,11 @@ public class PolyAllocDocCatalog implements PolySerializable, AllocationDocument
     @Serialize
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
+    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
+
 
     public PolyAllocDocCatalog( LogicalNamespace namespace ) {
-        this( namespace, new HashMap<>(), new HashMap<>(), new HashMap<>() );
+        this( namespace, Map.of(), Map.of(), Map.of() );
     }
 
 
@@ -73,15 +76,9 @@ public class PolyAllocDocCatalog implements PolySerializable, AllocationDocument
     }
 
 
-    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
-
-
     public void change() {
         listeners.firePropertyChange( "change", null, null );
     }
-
-
-    public BinarySerializer<PolyAllocDocCatalog> serializer = PolySerializable.buildSerializer( PolyAllocDocCatalog.class );
 
 
     @Override

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocDocCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocDocCatalog.java
@@ -23,7 +23,6 @@ import java.beans.PropertyChangeSupport;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Getter;
 import lombok.Value;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.IdBuilder;
@@ -43,19 +42,15 @@ public class PolyAllocDocCatalog implements PolySerializable, AllocationDocument
 
     IdBuilder idBuilder = IdBuilder.getInstance();
 
-    @Getter
     @Serialize
     public LogicalNamespace namespace;
 
-    @Getter
     @Serialize
     public ConcurrentHashMap<Long, AllocationCollection> collections;
 
-    @Getter
     @Serialize
     public ConcurrentHashMap<Long, AllocationPlacement> placements;
 
-    @Getter
     @Serialize
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
@@ -86,7 +81,6 @@ public class PolyAllocDocCatalog implements PolySerializable, AllocationDocument
     }
 
 
-    @Getter
     public BinarySerializer<PolyAllocDocCatalog> serializer = PolySerializable.buildSerializer( PolyAllocDocCatalog.class );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
@@ -20,7 +20,6 @@ import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.beans.PropertyChangeSupport;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
@@ -41,11 +40,12 @@ import org.polypheny.db.type.PolySerializable;
 @Value
 public class PolyAllocGraphCatalog implements PolySerializable, AllocationGraphCatalog {
 
+    public BinarySerializer<PolyAllocGraphCatalog> serializer = PolySerializable.buildSerializer( PolyAllocGraphCatalog.class );
+
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
     public LogicalNamespace namespace;
-    public BinarySerializer<PolyAllocGraphCatalog> serializer = PolySerializable.buildSerializer( PolyAllocGraphCatalog.class );
 
     @Serialize
     public ConcurrentHashMap<Long, AllocationGraph> graphs;
@@ -56,9 +56,11 @@ public class PolyAllocGraphCatalog implements PolySerializable, AllocationGraphC
     @Serialize
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
+    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
+
 
     public PolyAllocGraphCatalog( LogicalNamespace namespace ) {
-        this( namespace, new HashMap<>(), new HashMap<>(), new HashMap<>() );
+        this( namespace, Map.of(), Map.of(), Map.of() );
     }
 
 
@@ -73,9 +75,6 @@ public class PolyAllocGraphCatalog implements PolySerializable, AllocationGraphC
         this.partitions = new ConcurrentHashMap<>( partitions );
         listeners.addPropertyChangeListener( Catalog.getInstance().getChangeListener() );
     }
-
-
-    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 
     public void change() {

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
@@ -43,21 +43,16 @@ public class PolyAllocGraphCatalog implements PolySerializable, AllocationGraphC
 
     IdBuilder idBuilder = IdBuilder.getInstance();
 
-    @Getter
     @Serialize
     public LogicalNamespace namespace;
-    @Getter
     public BinarySerializer<PolyAllocGraphCatalog> serializer = PolySerializable.buildSerializer( PolyAllocGraphCatalog.class );
 
-    @Getter
     @Serialize
     public ConcurrentHashMap<Long, AllocationGraph> graphs;
 
-    @Getter
     @Serialize
     public ConcurrentHashMap<Long, AllocationPlacement> placements;
 
-    @Getter
     @Serialize
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
@@ -22,7 +22,6 @@ import io.activej.serializer.annotations.Serialize;
 import java.beans.PropertyChangeSupport;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Getter;
 import lombok.Value;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.IdBuilder;

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
-import lombok.Getter;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.polypheny.db.catalog.Catalog;
@@ -51,35 +50,27 @@ public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySer
 
     IdBuilder idBuilder = IdBuilder.getInstance();
 
-    @Getter
     @Serialize
     public LogicalNamespace namespace;
 
-    @Getter
     public BinarySerializer<PolyAllocRelCatalog> serializer = PolySerializable.buildSerializer( PolyAllocRelCatalog.class );
 
     @Serialize
-    @Getter
     public ConcurrentHashMap<Long, AllocationTable> tables;
 
     @Serialize
-    @Getter
     public ConcurrentHashMap<Pair<Long, Long>, AllocationColumn> columns; //placementId, columnId
 
     @Serialize
-    @Getter
     public ConcurrentHashMap<Long, PartitionProperty> properties;
 
     @Serialize
-    @Getter
     public ConcurrentHashMap<Long, AllocationPartitionGroup> partitionGroups;
 
     @Serialize
-    @Getter
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
     @Serialize
-    @Getter
     public ConcurrentHashMap<Long, AllocationPlacement> placements;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
@@ -225,7 +225,6 @@ public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySer
     }
 
 
-
     @Override
     public void updatePartition( long partitionId, Long partitionGroupId ) {
 
@@ -247,6 +246,7 @@ public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySer
         tables.remove( allocId );
         change();
     }
+
 
     @Override
     public AllocationPlacement addPlacement( long logicalEntityId, long namespaceId, long adapterId ) {

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
@@ -20,7 +20,6 @@ import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.beans.PropertyChangeSupport;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,13 +46,12 @@ import org.polypheny.db.util.Pair;
 @Value
 public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySerializable {
 
+    public BinarySerializer<PolyAllocRelCatalog> serializer = PolySerializable.buildSerializer( PolyAllocRelCatalog.class );
 
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
     public LogicalNamespace namespace;
-
-    public BinarySerializer<PolyAllocRelCatalog> serializer = PolySerializable.buildSerializer( PolyAllocRelCatalog.class );
 
     @Serialize
     public ConcurrentHashMap<Long, AllocationTable> tables;
@@ -73,16 +71,11 @@ public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySer
     @Serialize
     public ConcurrentHashMap<Long, AllocationPlacement> placements;
 
+    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
+
 
     public PolyAllocRelCatalog( LogicalNamespace namespace ) {
-        this(
-                namespace,
-                new HashMap<>(),
-                new HashMap<>(),
-                new HashMap<>(),
-                new HashMap<>(),
-                new HashMap<>(),
-                new HashMap<>() );
+        this( namespace, Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of() );
     }
 
 
@@ -103,9 +96,6 @@ public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySer
         this.placements = new ConcurrentHashMap<>( placements );
         listeners.addPropertyChangeListener( Catalog.getInstance().getChangeListener() );
     }
-
-
-    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 
     public void change() {

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
@@ -22,7 +22,6 @@ import io.activej.serializer.annotations.Serialize;
 import java.beans.PropertyChangeSupport;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
 import org.polypheny.db.catalog.Catalog;
@@ -35,7 +34,6 @@ import org.polypheny.db.catalog.logistic.EntityType;
 import org.polypheny.db.catalog.util.CatalogEvent;
 import org.polypheny.db.type.PolySerializable;
 
-@Getter
 @Value
 @SuperBuilder(toBuilder = true)
 public class DocumentCatalog implements PolySerializable, LogicalDocumentCatalog {
@@ -44,9 +42,7 @@ public class DocumentCatalog implements PolySerializable, LogicalDocumentCatalog
 
     IdBuilder idBuilder = IdBuilder.getInstance();
     @Serialize
-    @Getter
     public Map<Long, LogicalCollection> collections;
-    @Getter
     @Serialize
     public LogicalNamespace logicalNamespace;
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
@@ -41,14 +41,18 @@ public class DocumentCatalog implements PolySerializable, LogicalDocumentCatalog
     public BinarySerializer<DocumentCatalog> serializer = PolySerializable.buildSerializer( DocumentCatalog.class );
 
     IdBuilder idBuilder = IdBuilder.getInstance();
-    @Serialize
-    public Map<Long, LogicalCollection> collections;
+
     @Serialize
     public LogicalNamespace logicalNamespace;
 
+    @Serialize
+    public Map<Long, LogicalCollection> collections;
+
+    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
+
 
     public DocumentCatalog( LogicalNamespace logicalNamespace ) {
-        this( logicalNamespace, new ConcurrentHashMap<>() );
+        this( logicalNamespace, Map.of() );
     }
 
 
@@ -60,9 +64,6 @@ public class DocumentCatalog implements PolySerializable, LogicalDocumentCatalog
 
         listeners.addPropertyChangeListener( Catalog.getInstance().getChangeListener() );
     }
-
-
-    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 
     public void change( CatalogEvent event, Object oldValue, Object newValue ) {

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
@@ -39,16 +39,20 @@ public class GraphCatalog implements PolySerializable, LogicalGraphCatalog {
 
     public BinarySerializer<GraphCatalog> serializer = PolySerializable.buildSerializer( GraphCatalog.class );
 
+    IdBuilder idBuilder = IdBuilder.getInstance();
+
     @Serialize
     public LogicalNamespace logicalNamespace;
-    public IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
     public ConcurrentHashMap<Long, LogicalGraph> graphs;
 
 
+    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
+
+
     public GraphCatalog( LogicalNamespace logicalNamespace ) {
-        this( logicalNamespace, new ConcurrentHashMap<>() );
+        this( logicalNamespace, Map.of() );
     }
 
 
@@ -62,9 +66,6 @@ public class GraphCatalog implements PolySerializable, LogicalGraphCatalog {
         addGraph( logicalNamespace.id, logicalNamespace.name, true );
         listeners.addPropertyChangeListener( Catalog.getInstance().getChangeListener() );
     }
-
-
-    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 
     public void change( CatalogEvent event, Object oldValue, Object newValue ) {

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
@@ -22,7 +22,6 @@ import io.activej.serializer.annotations.Serialize;
 import java.beans.PropertyChangeSupport;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
 import org.polypheny.db.catalog.Catalog;
@@ -38,14 +37,12 @@ import org.polypheny.db.type.PolySerializable;
 @SuperBuilder(toBuilder = true)
 public class GraphCatalog implements PolySerializable, LogicalGraphCatalog {
 
-    @Getter
     public BinarySerializer<GraphCatalog> serializer = PolySerializable.buildSerializer( GraphCatalog.class );
-    @Getter
+
     @Serialize
     public LogicalNamespace logicalNamespace;
     public IdBuilder idBuilder = IdBuilder.getInstance();
 
-    @Getter
     @Serialize
     public ConcurrentHashMap<Long, LogicalGraph> graphs;
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -22,7 +22,6 @@ import io.activej.serializer.annotations.Serialize;
 import java.beans.PropertyChangeSupport;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +71,10 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
 
     public BinarySerializer<RelationalCatalog> serializer = PolySerializable.buildSerializer( RelationalCatalog.class );
 
-    public IdBuilder idBuilder = IdBuilder.getInstance();
+    IdBuilder idBuilder = IdBuilder.getInstance();
+
+    @Serialize
+    public LogicalNamespace logicalNamespace;
 
     @Serialize
     public Map<Long, LogicalTable> tables;
@@ -82,8 +84,6 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
 
     public Map<Long, AlgNode> nodes;
 
-    @Serialize
-    public LogicalNamespace logicalNamespace;
 
     @Serialize
     public Map<Long, LogicalIndex> indexes;
@@ -92,12 +92,17 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
     @Serialize
     public Map<Long, LogicalKey> keys;
 
-
     @Serialize
     public Map<Long, LogicalConstraint> constraints;
 
-
     List<Long> tablesFlaggedForDeletion = new ArrayList<>();
+
+    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
+
+
+    public RelationalCatalog( LogicalNamespace namespace ) {
+        this( namespace, Map.of(), Map.of(), Map.of(), Map.of(), Map.of() );
+    }
 
 
     public RelationalCatalog(
@@ -119,16 +124,8 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
     }
 
 
-    PropertyChangeSupport listeners = new PropertyChangeSupport( this );
-
-
     public void change( CatalogEvent event, Object oldValue, Object newValue ) {
         listeners.firePropertyChange( event.name(), oldValue, newValue );
-    }
-
-
-    public RelationalCatalog( LogicalNamespace namespace ) {
-        this( namespace, new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>() );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
@@ -95,7 +96,7 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
     @Serialize
     public Map<Long, LogicalConstraint> constraints;
 
-    List<Long> tablesFlaggedForDeletion = new ArrayList<>();
+    Set<Long> tablesFlaggedForDeletion = new HashSet<>();
 
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
@@ -569,9 +570,9 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
 
     @Override
     public void flagTableForDeletion( long tableId, boolean flag ) {
-        if ( flag && !tablesFlaggedForDeletion.contains( tableId ) ) {
+        if (flag) {
             tablesFlaggedForDeletion.add( tableId );
-        } else if ( !flag && tablesFlaggedForDeletion.contains( tableId ) ) {
+        } else {
             tablesFlaggedForDeletion.remove( tableId );
         }
     }

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -21,7 +21,6 @@ import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.beans.PropertyChangeSupport;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -570,7 +569,7 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
 
     @Override
     public void flagTableForDeletion( long tableId, boolean flag ) {
-        if (flag) {
+        if ( flag ) {
             tablesFlaggedForDeletion.add( tableId );
         } else {
             tablesFlaggedForDeletion.remove( tableId );

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
 import org.jetbrains.annotations.Nullable;
@@ -71,38 +70,30 @@ import org.polypheny.db.type.entity.PolyValue;
 @SuperBuilder(toBuilder = true)
 public class RelationalCatalog implements PolySerializable, LogicalRelationalCatalog {
 
-    @Getter
     public BinarySerializer<RelationalCatalog> serializer = PolySerializable.buildSerializer( RelationalCatalog.class );
 
     public IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
-    @Getter
     public Map<Long, LogicalTable> tables;
 
     @Serialize
-    @Getter
     public Map<Long, LogicalColumn> columns;
 
-    @Getter
     public Map<Long, AlgNode> nodes;
 
     @Serialize
-    @Getter
     public LogicalNamespace logicalNamespace;
 
     @Serialize
-    @Getter
     public Map<Long, LogicalIndex> indexes;
 
     // while keys "belong" to a specific table, they can reference other namespaces, atm they are place here, might change later
     @Serialize
-    @Getter
     public Map<Long, LogicalKey> keys;
 
 
     @Serialize
-    @Getter
     public Map<Long, LogicalConstraint> constraints;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -420,23 +420,14 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
     }
 
 
-    private int getKeyUniqueCount( long keyId ) {
-        int count = 0;
+    private long getKeyUniqueCount( long keyId ) {
+        long count = 0;
         if ( Catalog.snapshot().rel().getPrimaryKey( keyId ).isPresent() ) {
             count++;
         }
 
-        for ( LogicalConstraint constraint : constraints.values().stream().filter( c -> c.keyId == keyId ).toList() ) {
-            if ( constraint.type == ConstraintType.UNIQUE ) {
-                count++;
-            }
-        }
-
-        for ( LogicalIndex index : indexes.values().stream().filter( i -> i.keyId == keyId ).toList() ) {
-            if ( index.unique ) {
-                count++;
-            }
-        }
+        count += constraints.values().stream().filter( c -> c.keyId == keyId && c.type == ConstraintType.UNIQUE ).count();
+        count += indexes.values().stream().filter( i -> i.keyId == keyId && i.unique ).count();
 
         return count;
     }

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -196,9 +196,7 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
 
     @Override
     public void deleteTable( long tableId ) {
-        for ( Long columnId : tables.get( tableId ).getColumnIds() ) {
-            columns.remove( columnId );
-        }
+        tables.get( tableId ).getColumnIds().forEach( columns::remove );
         tables.remove( tableId );
         change( CatalogEvent.LOGICAL_REL_ENTITY_DROPPED, tableId, null );
     }

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/Collation.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/Collation.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.logistic;
 
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.NonNull;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
@@ -35,12 +36,7 @@ public enum Collation {
 
 
     public static Collation getById( int id ) {
-        for ( Collation c : values() ) {
-            if ( c.id == id ) {
-                return c;
-            }
-        }
-        throw new GenericRuntimeException( "Unknown Collation with id: " + id );
+        return Arrays.stream( values() ).filter( c -> c.id == id ).findAny().orElseThrow( () -> new GenericRuntimeException( "Unknown Collation with id: " + id ) );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/ConstraintType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/ConstraintType.java
@@ -35,16 +35,6 @@ public enum ConstraintType {
     }
 
 
-    public static ConstraintType getById( int id ) {
-        for ( ConstraintType e : values() ) {
-            if ( e.id == id ) {
-                return e;
-            }
-        }
-        throw new GenericRuntimeException( "Unknown ConstraintType with id: " + id );
-    }
-
-
     public static ConstraintType parse( @NonNull String str ) {
         if ( str.equalsIgnoreCase( "UNIQUE" ) ) {
             return ConstraintType.UNIQUE;

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/DataModel.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/DataModel.java
@@ -40,26 +40,6 @@ public enum DataModel {
     }
 
 
-    public static DataModel getById( final int id ) {
-        for ( DataModel t : values() ) {
-            if ( t.id == id ) {
-                return t;
-            }
-        }
-        throw new RuntimeException( "Unknown NamespaceType with id: " + id );
-    }
-
-
-    public static DataModel getByName( final String name ) {
-        for ( DataModel t : values() ) {
-            if ( t.name().equalsIgnoreCase( name ) ) {
-                return t;
-            }
-        }
-        throw new RuntimeException( "Unknown NamespaceType with name: " + name );
-    }
-
-
     public ModelTrait getModelTrait() {
         if ( this == DataModel.RELATIONAL ) {
             return ModelTrait.RELATIONAL;

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/DataModel.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/DataModel.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.logistic;
 
 import lombok.Getter;
+import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.schema.trait.ModelTrait;
 
 @Getter
@@ -48,6 +49,6 @@ public enum DataModel {
         } else if ( this == DataModel.GRAPH ) {
             return ModelTrait.GRAPH;
         }
-        throw new RuntimeException( "Not found a suitable NamespaceType." );
+        throw new GenericRuntimeException( "Not found a suitable NamespaceType." );
     }
 }

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/DataPlacementRole.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/DataPlacementRole.java
@@ -16,6 +16,11 @@
 
 package org.polypheny.db.catalog.logistic;
 
+import java.util.Arrays;
+import lombok.Getter;
+import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
+
+@Getter
 public enum DataPlacementRole {
     UP_TO_DATE( 0 ),
     REFRESHABLE( 1 );
@@ -28,28 +33,13 @@ public enum DataPlacementRole {
     }
 
 
-    public int getId() {
-        return id;
-    }
-
-
     public static DataPlacementRole from( final int id ) {
-        for ( DataPlacementRole t : values() ) {
-            if ( t.id == id ) {
-                return t;
-            }
-        }
-        throw new RuntimeException( "Unknown DataPlacementRole with id: " + id );
+        return Arrays.stream( values() ).filter( t -> t.id == id ).findAny().orElseThrow( () -> new GenericRuntimeException( "Unknown DataPlacementRole with id: " + id ) );
     }
 
 
     public static DataPlacementRole from( final String name ) {
-        for ( DataPlacementRole t : values() ) {
-            if ( t.name().equalsIgnoreCase( name ) ) {
-                return t;
-            }
-        }
-        throw new RuntimeException( "Unknown PartitionType with name: " + name );
+        return Arrays.stream( values() ).filter( t -> t.name().equalsIgnoreCase( name ) ).findAny().orElseThrow( () -> new GenericRuntimeException( "Unknown PartitionType with name: " + name ) );
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/EntityType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/EntityType.java
@@ -18,7 +18,6 @@ package org.polypheny.db.catalog.logistic;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.type.entity.PolyString;
 import org.polypheny.db.type.entity.PolyValue;
 

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/EntityType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/EntityType.java
@@ -38,26 +38,6 @@ public enum EntityType {
     }
 
 
-    public static EntityType getById( final int id ) {
-        for ( EntityType t : values() ) {
-            if ( t.id == id ) {
-                return t;
-            }
-        }
-        throw new GenericRuntimeException( "Unknown EntityType with id: " + id );
-    }
-
-
-    public static EntityType getByName( final String name ) {
-        for ( EntityType t : values() ) {
-            if ( t.name().equalsIgnoreCase( name ) ) {
-                return t;
-            }
-        }
-        throw new GenericRuntimeException( "Unknown EntityType with name: " + name );
-    }
-
-
     // Used for creating ResultSets
     public PolyValue[] getParameterArray() {
         return new PolyValue[]{ PolyString.of( name() ) };

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/ForeignKeyOption.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/ForeignKeyOption.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.logistic;
 
 import lombok.NonNull;
+import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 
 public enum ForeignKeyOption {
     NONE( -1 ),
@@ -39,16 +40,6 @@ public enum ForeignKeyOption {
     }
 
 
-    public static ForeignKeyOption getById( int id ) {
-        for ( ForeignKeyOption e : values() ) {
-            if ( e.id == id ) {
-                return e;
-            }
-        }
-        throw new RuntimeException( "Unknown ForeignKeyOption with id: " + id );
-    }
-
-
     public static ForeignKeyOption parse( @NonNull String str ) {
         if ( str.equalsIgnoreCase( "NONE" ) ) {
             return ForeignKeyOption.NONE;
@@ -61,6 +52,6 @@ public enum ForeignKeyOption {
         } else if ( str.equalsIgnoreCase( "SET DEFAULT" ) ) {
             return ForeignKeyOption.SET_DEFAULT;
         }*/
-        throw new RuntimeException( "Unknown ForeignKeyOption with name: " + str );
+        throw new GenericRuntimeException( "Unknown ForeignKeyOption with name: " + str );
     }
 }

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/IndexType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/IndexType.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.logistic;
 
 import lombok.NonNull;
+import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 
 public enum IndexType {
     MANUAL( 1 ),
@@ -41,6 +42,6 @@ public enum IndexType {
         } else if ( str.equalsIgnoreCase( "AUTOMATIC" ) ) {
             return IndexType.AUTOMATIC;
         }
-        throw new RuntimeException( "Unknown indexType with name: " + str );
+        throw new GenericRuntimeException( "Unknown indexType with name: " + str );
     }
 }

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/IndexType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/IndexType.java
@@ -35,16 +35,6 @@ public enum IndexType {
     }
 
 
-    public static IndexType getById( int id ) {
-        for ( IndexType e : values() ) {
-            if ( e.id == id ) {
-                return e;
-            }
-        }
-        throw new RuntimeException( "Unknown indexType with id: " + id );
-    }
-
-
     public static IndexType parse( @NonNull String str ) {
         if ( str.equalsIgnoreCase( "MANUAL" ) ) {
             return IndexType.MANUAL;

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/NameGenerator.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/NameGenerator.java
@@ -41,4 +41,5 @@ public class NameGenerator {
     public static String generateConstraintName() {
         return RuntimeConfig.GENERATED_NAME_PREFIX.getString() + "_c_" + constraintCounter.getAndIncrement();
     }
+
 }

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/PartitionType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/PartitionType.java
@@ -35,16 +35,6 @@ public enum PartitionType {
     }
 
 
-    public static PartitionType getById( final int id ) {
-        for ( PartitionType t : values() ) {
-            if ( t.id == id ) {
-                return t;
-            }
-        }
-        throw new RuntimeException( "Unknown PartitionType with id: " + id );
-    }
-
-
     public static PartitionType getByName( final String name ) {
         for ( PartitionType t : values() ) {
             if ( t.name().equalsIgnoreCase( name ) ) {

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/PartitionType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/PartitionType.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.logistic;
 
+import java.util.Arrays;
 import lombok.Getter;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 
@@ -37,12 +38,7 @@ public enum PartitionType {
 
 
     public static PartitionType getByName( final String name ) {
-        for ( PartitionType t : values() ) {
-            if ( t.name().equalsIgnoreCase( name ) ) {
-                return t;
-            }
-        }
-        throw new GenericRuntimeException( "Unknown PartitionType with name: " + name );
+        return Arrays.stream( values() ).filter( t -> t.name().equalsIgnoreCase( name ) ).findAny().orElseThrow( () -> new GenericRuntimeException( "Unknown PartitionType with name: " + name ) );
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/PartitionType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/PartitionType.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.logistic;
 
 import lombok.Getter;
+import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 
 @Getter
 public enum PartitionType {
@@ -41,7 +42,7 @@ public enum PartitionType {
                 return t;
             }
         }
-        throw new RuntimeException( "Unknown PartitionType with name: " + name );
+        throw new GenericRuntimeException( "Unknown PartitionType with name: " + name );
     }
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/PlacementType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/PlacementType.java
@@ -36,16 +36,6 @@ public enum PlacementType {
     }
 
 
-    public static PlacementType getById( int id ) {
-        for ( PlacementType e : values() ) {
-            if ( e.id == id ) {
-                return e;
-            }
-        }
-        throw new RuntimeException( "Unknown PlacementType with id: " + id );
-    }
-
-
     public static PlacementType parse( @NonNull String str ) {
         if ( str.equalsIgnoreCase( "MANUAL" ) ) {
             return PlacementType.MANUAL;

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/PlacementType.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/PlacementType.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.logistic;
 
 import lombok.NonNull;
+import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 
 public enum PlacementType {
     MANUAL( 1 ),
@@ -42,7 +43,7 @@ public enum PlacementType {
         } else if ( str.equalsIgnoreCase( "AUTOMATIC" ) ) {
             return PlacementType.AUTOMATIC;
         }
-        throw new RuntimeException( "Unknown PlacementType with name: " + str );
+        throw new GenericRuntimeException( "Unknown PlacementType with name: " + str );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/persistance/FilePersister.java
+++ b/core/src/main/java/org/polypheny/db/catalog/persistance/FilePersister.java
@@ -30,7 +30,7 @@ import org.polypheny.db.util.PolyphenyHomeDirManager;
 
 public class FilePersister implements Persister {
 
-    ExecutorService service = Executors.newSingleThreadExecutor();
+    private final ExecutorService service = Executors.newSingleThreadExecutor();
 
 
     private final File backup;

--- a/core/src/main/java/org/polypheny/db/catalog/persistance/InMemoryPersister.java
+++ b/core/src/main/java/org/polypheny/db/catalog/persistance/InMemoryPersister.java
@@ -18,7 +18,7 @@ package org.polypheny.db.catalog.persistance;
 
 public class InMemoryPersister implements Persister {
 
-    String backup = "";
+    private String backup = "";
 
 
     @Override

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/AllocSnapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/AllocSnapshot.java
@@ -30,7 +30,8 @@ import org.polypheny.db.partition.properties.PartitionProperty;
 
 public interface AllocSnapshot {
 
-    @NotNull List<AllocationColumn> getColumns();
+    @NotNull
+    List<AllocationColumn> getColumns();
 
     @NotNull
     Optional<List<AllocationEntity>> getEntitiesOnAdapter( long id );

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalDocSnapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalDocSnapshot.java
@@ -31,9 +31,11 @@ public interface LogicalDocSnapshot {
      * @param id The id of the collection
      * @return The requested collection
      */
-    @NonNull Optional<LogicalCollection> getCollection( long id );
+    @NonNull
+    Optional<LogicalCollection> getCollection( long id );
 
-    @NonNull Optional<LogicalCollection> getCollection( long namespaceId, String name );
+    @NonNull
+    Optional<LogicalCollection> getCollection( long namespaceId, String name );
 
     /**
      * Get a collection of collections which match the given naming pattern.
@@ -41,9 +43,11 @@ public interface LogicalDocSnapshot {
      * @param namePattern The naming pattern of the collection itself, null if all are matched
      * @return collection of collections matching conditions
      */
-    @NonNull List<LogicalCollection> getCollections( long namespaceId, @Nullable Pattern namePattern );
+    @NonNull
+    List<LogicalCollection> getCollections( long namespaceId, @Nullable Pattern namePattern );
 
-    @NonNull List<LogicalCollection> getCollections(@Nullable Pattern namespacePattern,@Nullable Pattern namePattern );
+    @NonNull
+    List<LogicalCollection> getCollections( @Nullable Pattern namespacePattern, @Nullable Pattern namePattern );
 
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalGraphSnapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalGraphSnapshot.java
@@ -31,7 +31,8 @@ public interface LogicalGraphSnapshot {
      * @param id The id of the graph to return
      * @return The graph entity with the provided id
      */
-    @NonNull Optional<LogicalGraph> getGraph( long id );
+    @NonNull
+    Optional<LogicalGraph> getGraph( long id );
 
 
     /**
@@ -40,7 +41,8 @@ public interface LogicalGraphSnapshot {
      * @param graphName The pattern to which the name has to match, null if every name is matched
      * @return A collection of all graphs matching
      */
-    @NonNull List<LogicalGraph> getGraphs( @Nullable Pattern graphName );
+    @NonNull
+    List<LogicalGraph> getGraphs( @Nullable Pattern graphName );
 
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
@@ -41,13 +41,17 @@ public interface LogicalRelSnapshot {
      * @param name Pattern for the table name. null returns all.
      * @return List of tables which fit to the specified filters. If there is no table which meets the criteria, an empty list is returned.
      */
-    @NonNull List<LogicalTable> getTables( @Nullable Pattern namespace, @Nullable Pattern name );
+    @NonNull
+    List<LogicalTable> getTables( @Nullable Pattern namespace, @Nullable Pattern name );
 
-    @NonNull List<LogicalTable> getTables( long namespaceId, @Nullable Pattern name );
+    @NonNull
+    List<LogicalTable> getTables( long namespaceId, @Nullable Pattern name );
 
-    @NonNull Optional<LogicalTable> getTables( @Nullable String namespace, @NonNull String name );
+    @NonNull
+    Optional<LogicalTable> getTables( @Nullable String namespace, @NonNull String name );
 
-    @NonNull List<LogicalTable> getTablesFromNamespace( long namespace );
+    @NonNull
+    List<LogicalTable> getTablesFromNamespace( long namespace );
 
 
     /**
@@ -56,9 +60,11 @@ public interface LogicalRelSnapshot {
      * @param tableName The name of the table
      * @return The table
      */
-    @NonNull Optional<LogicalTable> getTable( long namespaceId, String tableName );
+    @NonNull
+    Optional<LogicalTable> getTable( long namespaceId, String tableName );
 
-    @NonNull Optional<LogicalTable> getTable( String namespaceName, String tableName );
+    @NonNull
+    Optional<LogicalTable> getTable( String namespaceName, String tableName );
 
 
     /**
@@ -66,7 +72,8 @@ public interface LogicalRelSnapshot {
      *
      * @return The keys
      */
-    @NonNull List<LogicalKey> getKeys();
+    @NonNull
+    List<LogicalKey> getKeys();
 
 
     /**
@@ -75,7 +82,8 @@ public interface LogicalRelSnapshot {
      * @param tableId The id of the table for which the keys are returned
      * @return The collection of keys
      */
-    @NonNull List<LogicalKey> getTableKeys( long tableId );
+    @NonNull
+    List<LogicalKey> getTableKeys( long tableId );
 
 
     /**
@@ -84,7 +92,8 @@ public interface LogicalRelSnapshot {
      * @param tableId The id of the table
      * @return List of columns which fit to the specified filters. If there is no column which meets the criteria, an empty list is returned.
      */
-    @NonNull List<LogicalColumn> getColumns( long tableId );
+    @NonNull
+    List<LogicalColumn> getColumns( long tableId );
 
     /**
      * Get all columns of the specified database which fit to the specified filter patterns.
@@ -94,7 +103,8 @@ public interface LogicalRelSnapshot {
      * @param columnName Pattern for the column name. null returns all.
      * @return List of columns which fit to the specified filters. If there is no column which meets the criteria, an empty list is returned.
      */
-    @NonNull List<LogicalColumn> getColumns( @Nullable Pattern tableName, @Nullable Pattern columnName );
+    @NonNull
+    List<LogicalColumn> getColumns( @Nullable Pattern tableName, @Nullable Pattern columnName );
 
     /**
      * Returns the column with the specified id.
@@ -102,7 +112,8 @@ public interface LogicalRelSnapshot {
      * @param columnId The id of the column
      * @return A CatalogColumn
      */
-    @NonNull Optional<LogicalColumn> getColumn( long columnId );
+    @NonNull
+    Optional<LogicalColumn> getColumn( long columnId );
 
     /**
      * Returns the column with the specified name in the specified table of the specified database and schema.
@@ -111,7 +122,8 @@ public interface LogicalRelSnapshot {
      * @param columnName The name of the column
      * @return A CatalogColumn
      */
-    @NonNull Optional<LogicalColumn> getColumn( long tableId, String columnName );
+    @NonNull
+    Optional<LogicalColumn> getColumn( long tableId, String columnName );
 
     /**
      * Returns the column with the specified name in the specified table of the specified database and schema.
@@ -121,7 +133,8 @@ public interface LogicalRelSnapshot {
      * @param columnName The name of the column
      * @return A CatalogColumn
      */
-    @NonNull Optional<LogicalColumn> getColumn( long namespace, String tableName, String columnName );
+    @NonNull
+    Optional<LogicalColumn> getColumn( long namespace, String tableName, String columnName );
 
     /**
      * Returns a specified primary key
@@ -170,7 +183,8 @@ public interface LogicalRelSnapshot {
      * @param tableId The id of the table
      * @return List of foreign keys
      */
-    @NonNull List<LogicalForeignKey> getForeignKeys( long tableId );
+    @NonNull
+    List<LogicalForeignKey> getForeignKeys( long tableId );
 
     /**
      * Returns all foreign keys that reference the specified table (exported keys).
@@ -178,7 +192,8 @@ public interface LogicalRelSnapshot {
      * @param tableId The id of the table
      * @return List of foreign keys
      */
-    @NonNull List<LogicalForeignKey> getExportedKeys( long tableId );
+    @NonNull
+    List<LogicalForeignKey> getExportedKeys( long tableId );
 
     /**
      * Get all constraints of the specified table
@@ -186,7 +201,8 @@ public interface LogicalRelSnapshot {
      * @param tableId The id of the table
      * @return List of constraints
      */
-    @NonNull List<LogicalConstraint> getConstraints( long tableId );
+    @NonNull
+    List<LogicalConstraint> getConstraints( long tableId );
 
 
     /**
@@ -195,7 +211,8 @@ public interface LogicalRelSnapshot {
      * @param key The key for which the collection is returned
      * @return The collection of constraints
      */
-    @NonNull List<LogicalConstraint> getConstraints( LogicalKey key );
+    @NonNull
+    List<LogicalConstraint> getConstraints( LogicalKey key );
 
     /**
      * Returns the constraint with the specified name in the specified table.
@@ -204,7 +221,8 @@ public interface LogicalRelSnapshot {
      * @param constraintName The name of the constraint
      * @return The constraint
      */
-    @NonNull Optional<LogicalConstraint> getConstraint( long tableId, String constraintName );
+    @NonNull
+    Optional<LogicalConstraint> getConstraint( long tableId, String constraintName );
 
     /**
      * Return the foreign key with the specified name from the specified table
@@ -213,7 +231,8 @@ public interface LogicalRelSnapshot {
      * @param foreignKeyName The name of the foreign key
      * @return The foreign key
      */
-    @NonNull Optional<LogicalForeignKey> getForeignKey( long tableId, String foreignKeyName );
+    @NonNull
+    Optional<LogicalForeignKey> getForeignKey( long tableId, String foreignKeyName );
 
     List<LogicalIndex> getIndexes();
 
@@ -223,7 +242,8 @@ public interface LogicalRelSnapshot {
      * @param key The key for which the collection is returned
      * @return The collection of indexes
      */
-    @NonNull List<LogicalIndex> getIndexes( LogicalKey key );
+    @NonNull
+    List<LogicalIndex> getIndexes( LogicalKey key );
 
     /**
      * Gets a collection of foreign keys for a given {@link Catalog Key}.
@@ -231,7 +251,8 @@ public interface LogicalRelSnapshot {
      * @param key The key for which the collection is returned
      * @return The collection foreign keys
      */
-    @NonNull List<LogicalIndex> getForeignKeys( LogicalKey key );
+    @NonNull
+    List<LogicalIndex> getForeignKeys( LogicalKey key );
 
     /**
      * Returns all indexes of a table
@@ -240,7 +261,8 @@ public interface LogicalRelSnapshot {
      * @param onlyUnique true if only indexes for unique values are returned. false if all indexes are returned.
      * @return List of indexes
      */
-    @NonNull List<LogicalIndex> getIndexes( long tableId, boolean onlyUnique );
+    @NonNull
+    List<LogicalIndex> getIndexes( long tableId, boolean onlyUnique );
 
     /**
      * Returns the index with the specified name in the specified table
@@ -249,7 +271,8 @@ public interface LogicalRelSnapshot {
      * @param indexName The name of the index
      * @return The Index
      */
-    @NonNull Optional<LogicalIndex> getIndex( long tableId, String indexName );
+    @NonNull
+    Optional<LogicalIndex> getIndex( long tableId, String indexName );
 
     /**
      * Returns the index with the specified id
@@ -257,23 +280,30 @@ public interface LogicalRelSnapshot {
      * @param indexId The id of the index
      * @return The Index
      */
-    @NonNull Optional<LogicalIndex> getIndex( long indexId );
+    @NonNull
+    Optional<LogicalIndex> getIndex( long indexId );
 
-    @NonNull Optional<LogicalTable> getTable( long id );
+    @NonNull
+    Optional<LogicalTable> getTable( long id );
 
 
     AlgNode getNodeInfo( long id );
 
     List<LogicalView> getConnectedViews( long id );
 
-    @NotNull Optional<LogicalKey> getKeys( long[] columnIds );
+    @NotNull
+    Optional<LogicalKey> getKeys( long[] columnIds );
 
-    @NotNull Optional<LogicalKey> getKey( long id );
+    @NotNull
+    Optional<LogicalKey> getKey( long id );
 
-    @NotNull List<LogicalConstraint> getConstraints();
+    @NotNull
+    List<LogicalConstraint> getConstraints();
 
-    @NotNull List<LogicalPrimaryKey> getPrimaryKeys();
+    @NotNull
+    List<LogicalPrimaryKey> getPrimaryKeys();
 
-    @NotNull List<LogicalForeignKey> getForeignKeys();
+    @NotNull
+    List<LogicalForeignKey> getForeignKeys();
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/AllocSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/AllocSnapshotImpl.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +51,6 @@ import org.polypheny.db.util.Pair;
 
 @Value
 @Slf4j
-@EqualsAndHashCode
 public class AllocSnapshotImpl implements AllocSnapshot {
 
     @NotNull

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/AllocSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/AllocSnapshotImpl.java
@@ -533,6 +533,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
         return Optional.ofNullable( adapterLogicalToPlacement.get( Pair.of( adapterId, logicalEntityId ) ) );
     }
 
+
     @Override
     public @NonNull List<AllocationEntity> getFromLogical( long logicalId ) {
         return Optional.ofNullable( logicalAllocs.get( logicalId ) ).orElse( List.of() );

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/AllocSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/AllocSnapshotImpl.java
@@ -184,13 +184,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
 
     private ImmutableMap<Long, List<AllocationEntity>> buildAllocsOfPartitions() {
         Map<Long, List<AllocationEntity>> map = new HashMap<>();
-        for ( AllocationEntity value : allocs.values() ) {
-            if ( !map.containsKey( value.partitionId ) ) {
-                map.put( value.partitionId, new ArrayList<>() );
-            }
-            map.get( value.partitionId ).add( value );
-        }
-
+        allocs.values().forEach( value -> map.computeIfAbsent( value.partitionId, k -> new ArrayList<>() ).add( value ) );
         return ImmutableMap.copyOf( map );
     }
 
@@ -209,9 +203,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
         Map<Pair<Long, String>, AllocationPartition> map = new HashMap<>();
         for ( Entry<Long, AllocationPartition> entry : partitions.entrySet() ) {
             Pair<Long, String> key = Pair.of( entry.getValue().logicalEntityId, entry.getValue().name );
-            if ( !map.containsKey( key ) ) {
-                map.put( key, entry.getValue() );
-            }
+            map.putIfAbsent( key, entry.getValue() );
         }
 
         return ImmutableMap.copyOf( map );
@@ -221,10 +213,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, List<AllocationPlacement>> buildPlacementsOfColumn() {
         Map<Long, List<AllocationPlacement>> map = new HashMap<>();
         for ( AllocationColumn value : this.columns.values() ) {
-            if ( !map.containsKey( value.columnId ) ) {
-                map.put( value.columnId, new ArrayList<>() );
-            }
-            map.get( value.columnId ).add( placements.get( value.placementId ) );
+            map.computeIfAbsent( value.columnId, k -> new ArrayList<>() ).add( placements.get( value.placementId ) );
         }
         return ImmutableMap.copyOf( map );
     }
@@ -233,10 +222,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, List<AllocationEntity>> buildPlacementToPartitions() {
         Map<Long, List<AllocationEntity>> map = new HashMap<>();
         for ( AllocationEntity value : this.allocs.values() ) {
-            if ( !map.containsKey( value.placementId ) ) {
-                map.put( value.placementId, new ArrayList<>() );
-            }
-            map.get( value.placementId ).add( value );
+            map.computeIfAbsent( value.placementId, k -> new ArrayList<>() ).add( value );
         }
         return ImmutableMap.copyOf( map );
     }
@@ -265,10 +251,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, List<AllocationPlacement>> buildLogicalToPlacements() {
         Map<Long, List<AllocationPlacement>> map = new HashMap<>();
         for ( AllocationPlacement value : this.placements.values() ) {
-            if ( !map.containsKey( value.logicalEntityId ) ) {
-                map.put( value.logicalEntityId, new ArrayList<>() );
-            }
-            map.get( value.logicalEntityId ).add( value );
+            map.computeIfAbsent( value.logicalEntityId, k -> new ArrayList<>() ).add( value );
         }
         return ImmutableMap.copyOf( map );
     }
@@ -307,10 +290,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, List<AllocationPartitionGroup>> buildLogicalGroups() {
         Map<Long, List<AllocationPartitionGroup>> map = new HashMap<>();
         for ( AllocationPartitionGroup value : this.groups.values() ) {
-            if ( !map.containsKey( value.logicalEntityId ) ) {
-                map.put( value.logicalEntityId, new ArrayList<>() );
-            }
-            map.get( value.logicalEntityId ).add( value );
+            map.computeIfAbsent( value.logicalEntityId, k -> new ArrayList<>() ).add( value );
         }
         return ImmutableMap.copyOf( map );
     }
@@ -319,10 +299,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, List<AllocationPartition>> buildLogicalToPartitions() {
         Map<Long, List<AllocationPartition>> map = new HashMap<>();
         for ( AllocationPartition value : this.partitions.values() ) {
-            if ( !map.containsKey( value.logicalEntityId ) ) {
-                map.put( value.logicalEntityId, new ArrayList<>() );
-            }
-            map.get( value.logicalEntityId ).add( value );
+            map.computeIfAbsent( value.logicalEntityId, k -> new ArrayList<>() ).add( value );
         }
         return ImmutableMap.copyOf( map );
     }
@@ -337,13 +314,8 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, Map<Long, List<Long>>> buildTableAdapterColumns() {
         Map<Long, Map<Long, List<Long>>> map = new HashMap<>();
         for ( AllocationColumn column : this.columns.values() ) {
-            if ( !map.containsKey( column.logicalTableId ) ) {
-                map.put( column.logicalTableId, new HashMap<>() );
-            }
-            if ( !map.get( column.logicalTableId ).containsKey( column.adapterId ) ) {
-                map.get( column.logicalTableId ).put( column.adapterId, new ArrayList<>() );
-            }
-            map.get( column.logicalTableId ).get( column.adapterId ).add( column.columnId );
+            map.putIfAbsent( column.logicalTableId, new HashMap<>() );
+            map.get( column.logicalTableId ).computeIfAbsent( column.adapterId, k -> new ArrayList<>() ).add( column.columnId );
         }
 
         return ImmutableMap.copyOf( map );
@@ -352,12 +324,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
 
     private ImmutableMap<Long, List<AllocationEntity>> buildLogicalAllocs() {
         Map<Long, List<AllocationEntity>> map = new HashMap<>();
-        allocs.forEach( ( k, v ) -> {
-            if ( !map.containsKey( v.logicalId ) ) {
-                map.put( v.logicalId, new ArrayList<>() );
-            }
-            map.get( v.logicalId ).add( v );
-        } );
+        allocs.forEach( ( k, v ) -> map.computeIfAbsent( v.logicalId, e -> new ArrayList<>() ).add( v ) );
         return ImmutableMap.copyOf( map );
     }
 
@@ -365,10 +332,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, List<AllocationColumn>> buildPlacementColumns() {
         Map<Long, TreeSet<AllocationColumn>> map = new HashMap<>();
         for ( AllocationColumn value : columns.values() ) {
-            if ( !map.containsKey( value.placementId ) ) {
-                map.put( value.placementId, new TreeSet<>( ( a, b ) -> AllocSnapshotImpl.comparatorOrId( () -> a.position - b.position, a, b ) ) );
-            }
-            map.get( value.placementId ).add( value );
+            map.computeIfAbsent( value.placementId, k -> new TreeSet<>( ( a, b ) -> AllocSnapshotImpl.comparatorOrId( () -> Long.compare( a.position, b.position ), a, b ) ) ).add( value );
         }
 
         return ImmutableMap.copyOf( map.entrySet().stream().collect( Collectors.toMap( Entry::getKey, e -> new ArrayList<>( e.getValue() ) ) ) );
@@ -398,10 +362,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, List<AllocationColumn>> buildColumnPlacements() {
         Map<Long, List<AllocationColumn>> map = new HashMap<>();
         for ( AllocationColumn column : columns.values() ) {
-            if ( !map.containsKey( column.columnId ) ) {
-                map.put( column.columnId, new ArrayList<>() );
-            }
-            map.get( column.columnId ).add( column );
+            map.computeIfAbsent( column.columnId, k -> new ArrayList<>() ).add( column );
         }
 
         return ImmutableMap.copyOf( map );

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/AllocSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/AllocSnapshotImpl.java
@@ -190,12 +190,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
 
 
     private ImmutableMap<Long, List<AllocationPartition>> buildPartitionsOfGroups() {
-        Map<Long, List<AllocationPartition>> map = new HashMap<>();
-        for ( AllocationPartitionGroup group : groups.values() ) {
-            map.put( group.id, partitions.values().stream().filter( p -> p.groupId == group.id ).toList() );
-        }
-
-        return ImmutableMap.copyOf( map );
+        return ImmutableMap.copyOf( groups.values().stream().collect( Collectors.toMap( group -> group.id, group -> partitions.values().stream().filter( p -> p.groupId == group.id ).toList() ) ) );
     }
 
 
@@ -382,9 +377,7 @@ public class AllocSnapshotImpl implements AllocSnapshot {
     private ImmutableMap<Long, List<AllocationEntity>> buildAllocsOnAdapters( Map<Long, LogicalAdapter> adapters ) {
         Map<Long, List<AllocationEntity>> allocs = new HashMap<>();
 
-        for ( LogicalAdapter adapter : adapters.values() ) {
-            allocs.put( adapter.id, new ArrayList<>() );
-        }
+        adapters.values().forEach( adapter -> allocs.put( adapter.id, new ArrayList<>() ) );
         this.allocs.forEach( ( k, v ) -> allocs.get( v.adapterId ).add( v ) );
         return ImmutableMap.copyOf( allocs );
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalDocSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalDocSnapshotImpl.java
@@ -94,5 +94,4 @@ public class LogicalDocSnapshotImpl implements LogicalDocSnapshot {
     }
 
 
-
 }

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalDocSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalDocSnapshotImpl.java
@@ -66,7 +66,7 @@ public class LogicalDocSnapshotImpl implements LogicalDocSnapshot {
 
         return collections.stream().filter( c -> namespaces.get( c.namespaceId ).caseSensitive
                 ? c.name.matches( namePattern.toRegex() )
-                : c.name.toLowerCase().matches( namePattern.toLowerCase().toRegex() ) ).collect( Collectors.toList() );
+                : c.name.toLowerCase().matches( namePattern.toLowerCase().toRegex() ) ).toList();
     }
 
 
@@ -80,7 +80,7 @@ public class LogicalDocSnapshotImpl implements LogicalDocSnapshot {
                     : n.name.toLowerCase().matches( namespacePattern.toLowerCase().toRegex() ) ).toList();
         }
 
-        return namespaces.stream().flatMap( n -> getCollections( n.id, namePattern ).stream() ).collect( Collectors.toList() );
+        return namespaces.stream().flatMap( n -> getCollections( n.id, namePattern ).stream() ).toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalGraphSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalGraphSnapshotImpl.java
@@ -70,7 +70,7 @@ public class LogicalGraphSnapshotImpl implements LogicalGraphSnapshot {
             return graphs;
         }
 
-        return graphNames.values().stream().filter( g -> g.caseSensitive ? g.name.matches( graphName.toRegex() ) : g.name.toLowerCase().matches( graphName.toRegex().toLowerCase() ) ).collect( Collectors.toList() );
+        return graphNames.values().stream().filter( g -> g.caseSensitive ? g.name.matches( graphName.toRegex() ) : g.name.toLowerCase().matches( graphName.toRegex().toLowerCase() ) ).toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
@@ -294,7 +294,6 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
             return this.namespaces.values().asList();
         }
         return this.namespaces.values().stream().filter( n -> n.caseSensitive ? n.name.matches( namespaceName.toRegex() ) : n.name.toLowerCase().matches( namespaceName.toRegex().toLowerCase() ) ).toList();
-
     }
 
 
@@ -432,13 +431,13 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
 
     @Override
     public @NotNull List<LogicalForeignKey> getForeignKeys( long tableId ) {
-        return foreignKeys.values().stream().filter( k -> k.entityId == tableId ).collect( Collectors.toList() );
+        return foreignKeys.values().stream().filter( k -> k.entityId == tableId ).toList();
     }
 
 
     @Override
     public @NonNull List<LogicalForeignKey> getExportedKeys( long tableId ) {
-        return foreignKeys.values().stream().filter( k -> k.referencedKeyEntityId == tableId ).collect( Collectors.toList() );
+        return foreignKeys.values().stream().filter( k -> k.referencedKeyEntityId == tableId ).toList();
     }
 
 
@@ -451,7 +450,7 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
 
     @Override
     public @NotNull List<LogicalConstraint> getConstraints( LogicalKey key ) {
-        return constraints.values().stream().filter( c -> c.keyId == key.id ).collect( Collectors.toList() );
+        return constraints.values().stream().filter( c -> c.keyId == key.id ).toList();
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
@@ -238,9 +238,7 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
 
     private ImmutableMap<Long, List<LogicalKey>> buildTableKeys() {
         Map<Long, List<LogicalKey>> tableKeys = new HashMap<>();
-        for ( LogicalTable table : tables.values() ) {
-            tableKeys.put( table.id, new ArrayList<>() );
-        }
+        tables.values().forEach( table -> tableKeys.put( table.id, new ArrayList<>() ) );
         keys.forEach( ( k, v ) -> tableKeys.get( v.entityId ).add( v ) );
         return ImmutableMap.copyOf( tableKeys );
     }

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.TreeSet;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +50,6 @@ import org.polypheny.db.util.Pair;
 
 @Value
 @Slf4j
-@EqualsAndHashCode
 public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
 
     ImmutableMap<Long, LogicalNamespace> namespaces;

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
@@ -251,18 +251,11 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
 
         for ( LogicalView view : this.views.values() ) {
             for ( long entityId : view.underlyingTables.keySet() ) {
-                if ( !map.containsKey( entityId ) ) {
-                    map.put( entityId, new ArrayList<>() );
-                }
-                map.get( entityId ).add( view );
+                map.computeIfAbsent( entityId, k -> new ArrayList<>() ).add( view );
             }
         }
         // add tables which are not connected
-        for ( long id : this.tables.keySet() ) {
-            if ( !map.containsKey( id ) ) {
-                map.put( id, new ArrayList<>() );
-            }
-        }
+        this.tables.keySet().forEach( id -> map.putIfAbsent( id, new ArrayList<>() ) );
 
         return ImmutableMap.copyOf( map );
     }
@@ -550,6 +543,5 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
     public @NonNull Optional<LogicalKey> getKey( long id ) {
         return Optional.ofNullable( keys.get( id ) );
     }
-
 
 }

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/SnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/SnapshotImpl.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.Accessors;
@@ -48,7 +47,6 @@ import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 
 @Value
 @Accessors(fluent = true)
-@EqualsAndHashCode
 public class SnapshotImpl implements Snapshot {
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/SnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/SnapshotImpl.java
@@ -65,19 +65,17 @@ public class SnapshotImpl implements Snapshot {
     long id;
 
     ImmutableMap<Long, LogicalUser> users;
-
     ImmutableMap<String, LogicalUser> userNames;
+
     ImmutableMap<Long, LogicalQueryInterface> interfaces;
     ImmutableMap<String, QueryInterfaceTemplate> interfaceTemplates;
-
     ImmutableMap<String, LogicalQueryInterface> interfaceNames;
+
     ImmutableMap<Long, LogicalAdapter> adapters;
     ImmutableMap<Long, AdapterTemplate> adapterTemplates;
-
     ImmutableMap<String, LogicalAdapter> adapterNames;
 
     ImmutableMap<Long, LogicalNamespace> namespaces;
-
     ImmutableMap<String, LogicalNamespace> namespaceNames;
 
 

--- a/core/src/main/java/org/polypheny/db/iface/QueryInterfaceManager.java
+++ b/core/src/main/java/org/polypheny/db/iface/QueryInterfaceManager.java
@@ -184,6 +184,7 @@ public class QueryInterfaceManager {
             @JsonSerialize String interfaceType,
             @JsonSerialize String uniqueName,
             @JsonSerialize Map<String, String> currentSettings ) {
+
     }
 
 

--- a/core/src/main/java/org/polypheny/db/iface/QueryInterfaceManager.java
+++ b/core/src/main/java/org/polypheny/db/iface/QueryInterfaceManager.java
@@ -180,11 +180,10 @@ public class QueryInterfaceManager {
     /**
      * Model needed for the UI
      */
-    public record QueryInterfaceInformationRequest(
+    public record QueryInterfaceCreateRequest(
             @JsonSerialize String interfaceName,
             @JsonSerialize String uniqueName,
             @JsonSerialize Map<String, String> currentSettings ) {
-
     }
 
 

--- a/core/src/main/java/org/polypheny/db/iface/QueryInterfaceManager.java
+++ b/core/src/main/java/org/polypheny/db/iface/QueryInterfaceManager.java
@@ -181,7 +181,7 @@ public class QueryInterfaceManager {
      * Model needed for the UI
      */
     public record QueryInterfaceCreateRequest(
-            @JsonSerialize String interfaceName,
+            @JsonSerialize String interfaceType,
             @JsonSerialize String uniqueName,
             @JsonSerialize Map<String, String> currentSettings ) {
     }

--- a/core/src/main/java/org/polypheny/db/type/entity/PolyList.java
+++ b/core/src/main/java/org/polypheny/db/type/entity/PolyList.java
@@ -205,7 +205,7 @@ public class PolyList<E extends PolyValue> extends PolyValue implements List<E> 
         }
 
         if ( value.size() != o.asList().value.size() ) {
-            return value.size() - o.asList().value.size();
+            return Long.compare( value.size(), o.asList().value.size() );
         }
 
         for ( Pair<E, ?> pair : Pair.zip( value, o.asList().value ) ) {

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -21,7 +21,7 @@ import com.github.rvesse.airline.SingleCommand;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.parser.errors.ParseException;
-import java.awt.*;
+import java.awt.SystemTray;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -229,15 +229,6 @@ public class PolyphenyDb {
 
         initializeStatusNotificationService();
 
-        // Check if Polypheny is already running
-        if ( GuiUtils.checkPolyphenyAlreadyRunning() ) {
-            if ( openUiInBrowser ) {
-                GuiUtils.openUiInBrowser();
-            }
-            System.err.println( "There is already an instance of Polypheny running on this system." );
-            System.exit( 0 );
-        }
-
         // Restore content of Polypheny folder
         restoreHomeFolderIfNecessary( dirManager );
 

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -57,7 +57,6 @@ import org.polypheny.db.ddl.DdlManagerImpl;
 import org.polypheny.db.ddl.DefaultInserter;
 import org.polypheny.db.docker.AutoDocker;
 import org.polypheny.db.docker.DockerManager;
-import org.polypheny.db.gui.GuiUtils;
 import org.polypheny.db.gui.SplashHelper;
 import org.polypheny.db.gui.TrayGui;
 import org.polypheny.db.iface.Authenticator;

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -173,7 +173,7 @@ public class PolyphenyDb {
 
             polyphenyDb.runPolyphenyDb();
         } catch ( ParseException e ) {
-            log.error( "Error parsing command line parameters: " + e.getMessage() );
+            log.error( "Error parsing command line parameters: {}", e.getMessage() );
         } catch ( Throwable uncaught ) {
             if ( log.isErrorEnabled() ) {
                 log.error( "Uncaught Throwable.", uncaught );
@@ -269,7 +269,7 @@ public class PolyphenyDb {
             uuid += "-polypheny-test";
         }
 
-        log.info( "Polypheny UUID: " + uuid );
+        log.info( "Polypheny UUID: {}", uuid );
         RuntimeConfig.INSTANCE_UUID.setString( uuid );
 
         final ShutdownHelper sh = new ShutdownHelper();
@@ -419,7 +419,7 @@ public class PolyphenyDb {
             } catch ( GenericRuntimeException e ) {
                 // AutoDocker does not work in Windows containers
                 if ( mode == RunMode.TEST && !System.getenv( "RUNNER_OS" ).equals( "Windows" ) ) {
-                    log.error( "Failed to connect to Docker instance: " + e.getMessage() );
+                    log.error( "Failed to connect to Docker instance: {}", e.getMessage() );
                     throw e;
                 }
             }

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -529,7 +529,7 @@ public class PolyphenyDb {
     }
 
 
-    private String generateOrLoadPolyphenyUUID() {
+    private static String generateOrLoadPolyphenyUUID() {
         Optional<File> uuidFile = PolyphenyHomeDirManager.getInstance().getGlobalFile( "uuid" );
         if ( uuidFile.isEmpty() ) {
             UUID id = UUID.randomUUID();

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -21,7 +21,7 @@ import com.github.rvesse.airline.SingleCommand;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.parser.errors.ParseException;
-import java.awt.SystemTray;
+import java.awt.*;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -173,11 +173,9 @@ public class PolyphenyDb {
             }
 
             polyphenyDb.runPolyphenyDb();
-        } catch (
-                ParseException e ) {
+        } catch ( ParseException e ) {
             log.error( "Error parsing command line parameters: " + e.getMessage() );
-        } catch (
-                Throwable uncaught ) {
+        } catch ( Throwable uncaught ) {
             if ( log.isErrorEnabled() ) {
                 log.error( "Uncaught Throwable.", uncaught );
                 StatusNotificationService.printError(
@@ -200,11 +198,9 @@ public class PolyphenyDb {
         // Select behavior depending on arguments
         boolean showSplashScreen;
         boolean trayMenu;
-        boolean openUiInBrowser;
         if ( daemonMode ) {
             showSplashScreen = false;
             trayMenu = false;
-            openUiInBrowser = false;
         } else if ( desktopMode ) {
             showSplashScreen = true;
             try {
@@ -212,11 +208,9 @@ public class PolyphenyDb {
             } catch ( Exception e ) {
                 trayMenu = false;
             }
-            openUiInBrowser = true;
         } else {
             showSplashScreen = false;
             trayMenu = false;
-            openUiInBrowser = false;
         }
 
         // Open splash screen

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -229,9 +229,11 @@ public class PolyphenyDb {
         if ( resetCatalog ) {
             if ( !PolyphenyHomeDirManager.getInstance().recursiveDeleteFolder( "data" ) ) {
                 log.error( "Unable to delete the data folder." );
+                System.exit( 1 );
             }
             if ( !PolyphenyHomeDirManager.getInstance().recursiveDeleteFolder( "monitoring" ) ) {
                 log.error( "Unable to delete the monitoring folder." );
+                System.exit( 1 );
             }
             ConfigManager.getInstance().resetDefaultConfiguration();
         }

--- a/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
@@ -787,7 +787,7 @@ public class DdlManagerImpl extends DdlManager {
             columnIds.add( logicalColumn.id );
         }
 
-        if ( oldPk != null && oldPk.key.fieldIds.containsAll( columnIds ) && columnIds.contains( oldPk.key.fieldIds ) ) {
+        if ( oldPk != null && oldPk.key.fieldIds.containsAll( columnIds ) && columnIds.containsAll( oldPk.key.fieldIds ) ) {
             return;
         }
 

--- a/dbms/src/main/java/org/polypheny/db/ddl/DefaultInserter.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DefaultInserter.java
@@ -103,9 +103,9 @@ public class DefaultInserter {
         if ( !Catalog.getInstance().getInterfaces().isEmpty() ) {
             return;
         }
-        Catalog.getInstance().getInterfaceTemplates().values().forEach( i -> Catalog.getInstance().createQueryInterface( i.interfaceName().toLowerCase(), i.interfaceName(), i.getDefaultSettings() ) );
+        Catalog.getInstance().getInterfaceTemplates().values().forEach( i -> Catalog.getInstance().createQueryInterface( i.interfaceType().toLowerCase(), i.interfaceType(), i.getDefaultSettings() ) );
         // TODO: This is ugly, both because it is racy, and depends on a string (which might be changed)
-        if ( Catalog.getInstance().getInterfaceTemplates().values().stream().anyMatch( t -> t.interfaceName().equals( "Prism Interface (Unix transport)" ) ) ) {
+        if ( Catalog.getInstance().getInterfaceTemplates().values().stream().anyMatch( t -> t.interfaceType().equals( "Prism Interface (Unix transport)" ) ) ) {
             Catalog.getInstance().createQueryInterface(
                     "prism interface (unix transport @ .polypheny)",
                     "Prism Interface (Unix transport)",

--- a/dbms/src/main/java/org/polypheny/db/gui/GuiUtils.java
+++ b/dbms/src/main/java/org/polypheny/db/gui/GuiUtils.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.gui;
 
-import java.awt.Desktop;
+import java.awt.*;
 import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URI;

--- a/dbms/src/main/java/org/polypheny/db/gui/GuiUtils.java
+++ b/dbms/src/main/java/org/polypheny/db/gui/GuiUtils.java
@@ -17,10 +17,7 @@
 package org.polypheny.db.gui;
 
 import java.awt.Desktop;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
 import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -58,30 +55,6 @@ public class GuiUtils {
         } catch ( Exception e ) {
             return "Unknown";
         }
-    }
-
-
-    public static boolean checkPolyphenyAlreadyRunning() {
-        try {
-            String url = "http://localhost:" + RuntimeConfig.WEBUI_SERVER_PORT.getInteger() + "/product";
-            return httpGetRequest( url ).equals( "Polypheny-DB" );
-        } catch ( Exception e ) {
-            return false;
-        }
-    }
-
-
-    private static String httpGetRequest( String urlToRead ) throws java.io.IOException {
-        StringBuilder result = new StringBuilder();
-        URL url = new URL( urlToRead );
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setRequestMethod( "GET" );
-        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( conn.getInputStream() ) ) ) {
-            for ( String line; (line = reader.readLine()) != null; ) {
-                result.append( line );
-            }
-        }
-        return result.toString().trim();
     }
 
 

--- a/dbms/src/main/java/org/polypheny/db/gui/GuiUtils.java
+++ b/dbms/src/main/java/org/polypheny/db/gui/GuiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 The Polypheny Project
+ * Copyright 2019-2024 The Polypheny Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dbms/src/main/java/org/polypheny/db/gui/GuiUtils.java
+++ b/dbms/src/main/java/org/polypheny/db/gui/GuiUtils.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.gui;
 
-import java.awt.*;
+import java.awt.Desktop;
 import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URI;

--- a/dbms/src/main/java/org/polypheny/db/processing/AbstractQueryProcessor.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/AbstractQueryProcessor.java
@@ -286,11 +286,6 @@ public abstract class AbstractQueryProcessor implements QueryProcessor, Executio
         }
 
         if ( isAnalyze ) {
-            statement.getProcessingDuration().start( "Expand Views" );
-        }
-
-        if ( isAnalyze ) {
-            statement.getProcessingDuration().stop( "Expand Views" );
             statement.getProcessingDuration().start( "Parameter Validation" );
         }
 

--- a/dbms/src/main/java/org/polypheny/db/routing/routers/DmlRouterImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/routing/routers/DmlRouterImpl.java
@@ -657,7 +657,7 @@ public class DmlRouterImpl extends BaseRouter implements DmlRouter {
     public AlgNode routeDocumentDml( LogicalDocumentModify alg, Statement statement, @Nullable AllocationEntity target, @Nullable List<Long> excludedPlacements ) {
         Snapshot snapshot = statement.getTransaction().getSnapshot();
 
-        LogicalCollection collection = alg.entity.unwrap( LogicalCollection.class ).orElseThrow();
+        LogicalCollection collection = alg.entity.unwrap( LogicalCollection.class ).orElseThrow( () -> new GenericRuntimeException( String.format( "%s is not a collection", alg.entity.name ) ) );
 
         List<AlgNode> modifies = new ArrayList<>();
 

--- a/dbms/src/test/java/org/polypheny/db/TestHelper.java
+++ b/dbms/src/test/java/org/polypheny/db/TestHelper.java
@@ -246,7 +246,6 @@ public class TestHelper {
             field.setAccessible( true );
             field.set( catalog, new IdBuilder(
                     new AtomicLong( catalog.idBuilder.getSnapshotId().longValue() + offset.get() ),
-                    new AtomicLong( catalog.idBuilder.getNamespaceId().longValue() + offset.get() ),
                     new AtomicLong( catalog.idBuilder.getEntityId().longValue() + offset.get() ),
                     new AtomicLong( catalog.idBuilder.getFieldId().longValue() + offset.get() ),
                     new AtomicLong( catalog.idBuilder.getUserId().longValue() + offset.get() ),

--- a/dbms/src/test/java/org/polypheny/db/misc/HorizontalPartitioningTest.java
+++ b/dbms/src/test/java/org/polypheny/db/misc/HorizontalPartitioningTest.java
@@ -47,7 +47,6 @@ import org.polypheny.db.cypher.CypherTestTemplate;
 import org.polypheny.db.monitoring.core.MonitoringServiceProvider;
 import org.polypheny.db.partition.PartitionManager;
 import org.polypheny.db.partition.PartitionManagerFactory;
-import org.polypheny.db.partition.properties.PartitionProperty;
 import org.polypheny.db.partition.properties.TemperaturePartitionProperty;
 import org.polypheny.db.util.background.BackgroundTask.TaskSchedulingType;
 import org.polypheny.jdbc.PrismInterfaceServiceException;

--- a/dbms/src/test/java/org/polypheny/db/misc/HorizontalPartitioningTest.java
+++ b/dbms/src/test/java/org/polypheny/db/misc/HorizontalPartitioningTest.java
@@ -696,13 +696,13 @@ public class HorizontalPartitioningTest {
                 try {
                     LogicalTable table = Catalog.snapshot().rel().getTables( null, new Pattern( "temperaturetest" ) ).get( 0 );
 
-                    PartitionProperty partitionProperty = Catalog.snapshot().alloc().getPartitionProperty( table.id ).orElseThrow();
+                    TemperaturePartitionProperty partitionProperty = (TemperaturePartitionProperty) Catalog.snapshot().alloc().getPartitionProperty( table.id ).orElseThrow();
 
                     // Check if partition properties are correctly set and parsed
-                    assertEquals( 600, ((TemperaturePartitionProperty) partitionProperty).getFrequencyInterval() );
-                    assertEquals( 12, ((TemperaturePartitionProperty) partitionProperty).getHotAccessPercentageIn() );
-                    assertEquals( 14, ((TemperaturePartitionProperty) partitionProperty).getHotAccessPercentageOut() );
-                    assertEquals( PartitionType.HASH, ((TemperaturePartitionProperty) partitionProperty).getInternalPartitionFunction() );
+                    assertEquals( 600, partitionProperty.getFrequencyInterval() );
+                    assertEquals( 12, partitionProperty.getHotAccessPercentageIn() );
+                    assertEquals( 14, partitionProperty.getHotAccessPercentageOut() );
+                    assertEquals( PartitionType.HASH, partitionProperty.getInternalPartitionFunction() );
 
                     assertEquals( 2, partitionProperty.getPartitionGroupIds().size() );
                     assertEquals( 20, partitionProperty.getPartitionIds().size() );
@@ -712,9 +712,9 @@ public class HorizontalPartitioningTest {
 
                     // Retrieve partition distribution
                     // Get percentage of tables which can remain in HOT
-                    long numberOfPartitionsInHot = ((long) partitionProperty.partitionIds.size() * ((TemperaturePartitionProperty) partitionProperty).getHotAccessPercentageIn()) / 100;
+                    long numberOfPartitionsInHot = ((long) partitionProperty.partitionIds.size() * partitionProperty.getHotAccessPercentageIn()) / 100;
                     //These are the tables than can remain in HOT
-                    long allowedTablesInHot = ((long) partitionProperty.partitionIds.size() * ((TemperaturePartitionProperty) partitionProperty).getHotAccessPercentageOut()) / 100;
+                    long allowedTablesInHot = ((long) partitionProperty.partitionIds.size() * partitionProperty.getHotAccessPercentageOut()) / 100;
                     if ( numberOfPartitionsInHot == 0 ) {
                         numberOfPartitionsInHot = 1;
                     }
@@ -723,8 +723,8 @@ public class HorizontalPartitioningTest {
                     }
                     long numberOfPartitionsInCold = partitionProperty.partitionIds.size() - numberOfPartitionsInHot;
 
-                    List<AllocationPartition> hotPartitions = Catalog.snapshot().alloc().getPartitionsFromGroup( ((TemperaturePartitionProperty) partitionProperty).getHotPartitionGroupId() );
-                    List<AllocationPartition> coldPartitions = Catalog.snapshot().alloc().getPartitionsFromGroup( ((TemperaturePartitionProperty) partitionProperty).getColdPartitionGroupId() );
+                    List<AllocationPartition> hotPartitions = Catalog.snapshot().alloc().getPartitionsFromGroup( partitionProperty.getHotPartitionGroupId() );
+                    List<AllocationPartition> coldPartitions = Catalog.snapshot().alloc().getPartitionsFromGroup( partitionProperty.getColdPartitionGroupId() );
 
                     assertTrue( (numberOfPartitionsInHot == hotPartitions.size()) || (numberOfPartitionsInHot == allowedTablesInHot) );
 
@@ -754,14 +754,14 @@ public class HorizontalPartitioningTest {
                     // Verify that the partition is now in HOT and was not before
                     LogicalTable updatedTable = Catalog.snapshot().rel().getTables( null, new Pattern( "temperaturetest" ) ).get( 0 );
 
-                    PartitionProperty updatedProperty = Catalog.snapshot().alloc().getPartitionProperty( updatedTable.id ).orElseThrow();
+                    TemperaturePartitionProperty updatedProperty = (TemperaturePartitionProperty) Catalog.snapshot().alloc().getPartitionProperty( updatedTable.id ).orElseThrow();
 
                     // Manually get the target partitionID of query
                     PartitionManagerFactory partitionManagerFactory = PartitionManagerFactory.getInstance();
                     PartitionManager partitionManager = partitionManagerFactory.getPartitionManager( partitionProperty.partitionType );
                     long targetId = partitionManager.getTargetPartitionId( table, partitionProperty, partitionValue );
 
-                    List<AllocationPartition> hotPartitionsAfterChange = Catalog.snapshot().alloc().getPartitionsFromGroup( ((TemperaturePartitionProperty) updatedProperty).getHotPartitionGroupId() );
+                    List<AllocationPartition> hotPartitionsAfterChange = Catalog.snapshot().alloc().getPartitionsFromGroup( updatedProperty.getHotPartitionGroupId() );
                     assertTrue( hotPartitionsAfterChange.stream().map( p -> p.id ).toList().contains( targetId ) );
 
                     //Todo @Hennlo check number of access

--- a/plugins/cypher-language/src/main/java/org/polypheny/db/cypher/pattern/CypherNodePattern.java
+++ b/plugins/cypher-language/src/main/java/org/polypheny/db/cypher/pattern/CypherNodePattern.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.cypher.pattern;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import org.polypheny.db.cypher.expression.CypherExpression;

--- a/plugins/cypher-language/src/main/java/org/polypheny/db/cypher/pattern/CypherNodePattern.java
+++ b/plugins/cypher-language/src/main/java/org/polypheny/db/cypher/pattern/CypherNodePattern.java
@@ -46,7 +46,7 @@ public class CypherNodePattern extends CypherPattern {
     public CypherNodePattern( ParserPos pos, CypherVariable variable, List<StringPos> labels, CypherExpression properties, CypherExpression predicate ) {
         super( pos );
         this.variable = variable;
-        this.labels = PolyList.copyOf( labels.stream().map( StringPos::getImage ).map( PolyString::of ).collect( Collectors.toList() ) );
+        this.labels = PolyList.copyOf( labels.stream().map( StringPos::getImage ).map( PolyString::of ).toList() );
         this.positions = labels.stream().map( StringPos::getPos ).toList();
         this.properties = properties;
         this.predicate = predicate;

--- a/plugins/mongodb-adapter/src/main/java/org/polypheny/db/adapter/mongodb/MongoEntity.java
+++ b/plugins/mongodb-adapter/src/main/java/org/polypheny/db/adapter/mongodb/MongoEntity.java
@@ -323,12 +323,6 @@ public class MongoEntity extends PhysicalEntity implements TranslatableEntity, M
 
 
     @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
-    }
-
-
-    @Override
     public Expression asExpression() {
         return Expressions.call(
                 Expressions.convert_(

--- a/plugins/mongodb-adapter/src/main/java/org/polypheny/db/adapter/mongodb/rules/MongoFilter.java
+++ b/plugins/mongodb-adapter/src/main/java/org/polypheny/db/adapter/mongodb/rules/MongoFilter.java
@@ -406,7 +406,7 @@ public class MongoFilter extends Filter implements MongoAlg {
             /*shallowCopy.put( "$not", new BsonArray(
                     List.of( new BsonDocument(
                             this.map.entrySet().stream().map( e -> new BsonElement( e.getKey(), new BsonArray( e.getValue() ) ) )
-                                    .collect( Collectors.toList() ) ) ) ) );*/
+                                    .toList() ) ) ) );*/
             //mergeMaps( this.map, shallowCopy, "$not" );
             //this.map = shallowCopy;
 
@@ -630,11 +630,11 @@ public class MongoFilter extends Filter implements MongoAlg {
             String key = MongoRules.translateDocValueAsKey( rowType, node.operands.get( 0 ).unwrap( RexNameRef.class ).orElseThrow() );
 
             if ( node.operands.get( 1 ).unwrap( RexCall.class ).isPresent() ) {
-                List<BsonValue> types = ((RexCall) node.operands.get( 1 )).operands
+                List<BsonInt32> types = ((RexCall) node.operands.get( 1 )).operands
                         .stream()
                         .map( el -> ((RexLiteral) el).value.asNumber().intValue() )
                         .map( BsonInt32::new )
-                        .collect( Collectors.toList() );
+                        .toList();
                 attachCondition( "$type", key, new BsonArray( types ) );
             } else if ( node.operands.get( 1 ).isA( Kind.DYNAMIC_PARAM ) ) {
                 attachCondition( "$type", key, new BsonDynamic( (RexDynamicParam) node.operands.get( 1 ) ) );
@@ -955,7 +955,7 @@ public class MongoFilter extends Filter implements MongoAlg {
                 } else {
                     throw new GenericRuntimeException( "Input in array is not translatable." );
                 }
-            } ).collect( Collectors.toList() ) );
+            } ).toList() );
             if ( right.op.getKind() == Kind.CAST ) {
                 if ( array.size() == 1 ) {
                     return (BsonDocument) array.get( 0 );
@@ -977,7 +977,7 @@ public class MongoFilter extends Filter implements MongoAlg {
         private BsonValue getOperation( Operator op, ImmutableList<RexNode> operands ) {
             String operator = getOp( op );
 
-            return new BsonDocument( operator, new BsonArray( operands.stream().map( this::getSingle ).collect( Collectors.toList() ) ) );
+            return new BsonDocument( operator, new BsonArray( operands.stream().map( this::getSingle ).toList() ) );
 
         }
 

--- a/plugins/mongodb-adapter/src/main/java/org/polypheny/db/adapter/mongodb/util/MongoDynamic.java
+++ b/plugins/mongodb-adapter/src/main/java/org/polypheny/db/adapter/mongodb/util/MongoDynamic.java
@@ -405,7 +405,7 @@ public class MongoDynamic {
 
         @Override
         public List<Document> getAll( List<Map<Long, PolyValue>> parameterValues ) {
-            return parameterValues.stream().flatMap( e -> e.values().stream().map( polyValue -> Document.parse( polyValue.asDocument().toJson() ) ) ).collect( Collectors.toList() );
+            return parameterValues.stream().flatMap( e -> e.values().stream().map( polyValue -> Document.parse( polyValue.asDocument().toJson() ) ) ).toList();
         }
 
 

--- a/plugins/mql-language/src/main/codegen/DocumentParser.jj
+++ b/plugins/mql-language/src/main/codegen/DocumentParser.jj
@@ -154,8 +154,6 @@ TOKEN : /* IDENTIFIERS */ // for nested documentValues check out Document_Splits
 |
 < STORE: "store" >
 |
-< SHOWDB: ("show dbs" | "show databases") >
-|
 < REPLACE_ONE: "replaceOne" >
 |
 < FIND: "find" >

--- a/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/MqlFindAndModify.java
+++ b/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/MqlFindAndModify.java
@@ -24,29 +24,19 @@ import org.polypheny.db.languages.ParserPos;
 import org.polypheny.db.languages.mql.Mql.Type;
 
 
+@Getter
 public class MqlFindAndModify extends MqlCollectionStatement implements MqlQueryStatement {
 
-    @Getter
     private final BsonDocument query;
-    @Getter
     private final BsonDocument sort;
-    @Getter
     private final boolean remove;
-    @Getter
     private final BsonDocument update;
-    @Getter
     private final boolean newKey;
-    @Getter
     private final BsonDocument fields;
-    @Getter
     private final boolean upsert;
-    @Getter
     private final boolean bypassDocumentValidation;
-    @Getter
     private final BsonDocument collation;
-    @Getter
     private final BsonArray arrayFilters;
-    @Getter
     private final BsonDocument let;
 
 

--- a/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/parser/MqlParser.java
+++ b/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/parser/MqlParser.java
@@ -98,9 +98,9 @@ public class MqlParser implements Parser {
 
 
     /**
-     * Parses an SQL statement.
+     * Parses an MQL statement.
      *
-     * @return top-level SqlNode representing stmt
+     * @return top-level MqlNode representing stmt
      */
     public MqlNode parseStmt() throws NodeParseException {
         return parseQuery();
@@ -116,7 +116,7 @@ public class MqlParser implements Parser {
 
 
     /**
-     * Interface to define the configuration for a SQL parser.
+     * Interface to define the configuration for a MQL parser.
      *
      * @see ConfigBuilder
      */

--- a/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/parser/MqlParser.java
+++ b/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/parser/MqlParser.java
@@ -159,7 +159,7 @@ public class MqlParser implements Parser {
      * Implementation of {@link MqlParserConfig}.
      * Called by builder; all values are in private final fields.
      */
-    private record ConfigImpl(ParserFactory parserFactory) implements MqlParserConfig {
+    private record ConfigImpl( ParserFactory parserFactory ) implements MqlParserConfig {
 
         private ConfigImpl( ParserFactory parserFactory ) {
             this.parserFactory = Objects.requireNonNull( parserFactory );

--- a/plugins/mql-language/src/test/java/org/polypheny/db/mql/mql2alg/MqlMockCatalog.java
+++ b/plugins/mql-language/src/test/java/org/polypheny/db/mql/mql2alg/MqlMockCatalog.java
@@ -42,7 +42,7 @@ public class MqlMockCatalog extends MockCatalog {
 
 
     @Override
-    public <S extends AdapterCatalog> Optional<S> getAdapterCatalog( long id ) {
+    public Optional<AdapterCatalog> getAdapterCatalog( long id ) {
         return Optional.empty();
     }
 

--- a/plugins/neo4j-adapter/src/main/java/org/polypheny/db/adapter/neo4j/NeoEntity.java
+++ b/plugins/neo4j-adapter/src/main/java/org/polypheny/db/adapter/neo4j/NeoEntity.java
@@ -120,12 +120,6 @@ public class NeoEntity extends PhysicalEntity implements TranslatableEntity, Mod
 
 
     @Override
-    public PolyValue[] getParameterArray() {
-        return new PolyValue[0];
-    }
-
-
-    @Override
     public Expression asExpression() {
         return Expressions.call(
                 Expressions.convert_(

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
@@ -189,6 +189,8 @@ class PIService {
                     break;
                 }
             }
+        } catch ( EOFException e ) {
+            throw e;
         } catch ( Throwable t ) {
             if ( t.getCause() instanceof PIServiceException p && p.getCause() instanceof EOFException eof ) {
                 throw eof;

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
@@ -19,6 +19,7 @@ package org.polypheny.db.prisminterface;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import lombok.extern.slf4j.Slf4j;
@@ -163,7 +164,7 @@ class PIService {
         try {
             r = handleMessage( req );
         } catch ( Throwable t ) {
-            r = createErrorResponse( req.getId(), t.getMessage() );
+            r = createErrorResponse( req.getId(), Objects.requireNonNullElse( t.getMessage(), t.getClass().getSimpleName() ) );
         }
         try {
             sendOneMessage( r );

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/relational/RelationalMetaRetriever.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/relational/RelationalMetaRetriever.java
@@ -48,7 +48,7 @@ public class RelationalMetaRetriever {
     public static List<ParameterMeta> retrieveParameterMetas( AlgDataType parameterRowType ) {
         return parameterRowType.getFields().stream()
                 .map( p -> retrieveParameterMeta( p, null ) )
-                .collect( Collectors.toList() );
+                .toList();
     }
 
 
@@ -150,7 +150,7 @@ public class RelationalMetaRetriever {
                         .getFields()
                         .stream()
                         .map( f -> retrieveFieldMeta( f.getIndex(), f.getName(), f.getType() ) )
-                        .collect( Collectors.toList() );
+                        .toList();
                 return TypeMeta.newBuilder()
                         .setStructMeta( StructMeta.newBuilder().addAllFieldMetas( fieldMetas ).build() )
                         //.setProtoValueType( ProtoValueType.PROTO_VALUE_TYPE_STRUCTURED )

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/relational/RelationalMetaRetriever.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/relational/RelationalMetaRetriever.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Ord;
 import org.polypheny.db.PolyImplementation;
 import org.polypheny.db.adapter.java.JavaTypeFactory;

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statementProcessing/DocumentExecutor.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statementProcessing/DocumentExecutor.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.prisminterface.statementProcessing;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.StopWatch;
 import org.polypheny.db.PolyImplementation;
 import org.polypheny.db.ResultIterator;

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statementProcessing/DocumentExecutor.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statementProcessing/DocumentExecutor.java
@@ -139,7 +139,7 @@ public class DocumentExecutor extends Executor {
             );
         }
         startOrResumeStopwatch( executionStopWatch );
-        List<PolyValue> data = iterator.getNextBatch( fetchSize ).stream().map( p -> p.get( 0 ) ).collect( Collectors.toList() );
+        List<PolyValue> data = iterator.getNextBatch( fetchSize ).stream().map( p -> p.get( 0 ) ).toList();
         executionStopWatch.stop();
         return PrismUtils.buildDocumentFrame( !iterator.hasMoreRows(), data );
     }

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedIndexedStatement.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedIndexedStatement.java
@@ -164,7 +164,9 @@ public class PIPreparedIndexedStatement extends PIPreparedStatement {
 
     @Override
     public void close() {
-        statement.close();
+        if ( statement != null ) {
+            statement.close();
+        }
         closeResults();
     }
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/StatementManager.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/StatementManager.java
@@ -87,7 +87,7 @@ public class StatementManager {
     public PIUnparameterizedStatementBatch createUnparameterizedStatementBatch( List<ExecuteUnparameterizedStatementRequest> statements ) {
         List<PIUnparameterizedStatement> PIUnparameterizedStatements = statements.stream()
                 .map( this::createUnparameterizedStatement )
-                .collect( Collectors.toList() );
+                .toList();
         final int batchId = statementIdGenerator.getAndIncrement();
         final PIUnparameterizedStatementBatch batch = new PIUnparameterizedStatementBatch( batchId, client, PIUnparameterizedStatements );
         openUnparameterizedBatches.put( batchId, batch );

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PolyValueSerializer.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PolyValueSerializer.java
@@ -19,7 +19,6 @@ package org.polypheny.db.prisminterface.utils;
 import com.google.protobuf.ByteString;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
 import org.polypheny.db.type.entity.PolyBinary;
 import org.polypheny.db.type.entity.PolyBoolean;

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PolyValueSerializer.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PolyValueSerializer.java
@@ -60,12 +60,12 @@ public class PolyValueSerializer {
 
 
     public static List<ProtoValue> serializeList( List<PolyValue> valuesList ) {
-        return valuesList.stream().map( PolyValueSerializer::serialize ).collect( Collectors.toList() );
+        return valuesList.stream().map( PolyValueSerializer::serialize ).toList();
     }
 
 
     public static List<ProtoEntry> serializeToProtoEntryList( PolyMap<PolyValue, PolyValue> polyMap ) {
-        return polyMap.entrySet().stream().map( PolyValueSerializer::serializeToProtoEntry ).collect( Collectors.toList() );
+        return polyMap.entrySet().stream().map( PolyValueSerializer::serializeToProtoEntry ).toList();
     }
 
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismUtils.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismUtils.java
@@ -82,7 +82,7 @@ public class PrismUtils {
 
 
     public static List<Row> serializeToRows( List<List<PolyValue>> rows ) {
-        return rows.stream().map( PrismUtils::serializeToRow ).collect( Collectors.toList() );
+        return rows.stream().map( PrismUtils::serializeToRow ).toList();
     }
 
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismUtils.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismUtils.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.prisminterface.utils;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.prisminterface.statements.PIPreparedStatement;
 import org.polypheny.db.prisminterface.statements.PIStatement;

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismValueDeserializer.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismValueDeserializer.java
@@ -50,7 +50,7 @@ public class PrismValueDeserializer {
     public static List<List<PolyValue>> deserializeParameterLists( List<IndexedParameters> parameterListsList ) {
         return transpose( parameterListsList.stream()
                 .map( parameterList -> deserializeParameterList( parameterList.getParametersList() ) )
-                .collect( Collectors.toList() ) );
+                .toList() );
     }
 
 
@@ -69,7 +69,7 @@ public class PrismValueDeserializer {
 
 
     public static List<PolyValue> deserializeParameterList( List<ProtoValue> valuesList ) {
-        return valuesList.stream().map( PrismValueDeserializer::deserializeProtoValue ).collect( Collectors.toList() );
+        return valuesList.stream().map( PrismValueDeserializer::deserializeProtoValue ).toList();
     }
 
 
@@ -123,7 +123,7 @@ public class PrismValueDeserializer {
     private static PolyValue deserializeToPolyList( ProtoValue protoValue ) {
         List<PolyValue> values = protoValue.getList().getValuesList().stream()
                 .map( PrismValueDeserializer::deserializeProtoValue )
-                .collect( Collectors.toList() );
+                .toList();
         return new PolyList<>( values );
     }
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismValueDeserializer.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismValueDeserializer.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.type.entity.PolyBinary;
 import org.polypheny.db.type.entity.PolyBoolean;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlArrayLiteral.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlArrayLiteral.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.sql.language;
 
-import java.util.stream.Collectors;
 import org.polypheny.db.algebra.type.AlgDataType;
 import org.polypheny.db.languages.ParserPos;
 import org.polypheny.db.sql.language.SqlWriter.Frame;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlArrayLiteral.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlArrayLiteral.java
@@ -46,7 +46,7 @@ public class SqlArrayLiteral extends SqlLiteral {
         }
         if ( PolyTypeFamily.NUMERIC == component.getPolyType().getFamily() ) {
             AlgDataType finalComponent = component;
-            return PolyList.copyOf( list.stream().map( a -> adjustGeneric( a, finalComponent ) ).collect( Collectors.toList() ) );
+            return PolyList.copyOf( list.stream().map( a -> adjustGeneric( a, finalComponent ) ).toList() );
         }
         return list;
     }
@@ -54,7 +54,7 @@ public class SqlArrayLiteral extends SqlLiteral {
 
     private static PolyValue adjustGeneric( PolyValue value, AlgDataType component ) {
         if ( value.isList() ) {
-            return PolyList.copyOf( value.asList().stream().map( e -> adjustGeneric( e, component ) ).collect( Collectors.toList() ) );
+            return PolyList.copyOf( value.asList().stream().map( e -> adjustGeneric( e, component ) ).toList() );
         }
         return PolyValue.convert( value, component.getPolyType() );
     }

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlCallBinding.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlCallBinding.java
@@ -122,7 +122,7 @@ public class SqlCallBinding extends SqlOperatorBinding implements CallBinding {
 
 
     public List<SqlNode> sqlOperands() {
-        return operands().stream().map( e -> (SqlNode) e ).collect( Collectors.toList() );
+        return operands().stream().map( e -> (SqlNode) e ).toList();
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDdl.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDdl.java
@@ -22,7 +22,6 @@ import static org.polypheny.db.util.Static.RESOURCE;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.polypheny.db.adapter.Adapter;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDdl.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDdl.java
@@ -110,7 +110,7 @@ public abstract class SqlDdl extends SqlCall {
     protected List<LogicalColumn> getColumns( Context context, long tableId, SqlNodeList columns ) {
         return columns.getList().stream()
                 .map( c -> getColumn( context, tableId, (SqlIdentifier) c ) )
-                .collect( Collectors.toList() );
+                .toList();
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlSetOption.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlSetOption.java
@@ -141,7 +141,7 @@ public class SqlSetOption extends SqlAlter {
 
     @Override
     public List<SqlNode> getSqlOperandList() {
-        return getOperandList().stream().map( e -> (SqlNode) e ).collect( Collectors.toList() );
+        return getOperandList().stream().map( e -> (SqlNode) e ).toList();
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlSetOption.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlSetOption.java
@@ -19,7 +19,6 @@ package org.polypheny.db.sql.language;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import org.polypheny.db.algebra.constant.Kind;
 import org.polypheny.db.ddl.DdlManager;
@@ -218,4 +217,3 @@ public class SqlSetOption extends SqlAlter {
     }
 
 }
-

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateTable.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateTable.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateTable.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateTable.java
@@ -257,7 +257,7 @@ public class SqlCreateTable extends SqlCreate implements ExecutableStatement {
                                 getTableFailOnEmpty( context, new SqlIdentifier( tableName, ParserPos.ZERO ) ),
                                 partitionType.getSimple(),
                                 partitionColumn.getSimple(),
-                                partitionGroupNamesList.stream().map( n -> (Identifier) n ).collect( Collectors.toList() ),
+                                partitionGroupNamesList.stream().map( n -> (Identifier) n ).toList(),
                                 numPartitionGroups,
                                 numPartitions,
                                 partitionQualifierList.stream().map( l -> l.stream().map( e -> (Node) e ).toList() ).toList(),
@@ -313,13 +313,13 @@ public class SqlCreateTable extends SqlCreate implements ExecutableStatement {
                     constraint.getConstraintType(),
                     constraint.getFields().getSqlList().stream()
                             .map( SqlNode::toString )
-                            .collect( Collectors.toList() ) );
+                            .toList() );
             case FOREIGN -> new ConstraintInformation(
                     constraintName,
                     constraint.getConstraintType(),
                     constraint.getFields().getSqlList().stream()
                             .map( SqlNode::toString )
-                            .collect( Collectors.toList() ),
+                            .toList(),
                     ((SqlForeignKeyConstraint) constraint).getReferencedEntity().toString(),
                     ((SqlForeignKeyConstraint) constraint).getReferencedField().toString() );
         };

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddIndex.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddIndex.java
@@ -21,7 +21,6 @@ import static org.polypheny.db.util.Static.RESOURCE;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.polypheny.db.adapter.DataStore;
 import org.polypheny.db.adapter.index.IndexManager;
 import org.polypheny.db.catalog.entity.logical.LogicalTable;
@@ -155,4 +154,3 @@ public class SqlAlterTableAddIndex extends SqlAlterTable {
     }
 
 }
-

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddIndex.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddIndex.java
@@ -126,7 +126,7 @@ public class SqlAlterTableAddIndex extends SqlAlterTable {
                 DdlManager.getInstance().createPolyphenyIndex(
                         logicalTable,
                         indexMethodName,
-                        columnList.getList().stream().map( Node::toString ).collect( Collectors.toList() ),
+                        columnList.getList().stream().map( Node::toString ).toList(),
                         indexName.getSimple(),
                         unique,
                         statement );

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPartitions.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPartitions.java
@@ -150,7 +150,7 @@ public class SqlAlterTableAddPartitions extends SqlAlterTable {
                                 table,
                                 partitionType.getSimple(),
                                 partitionColumn.getSimple(),
-                                partitionGroupNamesList.stream().map( n -> (Identifier) n ).collect( Collectors.toList() ),
+                                partitionGroupNamesList.stream().map( n -> (Identifier) n ).toList(),
                                 numPartitionGroups,
                                 numPartitions,
                                 partitionQualifierList.stream().map( l -> l.stream().map( e -> (Node) e ).toList() ).toList(),

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPartitions.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPartitions.java
@@ -19,7 +19,6 @@ package org.polypheny.db.sql.language.ddl.altertable;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.logical.LogicalTable;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPrimaryKey.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPrimaryKey.java
@@ -19,7 +19,6 @@ package org.polypheny.db.sql.language.ddl.altertable;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.polypheny.db.catalog.entity.logical.LogicalTable;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.catalog.logistic.EntityType;
@@ -93,4 +92,3 @@ public class SqlAlterTableAddPrimaryKey extends SqlAlterTable {
     }
 
 }
-

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPrimaryKey.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddPrimaryKey.java
@@ -87,7 +87,7 @@ public class SqlAlterTableAddPrimaryKey extends SqlAlterTable {
 
         DdlManager.getInstance().createPrimaryKey(
                 logicalTable,
-                columnList.getList().stream().map( Node::toString ).collect( Collectors.toList() ),
+                columnList.getList().stream().map( Node::toString ).toList(),
                 statement );
 
     }

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacement.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacement.java
@@ -140,7 +140,7 @@ public class SqlAlterTableModifyPlacement extends SqlAlterTable {
 
         DdlManager.getInstance().modifyPlacement(
                 table,
-                getColumns( context, table.id, columns ).stream().map( c -> c.id ).collect( Collectors.toList() ),
+                getColumns( context, table.id, columns ).stream().map( c -> c.id ).toList(),
                 partitionGroups,
                 partitionGroupNames.stream()
                         .map( SqlIdentifier::toString )

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacement.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableModifyPlacement.java
@@ -20,7 +20,6 @@ package org.polypheny.db.sql.language.ddl.altertable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/util/SqlTypeUtil.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/util/SqlTypeUtil.java
@@ -503,7 +503,7 @@ public class SqlTypeUtil {
 
 
     private static List<AlgDataType> toSql( final AlgDataTypeFactory typeFactory, List<AlgDataType> types ) {
-        return types.stream().map( type -> toSql( typeFactory, type ) ).collect( Collectors.toList() );
+        return types.stream().map( type -> toSql( typeFactory, type ) ).toList();
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/util/SqlTypeUtil.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/util/SqlTypeUtil.java
@@ -20,7 +20,6 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
-import java.util.stream.Collectors;
 import org.polypheny.db.adapter.java.JavaTypeFactory;
 import org.polypheny.db.algebra.AlgNode;
 import org.polypheny.db.algebra.constant.FunctionCategory;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/ListScope.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/ListScope.java
@@ -74,7 +74,7 @@ public abstract class ListScope extends DelegatingScope {
      * @return list of child namespaces
      */
     public List<SqlValidatorNamespace> getChildren() {
-        return children.stream().map( scopeChild -> scopeChild.namespace ).collect( Collectors.toList() );
+        return children.stream().map( scopeChild -> scopeChild.namespace ).toList();
     }
 
 
@@ -84,7 +84,7 @@ public abstract class ListScope extends DelegatingScope {
      * @return list of child namespaces
      */
     List<String> getChildNames() {
-        return children.stream().map( scopeChild -> scopeChild.name ).collect( Collectors.toList() );
+        return children.stream().map( scopeChild -> scopeChild.name ).toList();
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/ListScope.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/ListScope.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.polypheny.db.algebra.constant.MonikerType;
 import org.polypheny.db.algebra.type.AlgDataType;
 import org.polypheny.db.algebra.type.AlgDataTypeField;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorImpl.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorImpl.java
@@ -42,7 +42,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorImpl.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorImpl.java
@@ -4943,9 +4943,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
                     }
                 } );
         return typeFactory.createStructType(
-                types.stream().map( t -> (Long) null ).collect( Collectors.toList() ),
+                types.stream().map( t -> (Long) null ).toList(),
                 types,
-                IntStream.range( 0, types.size() ).mapToObj( i -> "?" + i ).collect( Collectors.toList() ) );
+                IntStream.range( 0, types.size() ).mapToObj( i -> "?" + i ).toList() );
     }
 
 
@@ -5907,7 +5907,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
                         final AlgDataTypeField f2 = right.field( name );
                         final ImmutableList<Integer> source2 = right.sources.get( f2.getIndex() );
                         sourceSet.add( source2 );
-                        sources.add( ImmutableList.copyOf( Stream.concat( source.stream(), source2.stream() ).collect( Collectors.toList() ) ) );
+                        sources.add( ImmutableList.copyOf( Stream.concat( source.stream(), source2.stream() ).toList() ) );
                         final boolean nullable =
                                 (f.getType().isNullable()
                                         || join.getJoinType().generatesNullsOnLeft())

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorScope.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorScope.java
@@ -238,7 +238,7 @@ public interface SqlValidatorScope extends ValidatorScope {
          * Returns a list ["step1", "step2"].
          */
         List<String> stepNames() {
-            return steps().stream().map( input -> input.name ).collect( Collectors.toList() );
+            return steps().stream().map( input -> input.name ).toList();
         }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorScope.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorScope.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.polypheny.db.algebra.constant.Monotonicity;
 import org.polypheny.db.algebra.type.AlgDataType;
 import org.polypheny.db.algebra.type.StructKind;
@@ -339,9 +338,7 @@ public interface SqlValidatorScope extends ValidatorScope {
 
     }
 
-    /**
-     * A match found when looking up a name.
-     */
+
     /**
      * A match found when looking up a name.
      */
@@ -382,4 +379,3 @@ public interface SqlValidatorScope extends ValidatorScope {
     }
 
 }
-

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorUtil.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorUtil.java
@@ -171,7 +171,7 @@ public class SqlValidatorUtil {
      * Checks that there are no duplicates in a list of {@link SqlIdentifier}.
      */
     public static void checkIdentifierListForDuplicates( List<SqlNode> columnList, SqlValidatorImpl.ValidationErrorFunction validationErrorFunction ) {
-        final List<List<String>> names = columnList.stream().map( o -> ((SqlIdentifier) o).names ).collect( Collectors.toList() );
+        final List<ImmutableList<String>> names = columnList.stream().map( o -> ((SqlIdentifier) o).names ).toList();
         final int i = Util.firstDuplicate( names );
         if ( i >= 0 ) {
             throw validationErrorFunction.apply( columnList.get( i ), Static.RESOURCE.duplicateNameInColumnList( Util.last( names.get( i ) ) ) );

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorUtil.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/SqlValidatorUtil.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.linq4j.Ord;
 import org.polypheny.db.algebra.constant.Kind;
@@ -611,4 +610,3 @@ public class SqlValidatorUtil {
     }
 
 }
-

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/sql2alg/SqlToAlgConverter.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/sql2alg/SqlToAlgConverter.java
@@ -1264,7 +1264,7 @@ public class SqlToAlgConverter implements NodeToAlgConverter {
                                         pair.left,
                                         ensureSqlType(
                                                 pair.left.getType(),
-                                                bb.convertExpression( pair.right ) ) ) ).collect( Collectors.toList() ) );
+                                                bb.convertExpression( pair.right ) ) ) ).toList() );
             }
             comparisons.add( rexComparison );
         }
@@ -4472,7 +4472,7 @@ public class SqlToAlgConverter implements NodeToAlgConverter {
                                                 lookupOrCreateGroupExpr( fieldCollation.left ),
                                                 fieldCollation.getDirection(),
                                                 fieldCollation.getNullDirection() ) )
-                                .collect( Collectors.toList() ) );
+                                .toList() );
             }
 
             final AggregateCall aggCall =

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/sql2alg/SqlToAlgConverter.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/sql2alg/SqlToAlgConverter.java
@@ -60,7 +60,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import lombok.Getter;

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -2224,7 +2224,7 @@ public class Crud implements InformationObserver, PropertyChangeListener {
     }
 
 
-    void addQueryInterface( final Context ctx ) {
+    void createQueryInterface( final Context ctx ) {
         QueryInterfaceInformationRequest request = ctx.bodyAsClass( QueryInterfaceInformationRequest.class );
         try {
             QueryInterfaceManager.getInstance().createQueryInterface( request.interfaceName(), request.uniqueName(), request.currentSettings() );

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -2645,7 +2645,7 @@ public class Crud implements InformationObserver, PropertyChangeListener {
      * Get all supported data types of the DBMS.
      */
     public void getTypeInfo( final Context ctx ) {
-        ctx.json( PolyType.allowedFieldTypes().stream().map( PolyTypeModel::from ).collect( Collectors.toList() ) );
+        ctx.json( PolyType.allowedFieldTypes().stream().map( PolyTypeModel::from ).toList() );
     }
 
 

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -2227,7 +2227,7 @@ public class Crud implements InformationObserver, PropertyChangeListener {
     void createQueryInterface( final Context ctx ) {
         QueryInterfaceCreateRequest request = ctx.bodyAsClass( QueryInterfaceCreateRequest.class );
         try {
-            QueryInterfaceManager.getInstance().createQueryInterface( request.interfaceName(), request.uniqueName(), request.currentSettings() );
+            QueryInterfaceManager.getInstance().createQueryInterface( request.interfaceType(), request.uniqueName(), request.currentSettings() );
             ctx.status( 200 );
         } catch ( RuntimeException e ) {
             log.error( "Exception while deploying query interface", e );

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -2227,7 +2227,7 @@ public class Crud implements InformationObserver, PropertyChangeListener {
     void createQueryInterface( final Context ctx ) {
         QueryInterfaceCreateRequest request = ctx.bodyAsClass( QueryInterfaceCreateRequest.class );
         try {
-            QueryInterfaceManager.getInstance().createQueryInterface( request.interfaceType(), request.uniqueName(), request.currentSettings() );
+            QueryInterfaceManager.getInstance().createQueryInterface( request.interfaceType(), request.uniqueName(), request.settings() );
             ctx.status( 200 );
         } catch ( RuntimeException e ) {
             log.error( "Exception while deploying query interface", e );

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -140,7 +140,7 @@ import org.polypheny.db.docker.models.InstancesAndAutoDocker;
 import org.polypheny.db.docker.models.UpdateDockerRequest;
 import org.polypheny.db.iface.QueryInterface;
 import org.polypheny.db.iface.QueryInterfaceManager;
-import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceInformationRequest;
+import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceCreateRequest;
 import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 import org.polypheny.db.information.InformationGroup;
 import org.polypheny.db.information.InformationManager;
@@ -2225,7 +2225,7 @@ public class Crud implements InformationObserver, PropertyChangeListener {
 
 
     void createQueryInterface( final Context ctx ) {
-        QueryInterfaceInformationRequest request = ctx.bodyAsClass( QueryInterfaceInformationRequest.class );
+        QueryInterfaceCreateRequest request = ctx.bodyAsClass( QueryInterfaceCreateRequest.class );
         try {
             QueryInterfaceManager.getInstance().createQueryInterface( request.interfaceName(), request.uniqueName(), request.currentSettings() );
             ctx.status( 200 );

--- a/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
+++ b/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
@@ -274,7 +274,7 @@ public class HttpServer implements Runnable {
 
         webuiServer.get( "/getAvailableQueryInterfaces", crud::getAvailableQueryInterfaces );
 
-        webuiServer.post( "/createQueryInterface", crud::addQueryInterface );
+        webuiServer.post( "/createQueryInterface", crud::createQueryInterface );
 
         webuiServer.post( "/updateQueryInterfaceSettings", crud::updateQueryInterfaceSettings );
 


### PR DESCRIPTION
## Summary

Until now Polypheny used the port 7659 to determine if another instance is running and would then refuse to start.  This approach fails to detect instances using other ports.  This is especially a problem, if one of these instances were to use the same home directory.  So to prevent this, create a `.lock` file in the home directory and lock it using facilities provided by the operating system.  This way each home directory can only be used by one instance at a time.

There are also various other small improvements.

There is also a corresponding [UI PR](https://github.com/polypheny/Polypheny-UI/pull/97) because a field is renamed.