### PR TITLE
Serialize catalog with JSON

### DIFF
--- a/core/src/main/java/org/polypheny/db/catalog/Catalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/Catalog.java
@@ -109,6 +109,8 @@ public abstract class Catalog implements ExtensionPoint {
 
     public abstract void change();
 
+    public abstract String getJson();
+
     public abstract void executeCommitActions();
 
     public abstract void clearCommitActions();

--- a/core/src/main/java/org/polypheny/db/catalog/Catalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/Catalog.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
@@ -68,7 +69,9 @@ public abstract class Catalog implements ExtensionPoint {
 
     protected static List<Runnable> afterInit = new ArrayList<>();
 
+    @JsonIgnore
     protected final PropertyChangeSupport listeners = new PropertyChangeSupport( this );
+    @JsonIgnore
     public boolean isPersistent = false;
     private static Catalog INSTANCE = null;
     public static boolean resetCatalog;

--- a/core/src/main/java/org/polypheny/db/catalog/Catalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/Catalog.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog;
 
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
@@ -69,9 +68,7 @@ public abstract class Catalog implements ExtensionPoint {
 
     protected static List<Runnable> afterInit = new ArrayList<>();
 
-    @JsonIgnore
     protected final PropertyChangeSupport listeners = new PropertyChangeSupport( this );
-    @JsonIgnore
     public boolean isPersistent = false;
     private static Catalog INSTANCE = null;
     public static boolean resetCatalog;

--- a/core/src/main/java/org/polypheny/db/catalog/IdBuilder.java
+++ b/core/src/main/java/org/polypheny/db/catalog/IdBuilder.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.util.concurrent.atomic.AtomicLong;
@@ -25,48 +26,63 @@ import lombok.Value;
 public class IdBuilder {
 
     @Serialize
+    @JsonProperty
     public AtomicLong snapshotId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong entityId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong physicalId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong allocId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong fieldId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong userId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong indexId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong keyId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong adapterId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong adapterTemplateId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong interfaceId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong constraintId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong groupId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong partitionId;
 
     @Serialize
+    @JsonProperty
     public AtomicLong placementId;
 
     private static IdBuilder INSTANCE;

--- a/core/src/main/java/org/polypheny/db/catalog/IdBuilder.java
+++ b/core/src/main/java/org/polypheny/db/catalog/IdBuilder.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,63 +25,48 @@ import lombok.Value;
 public class IdBuilder {
 
     @Serialize
-    @JsonProperty
     public AtomicLong snapshotId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong entityId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong physicalId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong allocId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong fieldId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong userId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong indexId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong keyId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong adapterId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong adapterTemplateId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong interfaceId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong constraintId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong groupId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong partitionId;
 
     @Serialize
-    @JsonProperty
     public AtomicLong placementId;
 
     private static IdBuilder INSTANCE;

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/AdapterCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/AdapterCatalog.java
@@ -17,6 +17,8 @@
 package org.polypheny.db.catalog.catalogs;
 
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeClass;
 import java.util.Arrays;
@@ -45,6 +47,7 @@ import org.polypheny.db.util.Pair;
 @NonFinal
 @Slf4j
 @SerializeClass(subclasses = { DocAdapterCatalog.class, RelAdapterCatalog.class, GraphAdapterCatalog.class })
+@JsonTypeInfo(use = Id.CLASS)
 public abstract class AdapterCatalog {
 
     @Serialize

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/AllocationCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/AllocationCatalog.java
@@ -16,6 +16,8 @@
 
 package org.polypheny.db.catalog.catalogs;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.SerializeClass;
 import java.util.concurrent.ConcurrentHashMap;
 import org.polypheny.db.catalog.entity.allocation.AllocationPartition;
@@ -27,6 +29,7 @@ import org.polypheny.db.catalog.impl.allocation.PolyAllocRelCatalog;
 import org.polypheny.db.util.Wrapper;
 
 @SerializeClass(subclasses = { PolyAllocDocCatalog.class, PolyAllocGraphCatalog.class, PolyAllocRelCatalog.class })
+@JsonTypeInfo( use = Id.CLASS )
 public interface AllocationCatalog extends Wrapper {
 
     LogicalNamespace getNamespace();

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/LogicalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/LogicalCatalog.java
@@ -16,6 +16,8 @@
 
 package org.polypheny.db.catalog.catalogs;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.SerializeClass;
 import org.polypheny.db.catalog.entity.logical.LogicalNamespace;
 import org.polypheny.db.catalog.impl.logical.DocumentCatalog;
@@ -27,6 +29,7 @@ import org.polypheny.db.catalog.impl.logical.RelationalCatalog;
         RelationalCatalog.class,
         DocumentCatalog.class,
         GraphCatalog.class })
+@JsonTypeInfo(use = Id.CLASS)
 public interface LogicalCatalog {
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
@@ -47,27 +47,21 @@ import org.polypheny.db.util.Wrapper;
 public abstract class Entity implements PolyObject, Wrapper, Serializable, CatalogType, Expressible, Typed, Comparable<Entity> {
 
     @Serialize
-    @JsonProperty
     public long id;
 
     @Serialize
-    @JsonProperty
     public EntityType entityType;
 
     @Serialize
-    @JsonProperty
     public DataModel dataModel;
 
     @Serialize
-    @JsonProperty
     public String name;
 
     @Serialize
-    @JsonProperty
     public long namespaceId;
 
     @Serialize
-    @JsonProperty
     public boolean modifiable;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serializable;
 import java.util.List;
@@ -46,21 +47,27 @@ import org.polypheny.db.util.Wrapper;
 public abstract class Entity implements PolyObject, Wrapper, Serializable, CatalogType, Expressible, Typed, Comparable<Entity> {
 
     @Serialize
+    @JsonProperty
     public long id;
 
     @Serialize
+    @JsonProperty
     public EntityType entityType;
 
     @Serialize
+    @JsonProperty
     public DataModel dataModel;
 
     @Serialize
+    @JsonProperty
     public String name;
 
     @Serialize
+    @JsonProperty
     public long namespaceId;
 
     @Serialize
+    @JsonProperty
     public boolean modifiable;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/Entity.java
@@ -47,21 +47,27 @@ import org.polypheny.db.util.Wrapper;
 public abstract class Entity implements PolyObject, Wrapper, Serializable, CatalogType, Expressible, Typed, Comparable<Entity> {
 
     @Serialize
+    @JsonProperty
     public long id;
 
     @Serialize
+    @JsonProperty
     public EntityType entityType;
 
     @Serialize
+    @JsonProperty
     public DataModel dataModel;
 
     @Serialize
+    @JsonProperty
     public String name;
 
     @Serialize
+    @JsonProperty
     public long namespaceId;
 
     @Serialize
+    @JsonProperty
     public boolean modifiable;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalAdapter.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalAdapter.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.entity;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
@@ -37,25 +36,18 @@ public class LogicalAdapter implements PolyObject {
     private static final long serialVersionUID = -6140489767408917639L;
 
     @Serialize
-    @JsonProperty
     public long id;
     @Serialize
-    @JsonProperty
     public String uniqueName;
     @Serialize
-    @JsonProperty
     public String adapterName;
     @Serialize
-    @JsonProperty
     public AdapterType type;
     @Serialize
-    @JsonProperty
     public Map<String, String> settings;
     @Serialize
-    @JsonProperty
     public String adapterTypeName;
     @Serialize
-    @JsonProperty
     public DeployMode mode;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalAdapter.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalAdapter.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.entity;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
@@ -36,18 +37,25 @@ public class LogicalAdapter implements PolyObject {
     private static final long serialVersionUID = -6140489767408917639L;
 
     @Serialize
+    @JsonProperty
     public long id;
     @Serialize
+    @JsonProperty
     public String uniqueName;
     @Serialize
+    @JsonProperty
     public String adapterName;
     @Serialize
+    @JsonProperty
     public AdapterType type;
     @Serialize
+    @JsonProperty
     public Map<String, String> settings;
     @Serialize
+    @JsonProperty
     public String adapterTypeName;
     @Serialize
+    @JsonProperty
     public DeployMode mode;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalConstraint.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalConstraint.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.entity;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serializable;
@@ -32,19 +31,14 @@ import org.polypheny.db.catalog.logistic.ConstraintType;
 public class LogicalConstraint implements Serializable, Comparable<LogicalConstraint> {
 
     @Serialize
-    @JsonProperty
     public long id;
     @Serialize
-    @JsonProperty
     public long keyId;
     @Serialize
-    @JsonProperty
     public ConstraintType type;
     @Serialize
-    @JsonProperty
     public String name;
     @Serialize
-    @JsonProperty
     public LogicalKey key;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalConstraint.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalConstraint.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.entity;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serializable;
@@ -31,14 +32,19 @@ import org.polypheny.db.catalog.logistic.ConstraintType;
 public class LogicalConstraint implements Serializable, Comparable<LogicalConstraint> {
 
     @Serialize
+    @JsonProperty
     public long id;
     @Serialize
+    @JsonProperty
     public long keyId;
     @Serialize
+    @JsonProperty
     public ConstraintType type;
     @Serialize
+    @JsonProperty
     public String name;
     @Serialize
+    @JsonProperty
     public LogicalKey key;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.entity;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -36,16 +35,12 @@ public class LogicalQueryInterface implements PolyObject {
     private static final long serialVersionUID = 7212289724539530050L;
 
     @Serialize
-    @JsonProperty
     public long id;
     @Serialize
-    @JsonProperty
     public String name;
     @Serialize
-    @JsonProperty
     public String interfaceType;
     @Serialize
-    @JsonProperty
     public ImmutableMap<String, String> settings;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalQueryInterface.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.entity;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -35,12 +36,16 @@ public class LogicalQueryInterface implements PolyObject {
     private static final long serialVersionUID = 7212289724539530050L;
 
     @Serialize
+    @JsonProperty
     public long id;
     @Serialize
+    @JsonProperty
     public String name;
     @Serialize
+    @JsonProperty
     public String interfaceType;
     @Serialize
+    @JsonProperty
     public ImmutableMap<String, String> settings;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.entity;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
@@ -30,10 +31,13 @@ public class LogicalUser implements PolyObject, Comparable<LogicalUser> {
     private static final long serialVersionUID = 5022567585804699491L;
 
     @Serialize
+    @JsonProperty
     public long id;
     @Serialize
+    @JsonProperty
     public String name;
     @Serialize
+    @JsonProperty
     public String password;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalUser.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.entity;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
@@ -31,13 +30,10 @@ public class LogicalUser implements PolyObject, Comparable<LogicalUser> {
     private static final long serialVersionUID = 5022567585804699491L;
 
     @Serialize
-    @JsonProperty
     public long id;
     @Serialize
-    @JsonProperty
     public String name;
     @Serialize
-    @JsonProperty
     public String password;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import lombok.NonNull;
@@ -35,18 +36,25 @@ public class AllocationColumn implements PolyObject {
     private static final long serialVersionUID = -1909757888176291095L;
 
     @Serialize
+    @JsonProperty
     public long namespaceId;
     @Serialize
+    @JsonProperty
     public long placementId;
     @Serialize
+    @JsonProperty
     public long logicalTableId;
     @Serialize
+    @JsonProperty
     public long columnId;
     @Serialize
+    @JsonProperty
     public PlacementType placementType;
     @Serialize
+    @JsonProperty
     public int position;
     @Serialize
+    @JsonProperty
     public long adapterId;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationColumn.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import lombok.NonNull;
@@ -36,25 +35,18 @@ public class AllocationColumn implements PolyObject {
     private static final long serialVersionUID = -1909757888176291095L;
 
     @Serialize
-    @JsonProperty
     public long namespaceId;
     @Serialize
-    @JsonProperty
     public long placementId;
     @Serialize
-    @JsonProperty
     public long logicalTableId;
     @Serialize
-    @JsonProperty
     public long columnId;
     @Serialize
-    @JsonProperty
     public PlacementType placementType;
     @Serialize
-    @JsonProperty
     public int position;
     @Serialize
-    @JsonProperty
     public long adapterId;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationEntity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationEntity.java
@@ -16,6 +16,9 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeClass;
 import io.activej.serializer.annotations.SerializeVarLength;
@@ -35,19 +38,24 @@ import org.polypheny.db.catalog.logistic.PartitionType;
 @Slf4j
 @SuperBuilder(toBuilder = true)
 @SerializeClass(subclasses = { AllocationTable.class, AllocationGraph.class, AllocationCollection.class })
+@JsonTypeInfo(use = Id.CLASS)
 public abstract class AllocationEntity extends Entity {
 
     @Serialize
+    @JsonProperty
     public long adapterId;
 
     @Serialize
+    @JsonProperty
     public long logicalId;
 
     @Serialize
+    @JsonProperty
     @SerializeVarLength
     public long partitionId;
 
     @Serialize
+    @JsonProperty
     @SerializeVarLength
     public long placementId;
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationEntity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationEntity.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.Serialize;
@@ -42,20 +41,16 @@ import org.polypheny.db.catalog.logistic.PartitionType;
 public abstract class AllocationEntity extends Entity {
 
     @Serialize
-    @JsonProperty
     public long adapterId;
 
     @Serialize
-    @JsonProperty
     public long logicalId;
 
     @Serialize
-    @JsonProperty
     @SerializeVarLength
     public long partitionId;
 
     @Serialize
-    @JsonProperty
     @SerializeVarLength
     public long placementId;
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationEntity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationEntity.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.Serialize;
@@ -41,16 +42,20 @@ import org.polypheny.db.catalog.logistic.PartitionType;
 public abstract class AllocationEntity extends Entity {
 
     @Serialize
+    @JsonProperty
     public long adapterId;
 
     @Serialize
+    @JsonProperty
     public long logicalId;
 
     @Serialize
+    @JsonProperty
     @SerializeVarLength
     public long partitionId;
 
     @Serialize
+    @JsonProperty
     @SerializeVarLength
     public long placementId;
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartition.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartition.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.entity.allocation;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -43,32 +42,25 @@ public class AllocationPartition implements PolyObject {
     private static final long serialVersionUID = 8835793248417591036L;
 
     @Serialize
-    @JsonProperty
     public long namespaceId;
 
     @Serialize
-    @JsonProperty
     public long logicalEntityId;
 
     @Serialize
-    @JsonProperty
     public long groupId;
 
     @Serialize
-    @JsonProperty
     @SerializeNullable
     public String name;
 
     @Serialize
-    @JsonProperty
     public long id;
 
     @Serialize
-    @JsonProperty
     public PlacementType placementType;
 
     @Serialize
-    @JsonProperty
     public PartitionType partitionType;
 
     // Related to multi-tier replication. A physical partition placement is considered to be primary (uptodate) if it needs to receive every update eagerly.
@@ -84,13 +76,10 @@ public class AllocationPartition implements PolyObject {
     // A DataPlacement can directly forbid that any Placements within this DataPlacement container can get outdated.
     // Therefore, the role at the DataPlacement specifies if underlying placements can even be outdated.s
     @Serialize
-    @JsonProperty
     public DataPlacementRole role;
     @Serialize
-    @JsonProperty
     public boolean isUnbound;
     @Serialize
-    @JsonProperty
     @NotNull
     public List<String> qualifiers;
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartition.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartition.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.entity.allocation;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -42,25 +43,32 @@ public class AllocationPartition implements PolyObject {
     private static final long serialVersionUID = 8835793248417591036L;
 
     @Serialize
+    @JsonProperty
     public long namespaceId;
 
     @Serialize
+    @JsonProperty
     public long logicalEntityId;
 
     @Serialize
+    @JsonProperty
     public long groupId;
 
     @Serialize
+    @JsonProperty
     @SerializeNullable
     public String name;
 
     @Serialize
+    @JsonProperty
     public long id;
 
     @Serialize
+    @JsonProperty
     public PlacementType placementType;
 
     @Serialize
+    @JsonProperty
     public PartitionType partitionType;
 
     // Related to multi-tier replication. A physical partition placement is considered to be primary (uptodate) if it needs to receive every update eagerly.
@@ -76,10 +84,13 @@ public class AllocationPartition implements PolyObject {
     // A DataPlacement can directly forbid that any Placements within this DataPlacement container can get outdated.
     // Therefore, the role at the DataPlacement specifies if underlying placements can even be outdated.s
     @Serialize
+    @JsonProperty
     public DataPlacementRole role;
     @Serialize
+    @JsonProperty
     public boolean isUnbound;
     @Serialize
+    @JsonProperty
     @NotNull
     public List<String> qualifiers;
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartitionGroup.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartitionGroup.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -30,17 +31,23 @@ public class AllocationPartitionGroup implements PolyObject {
     private static final long serialVersionUID = 6229244317971622972L;
 
     @Serialize
+    @JsonProperty
     public long id;
     @Serialize
+    @JsonProperty
     @SerializeNullable
     public String name;
     @Serialize
+    @JsonProperty
     public long logicalEntityId;
     @Serialize
+    @JsonProperty
     public long namespaceId;
     @Serialize
+    @JsonProperty
     public boolean isUnbound;
     @Serialize
+    @JsonProperty
     public long partitionKey;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartitionGroup.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPartitionGroup.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -31,23 +30,17 @@ public class AllocationPartitionGroup implements PolyObject {
     private static final long serialVersionUID = 6229244317971622972L;
 
     @Serialize
-    @JsonProperty
     public long id;
     @Serialize
-    @JsonProperty
     @SerializeNullable
     public String name;
     @Serialize
-    @JsonProperty
     public long logicalEntityId;
     @Serialize
-    @JsonProperty
     public long namespaceId;
     @Serialize
-    @JsonProperty
     public boolean isUnbound;
     @Serialize
-    @JsonProperty
     public long partitionKey;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPlacement.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPlacement.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import lombok.Value;
@@ -25,12 +26,16 @@ import org.polypheny.db.catalog.entity.PolyObject;
 public class AllocationPlacement implements PolyObject {
 
     @Serialize
+    @JsonProperty
     public long id;
     @Serialize
+    @JsonProperty
     public long adapterId;
     @Serialize
+    @JsonProperty
     public long namespaceId;
     @Serialize
+    @JsonProperty
     public long logicalEntityId;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPlacement.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationPlacement.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.entity.allocation;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import lombok.Value;
@@ -26,16 +25,12 @@ import org.polypheny.db.catalog.entity.PolyObject;
 public class AllocationPlacement implements PolyObject {
 
     @Serialize
-    @JsonProperty
     public long id;
     @Serialize
-    @JsonProperty
     public long adapterId;
     @Serialize
-    @JsonProperty
     public long namespaceId;
     @Serialize
-    @JsonProperty
     public long logicalEntityId;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.entity.logical;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -44,49 +44,62 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
     private static final long serialVersionUID = -4792846455300897399L;
 
     @Serialize
+    @JsonProperty
     public long id;
 
     @Serialize
+    @JsonProperty
     public String name;
 
     @Serialize
+    @JsonProperty
     public long tableId;
 
     @Serialize
+    @JsonProperty
     public long namespaceId;
 
     @Serialize
+    @JsonProperty
     public int position;
 
     @Serialize
+    @JsonProperty
     public PolyType type;
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable PolyType collectionsType;
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Integer length; // JDBC length or precision depending on type
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Integer scale; // decimal digits
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Integer dimension;
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Integer cardinality;
 
     @Serialize
+    @JsonProperty
     public boolean nullable;
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Collation collation;
 
     @Serialize
+    @JsonProperty
     @SerializeNullable
     public LogicalDefaultValue defaultValue;
 
-    @JsonIgnore
     public DataModel dataModel = DataModel.RELATIONAL;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.entity.logical;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -43,45 +44,59 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
     private static final long serialVersionUID = -4792846455300897399L;
 
     @Serialize
+    @JsonProperty
     public long id;
 
     @Serialize
+    @JsonProperty
     public String name;
 
     @Serialize
+    @JsonProperty
     public long tableId;
 
     @Serialize
+    @JsonProperty
     public long namespaceId;
 
     @Serialize
+    @JsonProperty
     public int position;
 
     @Serialize
+    @JsonProperty
     public PolyType type;
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable PolyType collectionsType;
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Integer length; // JDBC length or precision depending on type
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Integer scale; // decimal digits
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Integer dimension;
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Integer cardinality;
 
     @Serialize
+    @JsonProperty
     public boolean nullable;
 
     @Serialize
+    @JsonProperty
     public @SerializeNullable Collation collation;
 
     @Serialize
+    @JsonProperty
     @SerializeNullable
     public LogicalDefaultValue defaultValue;
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.entity.logical;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -44,62 +44,49 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
     private static final long serialVersionUID = -4792846455300897399L;
 
     @Serialize
-    @JsonProperty
     public long id;
 
     @Serialize
-    @JsonProperty
     public String name;
 
     @Serialize
-    @JsonProperty
     public long tableId;
 
     @Serialize
-    @JsonProperty
     public long namespaceId;
 
     @Serialize
-    @JsonProperty
     public int position;
 
     @Serialize
-    @JsonProperty
     public PolyType type;
 
     @Serialize
-    @JsonProperty
     public @SerializeNullable PolyType collectionsType;
 
     @Serialize
-    @JsonProperty
     public @SerializeNullable Integer length; // JDBC length or precision depending on type
 
     @Serialize
-    @JsonProperty
     public @SerializeNullable Integer scale; // decimal digits
 
     @Serialize
-    @JsonProperty
     public @SerializeNullable Integer dimension;
 
     @Serialize
-    @JsonProperty
     public @SerializeNullable Integer cardinality;
 
     @Serialize
-    @JsonProperty
     public boolean nullable;
 
     @Serialize
-    @JsonProperty
     public @SerializeNullable Collation collation;
 
     @Serialize
-    @JsonProperty
     @SerializeNullable
     public LogicalDefaultValue defaultValue;
 
+    @JsonIgnore
     public DataModel dataModel = DataModel.RELATIONAL;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.entity.logical;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -37,35 +36,25 @@ public class LogicalIndex implements Serializable {
     private static final long serialVersionUID = -318228681682792406L;
 
     @Serialize
-    @JsonProperty
     public long id;
     @Serialize
-    @JsonProperty
     public String name;
     @Serialize
-    @JsonProperty
     @SerializeNullable
     public String physicalName;
     @Serialize
-    @JsonProperty
     public boolean unique;
     @Serialize
-    @JsonProperty
     public IndexType type;
     @Serialize
-    @JsonProperty
     public long location; // -1 is Polypheny
     @Serialize
-    @JsonProperty
     public String method;
     @Serialize
-    @JsonProperty
     public String methodDisplayName;
     @Serialize
-    @JsonProperty
     public LogicalKey key;
     @Serialize
-    @JsonProperty
     public long keyId;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalIndex.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.entity.logical;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -36,25 +37,35 @@ public class LogicalIndex implements Serializable {
     private static final long serialVersionUID = -318228681682792406L;
 
     @Serialize
+    @JsonProperty
     public long id;
     @Serialize
+    @JsonProperty
     public String name;
     @Serialize
+    @JsonProperty
     @SerializeNullable
     public String physicalName;
     @Serialize
+    @JsonProperty
     public boolean unique;
     @Serialize
+    @JsonProperty
     public IndexType type;
     @Serialize
+    @JsonProperty
     public long location; // -1 is Polypheny
     @Serialize
+    @JsonProperty
     public String method;
     @Serialize
+    @JsonProperty
     public String methodDisplayName;
     @Serialize
+    @JsonProperty
     public LogicalKey key;
     @Serialize
+    @JsonProperty
     public long keyId;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.entity.logical;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.google.common.collect.ImmutableList;
@@ -42,23 +41,18 @@ public abstract class LogicalKey implements PolyObject, Comparable<LogicalKey> {
     private static final long serialVersionUID = -5803762884192662540L;
 
     @Serialize
-    @JsonProperty
     public long id;
 
     @Serialize
-    @JsonProperty
     public long entityId;
 
     @Serialize
-    @JsonProperty
     public long namespaceId;
 
     @Serialize
-    @JsonProperty
     public ImmutableList<Long> fieldIds;
 
     @Serialize
-    @JsonProperty
     public EnforcementTime enforcementTime;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.entity.logical;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.google.common.collect.ImmutableList;
@@ -41,18 +42,23 @@ public abstract class LogicalKey implements PolyObject, Comparable<LogicalKey> {
     private static final long serialVersionUID = -5803762884192662540L;
 
     @Serialize
+    @JsonProperty
     public long id;
 
     @Serialize
+    @JsonProperty
     public long entityId;
 
     @Serialize
+    @JsonProperty
     public long namespaceId;
 
     @Serialize
+    @JsonProperty
     public ImmutableList<Long> fieldIds;
 
     @Serialize
+    @JsonProperty
     public EnforcementTime enforcementTime;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalKey.java
@@ -16,6 +16,9 @@
 
 package org.polypheny.db.catalog.entity.logical;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.google.common.collect.ImmutableList;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeClass;
@@ -32,24 +35,30 @@ import org.polypheny.db.catalog.snapshot.Snapshot;
 @Value
 @NonFinal
 @SerializeClass(subclasses = { LogicalGenericKey.class, LogicalPrimaryKey.class, LogicalForeignKey.class })
+@JsonTypeInfo(use = Id.CLASS)
 public abstract class LogicalKey implements PolyObject, Comparable<LogicalKey> {
 
     @Serial
     private static final long serialVersionUID = -5803762884192662540L;
 
     @Serialize
+    @JsonProperty
     public long id;
 
     @Serialize
+    @JsonProperty
     public long entityId;
 
     @Serialize
+    @JsonProperty
     public long namespaceId;
 
     @Serialize
+    @JsonProperty
     public ImmutableList<Long> fieldIds;
 
     @Serialize
+    @JsonProperty
     public EnforcementTime enforcementTime;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalMaterializedView.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalMaterializedView.java
@@ -75,5 +75,4 @@ public class LogicalMaterializedView extends LogicalView {
         this.ordered = ordered;
     }
 
-
 }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
@@ -17,8 +17,6 @@
 package org.polypheny.db.catalog.entity.logical;
 
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
@@ -40,17 +38,13 @@ public class LogicalNamespace implements PolyObject, Comparable<LogicalNamespace
     private static final long serialVersionUID = 3090632164988970558L;
 
     @Serialize
-    @JsonProperty
     public long id;
     @Serialize
-    @JsonProperty
     public String name;
     @Serialize
-    @JsonProperty
     @EqualsAndHashCode.Exclude
     public DataModel dataModel;
     @Serialize
-    @JsonProperty
     public boolean caseSensitive;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalNamespace.java
@@ -17,6 +17,8 @@
 package org.polypheny.db.catalog.entity.logical;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import java.io.Serial;
@@ -38,13 +40,17 @@ public class LogicalNamespace implements PolyObject, Comparable<LogicalNamespace
     private static final long serialVersionUID = 3090632164988970558L;
 
     @Serialize
+    @JsonProperty
     public long id;
     @Serialize
+    @JsonProperty
     public String name;
     @Serialize
+    @JsonProperty
     @EqualsAndHashCode.Exclude
     public DataModel dataModel;
     @Serialize
+    @JsonProperty
     public boolean caseSensitive;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.entity.logical;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -51,6 +52,7 @@ public class LogicalTable extends LogicalEntity {
 
     @Serialize
     @SerializeNullable
+    @JsonProperty
     public Long primaryKey;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.entity.logical;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
@@ -52,7 +51,6 @@ public class LogicalTable extends LogicalEntity {
 
     @Serialize
     @SerializeNullable
-    @JsonProperty
     public Long primaryKey;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalEntity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalEntity.java
@@ -16,6 +16,9 @@
 
 package org.polypheny.db.catalog.entity.physical;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeClass;
 import java.util.List;
@@ -32,21 +35,27 @@ import org.polypheny.db.catalog.logistic.EntityType;
 @NonFinal
 @SuperBuilder(toBuilder = true)
 @SerializeClass(subclasses = { PhysicalTable.class, PhysicalGraph.class, PhysicalCollection.class })
+@JsonTypeInfo(use = Id.CLASS)
 public abstract class PhysicalEntity extends Entity {
 
     @Serialize
+    @JsonProperty
     public String namespaceName;
 
     @Serialize
+    @JsonProperty
     public long adapterId;
 
     @Serialize
+    @JsonProperty
     public long allocationId;
 
     @Serialize
+    @JsonProperty
     public long logicalId;
 
     @Serialize
+    @JsonProperty
     public List<Long> uniqueFieldIds;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalEntity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalEntity.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.entity.physical;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.Serialize;
@@ -39,23 +38,18 @@ import org.polypheny.db.catalog.logistic.EntityType;
 public abstract class PhysicalEntity extends Entity {
 
     @Serialize
-    @JsonProperty
     public String namespaceName;
 
     @Serialize
-    @JsonProperty
     public long adapterId;
 
     @Serialize
-    @JsonProperty
     public long allocationId;
 
     @Serialize
-    @JsonProperty
     public long logicalId;
 
     @Serialize
-    @JsonProperty
     public List<Long> uniqueFieldIds;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalEntity.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/physical/PhysicalEntity.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.entity.physical;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.activej.serializer.annotations.Serialize;
@@ -38,18 +39,23 @@ import org.polypheny.db.catalog.logistic.EntityType;
 public abstract class PhysicalEntity extends Entity {
 
     @Serialize
+    @JsonProperty
     public String namespaceName;
 
     @Serialize
+    @JsonProperty
     public long adapterId;
 
     @Serialize
+    @JsonProperty
     public long allocationId;
 
     @Serialize
+    @JsonProperty
     public long logicalId;
 
     @Serialize
+    @JsonProperty
     public List<Long> uniqueFieldIds;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/AdapterRestore.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/AdapterRestore.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.impl;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.SerializeRecord;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +31,9 @@ import org.polypheny.db.prepare.Context;
 
 @SerializeRecord
 public record AdapterRestore(
-        long adapterId,
-        Map<Long, List<PhysicalEntity>> physicals,
-        Map<Long, AllocationEntity> allocations ) {
+        @JsonProperty long adapterId,
+        @JsonProperty Map<Long, List<PhysicalEntity>> physicals,
+        @JsonProperty Map<Long, AllocationEntity> allocations ) {
 
     public AdapterRestore(
             long adapterId,

--- a/core/src/main/java/org/polypheny/db/catalog/impl/AdapterRestore.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/AdapterRestore.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.impl;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.annotations.SerializeRecord;
 import java.util.List;
 import java.util.Map;
@@ -31,9 +30,9 @@ import org.polypheny.db.prepare.Context;
 
 @SerializeRecord
 public record AdapterRestore(
-        @JsonProperty long adapterId,
-        @JsonProperty Map<Long, List<PhysicalEntity>> physicals,
-        @JsonProperty Map<Long, AllocationEntity> allocations ) {
+        long adapterId,
+        Map<Long, List<PhysicalEntity>> physicals,
+        Map<Long, AllocationEntity> allocations ) {
 
     public AdapterRestore(
             long adapterId,

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.catalog.impl;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -92,7 +93,7 @@ public class PolyCatalog extends Catalog implements PolySerializable {
 
     private final static JsonMapper MAPPER = JsonMapper.builder()
             .configure( MapperFeature.AUTO_DETECT_CREATORS, false )
-            .configure( MapperFeature.AUTO_DETECT_FIELDS, false )
+            //.configure( MapperFeature.AUTO_DETECT_FIELDS, false )
             .configure( MapperFeature.AUTO_DETECT_GETTERS, false )
             .configure( MapperFeature.AUTO_DETECT_IS_GETTERS, false )
             .configure( MapperFeature.AUTO_DETECT_SETTERS, false )
@@ -100,64 +101,69 @@ public class PolyCatalog extends Catalog implements PolySerializable {
             .build();
 
     @Getter
+    @JsonIgnore
     private final BinarySerializer<PolyCatalog> serializer = PolySerializable.buildSerializer( PolyCatalog.class );
 
     /**
      * Constraints which have to be met before a commit can be executed.
      */
+    @JsonIgnore
     private final Collection<ConstraintCondition> commitConstraints = new ConcurrentLinkedDeque<>();
+    @JsonIgnore
     private final Collection<Runnable> commitActions = new ConcurrentLinkedDeque<>();
 
 
     @Serialize
-    @JsonProperty
     public final Map<Long, LogicalCatalog> logicalCatalogs;
 
     @Serialize
-    @JsonProperty
     public final Map<Long, AllocationCatalog> allocationCatalogs;
 
     @Serialize
-    @JsonProperty
     @Getter
     public final Map<Long, LogicalUser> users;
 
     @Serialize
-    @JsonProperty
     @Getter
     public final Map<Long, LogicalAdapter> adapters;
 
     @Serialize
-    @JsonProperty
     @Getter
     public final Map<Long, LogicalQueryInterface> interfaces;
 
     @Getter
+    @JsonIgnore
     public final Map<Long, AdapterTemplate> adapterTemplates;
 
     @Getter
+    @JsonIgnore
     public final Map<String, QueryInterfaceTemplate> interfaceTemplates;
 
     @Getter
+    @JsonIgnore
     public final Map<Long, AdapterCatalog> adapterCatalogs;
 
     @Serialize
-    @JsonProperty
     public final Map<Long, AdapterRestore> adapterRestore;
 
     @Serialize
-    @JsonProperty
     public final IdBuilder idBuilder;
 
+    @JsonIgnore
     private final Persister persister;
 
     @Getter
+    @JsonIgnore
     private Snapshot snapshot;
+
+    @JsonIgnore
     private String backup;
 
+    @JsonIgnore
     private final AtomicBoolean dirty = new AtomicBoolean( false );
 
     @Getter
+    @JsonIgnore
     PropertyChangeListener changeListener = evt -> dirty.set( true );
 
 
@@ -227,7 +233,7 @@ public class PolyCatalog extends Catalog implements PolySerializable {
     @Override
     public String getJson() {
         try {
-            return MAPPER.writeValueAsString( this );
+            return MAPPER.setVisibility( PropertyAccessor.FIELD, Visibility.ANY ).writeValueAsString( this );
         } catch ( JsonProcessingException e ) {
             throw new GenericRuntimeException( e );
         }

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -16,6 +16,13 @@
 
 package org.polypheny.db.catalog.impl;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
@@ -83,6 +90,15 @@ import org.polypheny.db.util.Pair;
 @Slf4j
 public class PolyCatalog extends Catalog implements PolySerializable {
 
+    private final static JsonMapper MAPPER = JsonMapper.builder()
+            .configure( MapperFeature.AUTO_DETECT_CREATORS, false )
+            .configure( MapperFeature.AUTO_DETECT_FIELDS, false )
+            .configure( MapperFeature.AUTO_DETECT_GETTERS, false )
+            .configure( MapperFeature.AUTO_DETECT_IS_GETTERS, false )
+            .configure( MapperFeature.AUTO_DETECT_SETTERS, false )
+            .configure( SerializationFeature.FAIL_ON_EMPTY_BEANS, false )
+            .build();
+
     @Getter
     private final BinarySerializer<PolyCatalog> serializer = PolySerializable.buildSerializer( PolyCatalog.class );
 
@@ -94,20 +110,25 @@ public class PolyCatalog extends Catalog implements PolySerializable {
 
 
     @Serialize
+    @JsonProperty
     public final Map<Long, LogicalCatalog> logicalCatalogs;
 
     @Serialize
+    @JsonProperty
     public final Map<Long, AllocationCatalog> allocationCatalogs;
 
     @Serialize
+    @JsonProperty
     @Getter
     public final Map<Long, LogicalUser> users;
 
     @Serialize
+    @JsonProperty
     @Getter
     public final Map<Long, LogicalAdapter> adapters;
 
     @Serialize
+    @JsonProperty
     @Getter
     public final Map<Long, LogicalQueryInterface> interfaces;
 
@@ -121,9 +142,11 @@ public class PolyCatalog extends Catalog implements PolySerializable {
     public final Map<Long, AdapterCatalog> adapterCatalogs;
 
     @Serialize
+    @JsonProperty
     public final Map<Long, AdapterRestore> adapterRestore;
 
     @Serialize
+    @JsonProperty
     public final IdBuilder idBuilder;
 
     private final Persister persister;
@@ -198,6 +221,16 @@ public class PolyCatalog extends Catalog implements PolySerializable {
         // empty for now
         this.dirty.set( true );
         updateSnapshot();
+    }
+
+
+    @Override
+    public String getJson() {
+        try {
+            return MAPPER.writeValueAsString( this );
+        } catch ( JsonProcessingException e ) {
+            throw new GenericRuntimeException( e );
+        }
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.impl;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -93,7 +92,7 @@ public class PolyCatalog extends Catalog implements PolySerializable {
 
     private final static JsonMapper MAPPER = JsonMapper.builder()
             .configure( MapperFeature.AUTO_DETECT_CREATORS, false )
-            //.configure( MapperFeature.AUTO_DETECT_FIELDS, false )
+            .configure( MapperFeature.AUTO_DETECT_FIELDS, false )
             .configure( MapperFeature.AUTO_DETECT_GETTERS, false )
             .configure( MapperFeature.AUTO_DETECT_IS_GETTERS, false )
             .configure( MapperFeature.AUTO_DETECT_SETTERS, false )
@@ -101,69 +100,64 @@ public class PolyCatalog extends Catalog implements PolySerializable {
             .build();
 
     @Getter
-    @JsonIgnore
     private final BinarySerializer<PolyCatalog> serializer = PolySerializable.buildSerializer( PolyCatalog.class );
 
     /**
      * Constraints which have to be met before a commit can be executed.
      */
-    @JsonIgnore
     private final Collection<ConstraintCondition> commitConstraints = new ConcurrentLinkedDeque<>();
-    @JsonIgnore
     private final Collection<Runnable> commitActions = new ConcurrentLinkedDeque<>();
 
 
     @Serialize
+    @JsonProperty
     public final Map<Long, LogicalCatalog> logicalCatalogs;
 
     @Serialize
+    @JsonProperty
     public final Map<Long, AllocationCatalog> allocationCatalogs;
 
     @Serialize
+    @JsonProperty
     @Getter
     public final Map<Long, LogicalUser> users;
 
     @Serialize
+    @JsonProperty
     @Getter
     public final Map<Long, LogicalAdapter> adapters;
 
     @Serialize
+    @JsonProperty
     @Getter
     public final Map<Long, LogicalQueryInterface> interfaces;
 
     @Getter
-    @JsonIgnore
     public final Map<Long, AdapterTemplate> adapterTemplates;
 
     @Getter
-    @JsonIgnore
     public final Map<String, QueryInterfaceTemplate> interfaceTemplates;
 
     @Getter
-    @JsonIgnore
     public final Map<Long, AdapterCatalog> adapterCatalogs;
 
     @Serialize
+    @JsonProperty
     public final Map<Long, AdapterRestore> adapterRestore;
 
     @Serialize
+    @JsonProperty
     public final IdBuilder idBuilder;
 
-    @JsonIgnore
     private final Persister persister;
 
     @Getter
-    @JsonIgnore
     private Snapshot snapshot;
-
-    @JsonIgnore
     private String backup;
 
-    @JsonIgnore
     private final AtomicBoolean dirty = new AtomicBoolean( false );
 
     @Getter
-    @JsonIgnore
     PropertyChangeListener changeListener = evt -> dirty.set( true );
 
 
@@ -233,7 +227,7 @@ public class PolyCatalog extends Catalog implements PolySerializable {
     @Override
     public String getJson() {
         try {
-            return MAPPER.setVisibility( PropertyAccessor.FIELD, Visibility.ANY ).writeValueAsString( this );
+            return MAPPER.writeValueAsString( this );
         } catch ( JsonProcessingException e ) {
             throw new GenericRuntimeException( e );
         }

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocDocCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocDocCatalog.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.impl.allocation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -39,8 +40,10 @@ import org.polypheny.db.type.PolySerializable;
 @Value
 public class PolyAllocDocCatalog implements PolySerializable, AllocationDocumentCatalog {
 
+    @JsonIgnore
     public BinarySerializer<PolyAllocDocCatalog> serializer = PolySerializable.buildSerializer( PolyAllocDocCatalog.class );
 
+    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
@@ -55,6 +58,7 @@ public class PolyAllocDocCatalog implements PolySerializable, AllocationDocument
     @Serialize
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
+    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocDocCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocDocCatalog.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.impl.allocation;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -40,10 +39,8 @@ import org.polypheny.db.type.PolySerializable;
 @Value
 public class PolyAllocDocCatalog implements PolySerializable, AllocationDocumentCatalog {
 
-    @JsonIgnore
     public BinarySerializer<PolyAllocDocCatalog> serializer = PolySerializable.buildSerializer( PolyAllocDocCatalog.class );
 
-    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
@@ -58,7 +55,6 @@ public class PolyAllocDocCatalog implements PolySerializable, AllocationDocument
     @Serialize
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
-    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.impl.allocation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -39,8 +40,10 @@ import org.polypheny.db.type.PolySerializable;
 @Value
 public class PolyAllocGraphCatalog implements PolySerializable, AllocationGraphCatalog {
 
+    @JsonIgnore
     public BinarySerializer<PolyAllocGraphCatalog> serializer = PolySerializable.buildSerializer( PolyAllocGraphCatalog.class );
 
+    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
@@ -55,6 +58,7 @@ public class PolyAllocGraphCatalog implements PolySerializable, AllocationGraphC
     @Serialize
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
+    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocGraphCatalog.java
@@ -16,7 +16,6 @@
 
 package org.polypheny.db.catalog.impl.allocation;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -40,10 +39,8 @@ import org.polypheny.db.type.PolySerializable;
 @Value
 public class PolyAllocGraphCatalog implements PolySerializable, AllocationGraphCatalog {
 
-    @JsonIgnore
     public BinarySerializer<PolyAllocGraphCatalog> serializer = PolySerializable.buildSerializer( PolyAllocGraphCatalog.class );
 
-    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
@@ -58,7 +55,6 @@ public class PolyAllocGraphCatalog implements PolySerializable, AllocationGraphC
     @Serialize
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
-    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.impl.allocation;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -47,34 +47,38 @@ import org.polypheny.db.util.Pair;
 @Value
 public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySerializable {
 
-    @JsonIgnore
     public BinarySerializer<PolyAllocRelCatalog> serializer = PolySerializable.buildSerializer( PolyAllocRelCatalog.class );
 
-    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
+    @JsonProperty
     public LogicalNamespace namespace;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, AllocationTable> tables;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Pair<Long, Long>, AllocationColumn> columns; //placementId, columnId
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, PartitionProperty> properties;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPartitionGroup> partitionGroups;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPlacement> placements;
 
-    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.impl.allocation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -51,24 +52,31 @@ public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySer
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
+    @JsonProperty
     public LogicalNamespace namespace;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, AllocationTable> tables;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Pair<Long, Long>, AllocationColumn> columns; //placementId, columnId
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, PartitionProperty> properties;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPartitionGroup> partitionGroups;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPlacement> placements;
 
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );

--- a/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/allocation/PolyAllocRelCatalog.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.impl.allocation;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -47,38 +47,34 @@ import org.polypheny.db.util.Pair;
 @Value
 public class PolyAllocRelCatalog implements AllocationRelationalCatalog, PolySerializable {
 
+    @JsonIgnore
     public BinarySerializer<PolyAllocRelCatalog> serializer = PolySerializable.buildSerializer( PolyAllocRelCatalog.class );
 
+    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
-    @JsonProperty
     public LogicalNamespace namespace;
 
     @Serialize
-    @JsonProperty
     public ConcurrentHashMap<Long, AllocationTable> tables;
 
     @Serialize
-    @JsonProperty
     public ConcurrentHashMap<Pair<Long, Long>, AllocationColumn> columns; //placementId, columnId
 
     @Serialize
-    @JsonProperty
     public ConcurrentHashMap<Long, PartitionProperty> properties;
 
     @Serialize
-    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPartitionGroup> partitionGroups;
 
     @Serialize
-    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPartition> partitions;
 
     @Serialize
-    @JsonProperty
     public ConcurrentHashMap<Long, AllocationPlacement> placements;
 
+    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -43,9 +44,11 @@ public class DocumentCatalog implements PolySerializable, LogicalDocumentCatalog
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
+    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalCollection> collections;
 
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -39,18 +39,19 @@ import org.polypheny.db.type.PolySerializable;
 @SuperBuilder(toBuilder = true)
 public class DocumentCatalog implements PolySerializable, LogicalDocumentCatalog {
 
+    @JsonIgnore
     public BinarySerializer<DocumentCatalog> serializer = PolySerializable.buildSerializer( DocumentCatalog.class );
 
+    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
-    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
-    @JsonProperty
     public Map<Long, LogicalCollection> collections;
 
+    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/DocumentCatalog.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -39,19 +39,18 @@ import org.polypheny.db.type.PolySerializable;
 @SuperBuilder(toBuilder = true)
 public class DocumentCatalog implements PolySerializable, LogicalDocumentCatalog {
 
-    @JsonIgnore
     public BinarySerializer<DocumentCatalog> serializer = PolySerializable.buildSerializer( DocumentCatalog.class );
 
-    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
+    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalCollection> collections;
 
-    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -38,19 +38,19 @@ import org.polypheny.db.type.PolySerializable;
 @SuperBuilder(toBuilder = true)
 public class GraphCatalog implements PolySerializable, LogicalGraphCatalog {
 
-    @JsonIgnore
     public BinarySerializer<GraphCatalog> serializer = PolySerializable.buildSerializer( GraphCatalog.class );
 
-    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
+    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, LogicalGraph> graphs;
 
-    @JsonIgnore
+
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -42,9 +43,11 @@ public class GraphCatalog implements PolySerializable, LogicalGraphCatalog {
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
+    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
+    @JsonProperty
     public ConcurrentHashMap<Long, LogicalGraph> graphs;
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/GraphCatalog.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -38,19 +38,19 @@ import org.polypheny.db.type.PolySerializable;
 @SuperBuilder(toBuilder = true)
 public class GraphCatalog implements PolySerializable, LogicalGraphCatalog {
 
+    @JsonIgnore
     public BinarySerializer<GraphCatalog> serializer = PolySerializable.buildSerializer( GraphCatalog.class );
 
+    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
-    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
-    @JsonProperty
     public ConcurrentHashMap<Long, LogicalGraph> graphs;
 
-
+    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -74,25 +75,31 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
+    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalTable> tables;
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalColumn> columns;
 
     public Map<Long, AlgNode> nodes;
 
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalIndex> indexes;
 
     // while keys "belong" to a specific table, they can reference other namespaces, atm they are place here, might change later
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalKey> keys;
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalConstraint> constraints;
 
     Set<Long> tablesFlaggedForDeletion = new HashSet<>();

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -70,40 +70,38 @@ import org.polypheny.db.type.entity.PolyValue;
 @SuperBuilder(toBuilder = true)
 public class RelationalCatalog implements PolySerializable, LogicalRelationalCatalog {
 
+    @JsonIgnore
     public BinarySerializer<RelationalCatalog> serializer = PolySerializable.buildSerializer( RelationalCatalog.class );
 
+    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
-    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
-    @JsonProperty
     public Map<Long, LogicalTable> tables;
 
     @Serialize
-    @JsonProperty
     public Map<Long, LogicalColumn> columns;
 
+    @JsonIgnore
     public Map<Long, AlgNode> nodes;
 
-
     @Serialize
-    @JsonProperty
     public Map<Long, LogicalIndex> indexes;
 
     // while keys "belong" to a specific table, they can reference other namespaces, atm they are place here, might change later
     @Serialize
-    @JsonProperty
     public Map<Long, LogicalKey> keys;
 
     @Serialize
-    @JsonProperty
     public Map<Long, LogicalConstraint> constraints;
 
+    @JsonIgnore
     Set<Long> tablesFlaggedForDeletion = new HashSet<>();
 
+    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -16,7 +16,7 @@
 
 package org.polypheny.db.catalog.impl.logical;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.activej.serializer.BinarySerializer;
 import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
@@ -70,38 +70,40 @@ import org.polypheny.db.type.entity.PolyValue;
 @SuperBuilder(toBuilder = true)
 public class RelationalCatalog implements PolySerializable, LogicalRelationalCatalog {
 
-    @JsonIgnore
     public BinarySerializer<RelationalCatalog> serializer = PolySerializable.buildSerializer( RelationalCatalog.class );
 
-    @JsonIgnore
     IdBuilder idBuilder = IdBuilder.getInstance();
 
     @Serialize
+    @JsonProperty
     public LogicalNamespace logicalNamespace;
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalTable> tables;
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalColumn> columns;
 
-    @JsonIgnore
     public Map<Long, AlgNode> nodes;
 
+
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalIndex> indexes;
 
     // while keys "belong" to a specific table, they can reference other namespaces, atm they are place here, might change later
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalKey> keys;
 
     @Serialize
+    @JsonProperty
     public Map<Long, LogicalConstraint> constraints;
 
-    @JsonIgnore
     Set<Long> tablesFlaggedForDeletion = new HashSet<>();
 
-    @JsonIgnore
     PropertyChangeSupport listeners = new PropertyChangeSupport( this );
 
 

--- a/plugins/mql-language/src/test/java/org/polypheny/db/mql/mql2alg/MqlMockCatalog.java
+++ b/plugins/mql-language/src/test/java/org/polypheny/db/mql/mql2alg/MqlMockCatalog.java
@@ -47,6 +47,11 @@ public class MqlMockCatalog extends MockCatalog {
     }
 
 
+    public String getJson() {
+        return null;
+    }
+
+
     @Override
     public void addStoreSnapshot( AdapterCatalog snapshot ) {
 

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -2813,6 +2813,15 @@ public class Crud implements InformationObserver, PropertyChangeListener {
         ctx.result( "" );
     }
 
+
+    void getCatalog( final Context ctx ) {
+        // Assigning the result to a variable causes an error when the switch expression is not exhaustive
+        Context ignore = switch ( Catalog.mode ) {
+            case PRODUCTION -> ctx.status( HttpCode.FORBIDDEN ).result( "Forbidden" );
+            case DEVELOPMENT, BENCHMARK, TEST -> ctx.json( Catalog.getInstance().getJson() );
+        };
+    }
+
     // -----------------------------------------------------------------------
     //                                Helper
     // -----------------------------------------------------------------------

--- a/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
+++ b/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
@@ -282,6 +282,8 @@ public class HttpServer implements Runnable {
 
         webuiServer.get( "/getFile/{file}", crud::getFile );
 
+        webuiServer.get( "/catalog.json", crud::getCatalog );
+
         webuiServer.get( "/getDocumentDatabases", crud.languageCrud::getDocumentDatabases );
 
         webuiServer.get( "/product", ctx -> ctx.result( "Polypheny-DB" ) );


### PR DESCRIPTION
## Summary

Add a JSON serialization of the Catalog in addition to binary serialization.  This feature for debugging.  The serialized Catalog can be retrieved over a new Crud endpoint, but only when Polypheny is not running in production mode.

### Features

* Add an endpoint (`/catalog.json`) to retrieve a JSON serialization of the Catalog.  This endpoint returns 403 (Forbidden) when Polypheny is running in production mode.
