### PR TITLE
Small Improvements Related to the Catalog

### DIFF
--- a/core/src/main/java/org/polypheny/db/adapter/AdapterManager.java
+++ b/core/src/main/java/org/polypheny/db/adapter/AdapterManager.java
@@ -68,7 +68,7 @@ public class AdapterManager {
 
     public static void removeAdapterTemplate( long templateId ) {
         AdapterTemplate template = Catalog.snapshot().getAdapterTemplate( templateId ).orElseThrow();
-        if ( Catalog.getInstance().getSnapshot().getAdapters().stream().anyMatch( a -> a.adapterName.equals( template.adapterName ) && a.type == template.adapterType ) ) {
+        if ( Catalog.snapshot().getAdapters().stream().anyMatch( a -> a.adapterName.equals( template.adapterName ) && a.type == template.adapterType ) ) {
             throw new GenericRuntimeException( "Adapter is still deployed!" );
         }
         Catalog.getInstance().dropAdapterTemplate( templateId );
@@ -196,10 +196,10 @@ public class AdapterManager {
         }
         Adapter<?> adapterInstance = optionalAdapter.get();
 
-        LogicalAdapter logicalAdapter = Catalog.getInstance().getSnapshot().getAdapter( adapterId ).orElseThrow();
+        LogicalAdapter logicalAdapter = Catalog.snapshot().getAdapter( adapterId ).orElseThrow();
 
         // Check if the store has any placements
-        List<AllocationEntity> placements = Catalog.getInstance().getSnapshot().alloc().getEntitiesOnAdapter( logicalAdapter.id ).orElseThrow( () -> new GenericRuntimeException( "There is still data placed on this data store" ) );
+        List<AllocationEntity> placements = Catalog.snapshot().alloc().getEntitiesOnAdapter( logicalAdapter.id ).orElseThrow( () -> new GenericRuntimeException( "There is still data placed on this data store" ) );
         if ( !placements.isEmpty() ) {
             if ( adapterInstance instanceof DataStore<?> ) {
                 throw new GenericRuntimeException( "There is still data placed on this data store" );

--- a/core/src/main/java/org/polypheny/db/adapter/DataStore.java
+++ b/core/src/main/java/org/polypheny/db/adapter/DataStore.java
@@ -64,7 +64,7 @@ public abstract class DataStore<S extends AdapterCatalog> extends Adapter<S> imp
         public List<String> getColumnNames() {
             List<String> columnNames = new ArrayList<>( columnIds.size() );
             for ( long columnId : columnIds ) {
-                columnNames.add( Catalog.getInstance().getSnapshot().rel().getColumn( columnId ).orElseThrow().name );
+                columnNames.add( Catalog.snapshot().rel().getColumn( columnId ).orElseThrow().name );
             }
             return columnNames;
         }

--- a/core/src/main/java/org/polypheny/db/adapter/index/IndexManager.java
+++ b/core/src/main/java/org/polypheny/db/adapter/index/IndexManager.java
@@ -144,7 +144,7 @@ public class IndexManager {
 
 
     public void restoreIndexes() throws TransactionException {
-        for ( final LogicalIndex index : Catalog.getInstance().getSnapshot().rel().getIndexes() ) {
+        for ( final LogicalIndex index : Catalog.snapshot().rel().getIndexes() ) {
             if ( index.location < 0 ) {
                 addIndex( index );
             }
@@ -175,7 +175,7 @@ public class IndexManager {
                 method,
                 unique,
                 persistent,
-                Catalog.getInstance().getSnapshot().getNamespace( key.namespaceId ).orElseThrow(),
+                Catalog.snapshot().getNamespace( key.namespaceId ).orElseThrow(),
                 table,
                 key.getFieldNames(),
                 pk.getFieldNames() );

--- a/core/src/main/java/org/polypheny/db/algebra/logical/common/LogicalConstraintEnforcer.java
+++ b/core/src/main/java/org/polypheny/db/algebra/logical/common/LogicalConstraintEnforcer.java
@@ -95,7 +95,7 @@ public class LogicalConstraintEnforcer extends ConstraintEnforcer {
         AlgBuilder builder = AlgBuilder.create( statement );
         final RexBuilder rexBuilder = modify.getCluster().getRexBuilder();
 
-        LogicalRelSnapshot snapshot = Catalog.getInstance().getSnapshot().rel();
+        LogicalRelSnapshot snapshot = Catalog.snapshot().rel();
 
         EnforcementTime enforcementTime = EnforcementTime.ON_QUERY;
         final List<LogicalConstraint> constraints = new ArrayList<>( snapshot.getConstraints( table.id ) )
@@ -224,7 +224,7 @@ public class LogicalConstraintEnforcer extends ConstraintEnforcer {
 
         AlgBuilder builder = AlgBuilder.create( statement );
         final RexBuilder rexBuilder = builder.getRexBuilder();
-        LogicalRelSnapshot snapshot = Catalog.getInstance().getSnapshot().rel();
+        LogicalRelSnapshot snapshot = Catalog.snapshot().rel();
 
         final List<LogicalConstraint> constraints = snapshot
                 .getConstraints( table.id )

--- a/core/src/main/java/org/polypheny/db/catalog/Catalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/Catalog.java
@@ -260,11 +260,6 @@ public abstract class Catalog implements ExtensionPoint {
     public abstract Snapshot getSnapshot();
 
 
-    public Snapshot getSnapshot( long id ) {
-        return snapshot();
-    }
-
-
     public static Snapshot snapshot() {
         return INSTANCE.getSnapshot();
     }

--- a/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/allocation/AllocationTable.java
@@ -82,7 +82,7 @@ public class AllocationTable extends AllocationEntity {
 
 
     public String getNamespaceName() {
-        return Catalog.getInstance().getSnapshot().getNamespace( namespaceId ).orElseThrow().name;
+        return Catalog.snapshot().getNamespace( namespaceId ).orElseThrow().name;
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
@@ -76,7 +76,7 @@ public class LogicalTable extends LogicalEntity {
     public AlgDataType getTupleType() {
         final AlgDataTypeFactory.Builder fieldInfo = AlgDataTypeFactory.DEFAULT.builder();
 
-        for ( LogicalColumn column : Catalog.getInstance().getSnapshot().rel().getColumns( id ).stream().sorted( Comparator.comparingInt( a -> a.position ) ).toList() ) {
+        for ( LogicalColumn column : Catalog.snapshot().rel().getColumns( id ).stream().sorted( Comparator.comparingInt( a -> a.position ) ).toList() ) {
             AlgDataType sqlType = column.getAlgDataType( AlgDataTypeFactory.DEFAULT );
             fieldInfo.add( column.id, column.name, null, sqlType ).nullable( column.nullable );
         }
@@ -97,7 +97,7 @@ public class LogicalTable extends LogicalEntity {
 
 
     public List<LogicalColumn> getColumns() {
-        return Catalog.getInstance().getSnapshot().rel().getColumns( id );
+        return Catalog.snapshot().rel().getColumns( id );
     }
 
 
@@ -113,7 +113,7 @@ public class LogicalTable extends LogicalEntity {
 
     @Override
     public String getNamespaceName() {
-        return Catalog.getInstance().getSnapshot().getNamespace( namespaceId ).orElseThrow().name;
+        return Catalog.snapshot().getNamespace( namespaceId ).orElseThrow().name;
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -29,6 +29,7 @@ import java.beans.PropertyChangeListener;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -255,7 +256,7 @@ public class PolyCatalog extends Catalog implements PolySerializable {
 
         this.adapterRestore.clear();
         adapterCatalogs.forEach( ( id, catalog ) -> {
-            Map<Long, List<PhysicalEntity>> restore = catalog.allocToPhysicals.entrySet().stream().map( a -> Pair.of( a, a.getValue().stream().map( key -> catalog.physicals.get( key ).normalize() ).toList() ) ).collect( Collectors.toMap( a -> a.getKey().getKey(), Pair::getValue ) );
+            Map<Long, List<PhysicalEntity>> restore = catalog.allocToPhysicals.entrySet().stream().collect( Collectors.toMap( Entry::getKey, a -> a.getValue().stream().map( key -> catalog.physicals.get( key ).normalize() ).toList() ) );
             this.adapterRestore.put( id, new AdapterRestore( id, restore, catalog.allocations ) );
         } );
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -447,7 +447,7 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
         }
 
         LogicalTable table = tables.get( tableId );
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
         List<LogicalKey> childKeys = snapshot.rel().getTableKeys( referencesTableId );
 
         for ( LogicalKey refKey : childKeys ) {

--- a/core/src/main/java/org/polypheny/db/interpreter/ScanNode.java
+++ b/core/src/main/java/org/polypheny/db/interpreter/ScanNode.java
@@ -120,7 +120,7 @@ public class ScanNode implements Node {
 
         final Enumerable<Row<PolyValue>> rowEnumerable;
         if ( elementType instanceof Class<?> type ) {
-            final Queryable<PolyValue[]> queryable = Schemas.queryable( root, List.of( Catalog.getInstance().getSnapshot().getNamespace( alg.entity.namespaceId ).orElseThrow().name, alg.entity.name ) );
+            final Queryable<PolyValue[]> queryable = Schemas.queryable( root, List.of( Catalog.snapshot().getNamespace( alg.entity.namespaceId ).orElseThrow().name, alg.entity.name ) );
             ImmutableList.Builder<Field> fieldBuilder = ImmutableList.builder();
             for ( Field field : type.getFields() ) {
                 if ( Modifier.isPublic( field.getModifiers() ) && !Modifier.isStatic( field.getModifiers() ) ) {
@@ -141,7 +141,7 @@ public class ScanNode implements Node {
                 return new Row<>( values, PolyValue.class );
             } );
         } else {
-            rowEnumerable = Schemas.queryableRow( root, Object.class, List.of( Catalog.getInstance().getSnapshot().getNamespace( alg.entity.namespaceId ).orElseThrow().name, alg.getEntity().name ) );
+            rowEnumerable = Schemas.queryableRow( root, Object.class, List.of( Catalog.snapshot().getNamespace( alg.entity.namespaceId ).orElseThrow().name, alg.getEntity().name ) );
         }
         return createEnumerable( compiler, alg, rowEnumerable, null, filters, projects );
     }

--- a/core/src/main/java/org/polypheny/db/processing/LogicalAlgAnalyzeShuttle.java
+++ b/core/src/main/java/org/polypheny/db/processing/LogicalAlgAnalyzeShuttle.java
@@ -445,9 +445,9 @@ public class LogicalAlgAnalyzeShuttle extends AlgShuttleImpl {
 
         if ( scan.getEntity().unwrap( LogicalTable.class ).isPresent() ) {
             final LogicalTable table = scan.getEntity().unwrap( LogicalTable.class ).get();
-            final List<LogicalColumn> columns = Catalog.getInstance().getSnapshot().rel().getColumns( table.id );
+            final List<LogicalColumn> columns = Catalog.snapshot().rel().getColumns( table.id );
             final List<String> names = columns.stream().map( c -> c.name ).toList();
-            final String baseName = Catalog.getInstance().getSnapshot().getNamespace( table.namespaceId ) + "." + table.name + ".";
+            final String baseName = Catalog.snapshot().getNamespace( table.namespaceId ) + "." + table.name + ".";
 
             for ( int i = 0; i < columns.size(); i++ ) {
                 this.availableColumns.putIfAbsent( columns.get( i ).id, baseName + names.get( i ) );

--- a/core/src/main/java/org/polypheny/db/rex/RexTableIndexRef.java
+++ b/core/src/main/java/org/polypheny/db/rex/RexTableIndexRef.java
@@ -160,7 +160,7 @@ public class RexTableIndexRef extends RexIndexRef {
 
 
         public List<String> getQualifiedName() {
-            return List.of( Catalog.getInstance().getSnapshot().getNamespace( table.namespaceId ).orElseThrow().name, table.name );
+            return List.of( Catalog.snapshot().getNamespace( table.namespaceId ).orElseThrow().name, table.name );
         }
 
 

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -593,7 +593,7 @@ public class PolyphenyDb {
     private static void restoreDefaults( Catalog catalog, RunMode mode ) {
         catalog.updateSnapshot();
         DefaultInserter.resetData( DdlManager.getInstance(), mode );
-        DefaultInserter.restoreInterfacesIfNecessary();
+        DefaultInserter.restoreInterfacesIfNecessary( catalog );
     }
 
 

--- a/dbms/src/main/java/org/polypheny/db/ddl/DefaultInserter.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DefaultInserter.java
@@ -97,22 +97,22 @@ public class DefaultInserter {
     }
 
 
-    public static void restoreInterfacesIfNecessary() {
+    public static void restoreInterfacesIfNecessary( Catalog catalog ) {
         ////////////////////////
         // init query interfaces
-        if ( !Catalog.getInstance().getInterfaces().isEmpty() ) {
+        if ( !catalog.getInterfaces().isEmpty() ) {
             return;
         }
-        Catalog.getInstance().getInterfaceTemplates().values().forEach( i -> Catalog.getInstance().createQueryInterface( i.interfaceType().toLowerCase(), i.interfaceType(), i.getDefaultSettings() ) );
+        catalog.getInterfaceTemplates().values().forEach( i -> Catalog.getInstance().createQueryInterface( i.interfaceType().toLowerCase(), i.interfaceType(), i.getDefaultSettings() ) );
         // TODO: This is ugly, both because it is racy, and depends on a string (which might be changed)
-        if ( Catalog.getInstance().getInterfaceTemplates().values().stream().anyMatch( t -> t.interfaceType().equals( "Prism Interface (Unix transport)" ) ) ) {
-            Catalog.getInstance().createQueryInterface(
+        if ( catalog.getInterfaceTemplates().values().stream().anyMatch( t -> t.interfaceType().equals( "Prism Interface (Unix transport)" ) ) ) {
+            catalog.createQueryInterface(
                     "prism interface (unix transport @ .polypheny)",
                     "Prism Interface (Unix transport)",
                     Map.of( "path", PolyphenyHomeDirManager.getInstance().registerNewGlobalFile( "polypheny-prism.sock" ).getAbsolutePath() )
             );
         }
-        Catalog.getInstance().commit();
+        catalog.commit();
 
     }
 

--- a/dbms/src/main/java/org/polypheny/db/partition/AbstractPartitionManager.java
+++ b/dbms/src/main/java/org/polypheny/db/partition/AbstractPartitionManager.java
@@ -72,7 +72,7 @@ public abstract class AbstractPartitionManager implements PartitionManager {
                     continue;
                 }
                 List<AllocationColumn> allocColumns = allocation.unwrap( AllocationTable.class ).orElseThrow().getColumns();
-                if( placementDistribution.containsKey( allocation.partitionId ) ){
+                if ( placementDistribution.containsKey( allocation.partitionId ) ) {
                     List<AllocationColumn> existingAllocColumns = placementDistribution.get( allocation.partitionId );
                     List<Long> existingColumnsIds = existingAllocColumns.stream().map( e -> e.columnId ).toList();
                     List<Long> allocColumnIds = allocColumns.stream().map( c -> c.columnId ).toList();

--- a/dbms/src/main/java/org/polypheny/db/partition/AbstractPartitionManager.java
+++ b/dbms/src/main/java/org/polypheny/db/partition/AbstractPartitionManager.java
@@ -47,7 +47,7 @@ public abstract class AbstractPartitionManager implements PartitionManager {
     @Override
     public boolean probePartitionGroupDistributionChange( LogicalTable table, int storeId, long columnId, int threshold ) {
         // Check for the specified columnId if we still have a ColumnPlacement for every partitionGroup
-        for ( Long partitionIds : Catalog.snapshot().alloc().getPartitionProperty( table.id ).orElseThrow().partitionIds ) {
+        for ( Long partitionIds : catalog.getSnapshot().alloc().getPartitionProperty( table.id ).orElseThrow().partitionIds ) {
             List<AllocationColumn> ccps = catalog.getSnapshot().alloc().getColumnAllocsByPartitionGroup( table.id, partitionIds, columnId );
             if ( ccps.size() <= threshold ) {
                 for ( AllocationColumn placement : ccps ) {

--- a/dbms/src/main/java/org/polypheny/db/partition/AbstractPartitionManager.java
+++ b/dbms/src/main/java/org/polypheny/db/partition/AbstractPartitionManager.java
@@ -47,7 +47,7 @@ public abstract class AbstractPartitionManager implements PartitionManager {
     @Override
     public boolean probePartitionGroupDistributionChange( LogicalTable table, int storeId, long columnId, int threshold ) {
         // Check for the specified columnId if we still have a ColumnPlacement for every partitionGroup
-        for ( Long partitionIds : Catalog.getInstance().getSnapshot().alloc().getPartitionProperty( table.id ).orElseThrow().partitionIds ) {
+        for ( Long partitionIds : Catalog.snapshot().alloc().getPartitionProperty( table.id ).orElseThrow().partitionIds ) {
             List<AllocationColumn> ccps = catalog.getSnapshot().alloc().getColumnAllocsByPartitionGroup( table.id, partitionIds, columnId );
             if ( ccps.size() <= threshold ) {
                 for ( AllocationColumn placement : ccps ) {

--- a/dbms/src/main/java/org/polypheny/db/partition/FrequencyMapImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/partition/FrequencyMapImpl.java
@@ -336,7 +336,6 @@ public class FrequencyMapImpl extends FrequencyMap {
             if ( !hotPartitionsToCreate.isEmpty() ) {
                 catalog.getSnapshot().alloc().getPartitionsOnDataPlacement( store.getAdapterId(), table.id );
 
-
                 store.createTable( statement.getPrepareContext(), LogicalTableWrapper.of( null, null, null ), AllocationTableWrapper.of( null, null ) );
 
                 List<LogicalColumn> logicalColumns = new ArrayList<>();

--- a/dbms/src/main/java/org/polypheny/db/partition/FrequencyMapImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/partition/FrequencyMapImpl.java
@@ -219,7 +219,7 @@ public class FrequencyMapImpl extends FrequencyMap {
 
             // Which of those are currently in cold --> action needed
 
-            List<AllocationPartition> currentHotPartitions = Catalog.getInstance().getSnapshot().alloc().getPartitions( ((TemperaturePartitionProperty) property).getHotPartitionGroupId() );
+            List<AllocationPartition> currentHotPartitions = Catalog.snapshot().alloc().getPartitions( ((TemperaturePartitionProperty) property).getHotPartitionGroupId() );
             for ( AllocationPartition logicalPartition : currentHotPartitions ) {
 
                 // Remove partitions from List if they are already in HOT (not necessary to send to DataMigrator)
@@ -334,7 +334,7 @@ public class FrequencyMapImpl extends FrequencyMap {
 
             // If this storeId contains both Groups HOT {@literal &}  COLD do nothing
             if ( !hotPartitionsToCreate.isEmpty() ) {
-                Catalog.getInstance().getSnapshot().alloc().getPartitionsOnDataPlacement( store.getAdapterId(), table.id );
+                Catalog.snapshot().alloc().getPartitionsOnDataPlacement( store.getAdapterId(), table.id );
 
 
                 store.createTable( statement.getPrepareContext(), LogicalTableWrapper.of( null, null, null ), AllocationTableWrapper.of( null, null ) );
@@ -382,7 +382,7 @@ public class FrequencyMapImpl extends FrequencyMap {
      */
     private List<Long> filterList( long namespaceId, long adapterId, long tableId, List<Long> partitionsToFilter ) {
         // Remove partition from list if it's already contained on the storeId
-        for ( long partitionId : Catalog.getInstance().getSnapshot().alloc().getPartitionsOnDataPlacement( adapterId, tableId ) ) {
+        for ( long partitionId : Catalog.snapshot().alloc().getPartitionsOnDataPlacement( adapterId, tableId ) ) {
             partitionsToFilter.remove( partitionId );
         }
         return partitionsToFilter;

--- a/dbms/src/main/java/org/polypheny/db/partition/FrequencyMapImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/partition/FrequencyMapImpl.java
@@ -120,13 +120,13 @@ public class FrequencyMapImpl extends FrequencyMap {
      */
     private void processAllPeriodicTables() {
         log.debug( "Start processing access frequency of tables" );
-        Catalog catalog = Catalog.getInstance();
+        Snapshot snapshot = catalog.getSnapshot();
 
         long invocationTimestamp = System.currentTimeMillis();
-        List<LogicalTable> periodicTables = catalog.getSnapshot().getTablesForPeriodicProcessing();
+        List<LogicalTable> periodicTables = snapshot.getTablesForPeriodicProcessing();
         // Retrieve all Tables which rely on periodic processing
         for ( LogicalTable table : periodicTables ) {
-            if ( catalog.getSnapshot().alloc().getPartitionProperty( table.id ).orElseThrow().partitionType == PartitionType.TEMPERATURE ) {
+            if ( snapshot.alloc().getPartitionProperty( table.id ).orElseThrow().partitionType == PartitionType.TEMPERATURE ) {
                 determinePartitionFrequency( table, invocationTimestamp );
             }
         }
@@ -219,7 +219,7 @@ public class FrequencyMapImpl extends FrequencyMap {
 
             // Which of those are currently in cold --> action needed
 
-            List<AllocationPartition> currentHotPartitions = Catalog.snapshot().alloc().getPartitions( ((TemperaturePartitionProperty) property).getHotPartitionGroupId() );
+            List<AllocationPartition> currentHotPartitions = catalog.getSnapshot().alloc().getPartitions( ((TemperaturePartitionProperty) property).getHotPartitionGroupId() );
             for ( AllocationPartition logicalPartition : currentHotPartitions ) {
 
                 // Remove partitions from List if they are already in HOT (not necessary to send to DataMigrator)
@@ -303,8 +303,8 @@ public class FrequencyMapImpl extends FrequencyMap {
             long coldPartitionGroupId = ((TemperaturePartitionProperty) property).getColdPartitionGroupId();
 
             // Update catalogInformation
-            partitionsFromColdToHot.forEach( p -> Catalog.getInstance().getAllocRel( table.namespaceId ).updatePartition( p, hotPartitionGroupId ) );
-            partitionsFromHotToCold.forEach( p -> Catalog.getInstance().getAllocRel( table.namespaceId ).updatePartition( p, coldPartitionGroupId ) );
+            partitionsFromColdToHot.forEach( p -> catalog.getAllocRel( table.namespaceId ).updatePartition( p, hotPartitionGroupId ) );
+            partitionsFromHotToCold.forEach( p -> catalog.getAllocRel( table.namespaceId ).updatePartition( p, coldPartitionGroupId ) );
 
             // Remove all tables that have been moved
             for ( DataStore<?> store : partitionsToRemoveFromStore.keySet() ) {
@@ -334,7 +334,7 @@ public class FrequencyMapImpl extends FrequencyMap {
 
             // If this storeId contains both Groups HOT {@literal &}  COLD do nothing
             if ( !hotPartitionsToCreate.isEmpty() ) {
-                Catalog.snapshot().alloc().getPartitionsOnDataPlacement( store.getAdapterId(), table.id );
+                catalog.getSnapshot().alloc().getPartitionsOnDataPlacement( store.getAdapterId(), table.id );
 
 
                 store.createTable( statement.getPrepareContext(), LogicalTableWrapper.of( null, null, null ), AllocationTableWrapper.of( null, null ) );
@@ -345,7 +345,7 @@ public class FrequencyMapImpl extends FrequencyMap {
                 AllocationPlacement placement = catalog.getSnapshot().alloc().getPlacement( store.getAdapterId(), table.id ).orElseThrow();
 
                 for ( long id : hotPartitionsToCreate ) {
-                    AllocationEntity entity = Catalog.snapshot().alloc().getAlloc( placement.id, id ).orElseThrow();
+                    AllocationEntity entity = catalog.getSnapshot().alloc().getAlloc( placement.id, id ).orElseThrow();
                     dataMigrator.copyData(
                             statement.getTransaction(),
                             catalog.getSnapshot().getAdapter( store.getAdapterId() ).orElseThrow(),
@@ -382,7 +382,7 @@ public class FrequencyMapImpl extends FrequencyMap {
      */
     private List<Long> filterList( long namespaceId, long adapterId, long tableId, List<Long> partitionsToFilter ) {
         // Remove partition from list if it's already contained on the storeId
-        for ( long partitionId : Catalog.snapshot().alloc().getPartitionsOnDataPlacement( adapterId, tableId ) ) {
+        for ( long partitionId : catalog.getSnapshot().alloc().getPartitionsOnDataPlacement( adapterId, tableId ) ) {
             partitionsToFilter.remove( partitionId );
         }
         return partitionsToFilter;

--- a/dbms/src/main/java/org/polypheny/db/partition/TemperatureAwarePartitionManager.java
+++ b/dbms/src/main/java/org/polypheny/db/partition/TemperatureAwarePartitionManager.java
@@ -55,7 +55,7 @@ public class TemperatureAwarePartitionManager extends AbstractPartitionManager {
     public Map<Long, List<AllocationColumn>> getRelevantPlacements( LogicalTable table, List<AllocationEntity> allocs, List<Long> excludedAdapters ) {
         // Get partition manager
         PartitionManagerFactory partitionManagerFactory = PartitionManagerFactory.getInstance();
-        PartitionProperty property = Catalog.getInstance().getSnapshot().alloc().getPartitionProperty( table.id ).orElseThrow();
+        PartitionProperty property = Catalog.snapshot().alloc().getPartitionProperty( table.id ).orElseThrow();
         PartitionManager partitionManager = partitionManagerFactory.getPartitionManager(
                 ((TemperaturePartitionProperty) property).getInternalPartitionFunction()
         );
@@ -68,7 +68,7 @@ public class TemperatureAwarePartitionManager extends AbstractPartitionManager {
     public Map<Long, Map<Long, List<AllocationColumn>>> getAllPlacements( LogicalTable table, List<Long> partitionIds ) {
         // Get partition manager
         PartitionManagerFactory partitionManagerFactory = PartitionManagerFactory.getInstance();
-        PartitionProperty property = Catalog.getInstance().getSnapshot().alloc().getPartitionProperty( table.id ).orElseThrow();
+        PartitionProperty property = Catalog.snapshot().alloc().getPartitionProperty( table.id ).orElseThrow();
         PartitionManager partitionManager = partitionManagerFactory.getPartitionManager(
                 ((TemperaturePartitionProperty) property).getInternalPartitionFunction()
         );

--- a/dbms/src/main/java/org/polypheny/db/processing/AbstractQueryProcessor.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/AbstractQueryProcessor.java
@@ -1266,7 +1266,7 @@ public abstract class AbstractQueryProcessor implements QueryProcessor, Executio
                                 "TableID: {} is partitioned on column: {} - {}",
                                 table.id,
                                 property.partitionColumnId,
-                                Catalog.getInstance().getSnapshot().rel().getColumn( property.partitionColumnId ).orElseThrow().name );
+                                Catalog.snapshot().rel().getColumn( property.partitionColumnId ).orElseThrow().name );
 
                     }
                     List<Long> identifiedPartitions = new ArrayList<>();

--- a/dbms/src/main/java/org/polypheny/db/processing/AuthenticatorImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/AuthenticatorImpl.java
@@ -32,7 +32,7 @@ public class AuthenticatorImpl implements Authenticator {
 
     @Override
     public LogicalUser authenticate( final String username, final String password ) throws AuthenticationException {
-        LogicalUser logicalUser = Catalog.getInstance().getSnapshot().getUser( username ).orElseThrow( () -> new AuthenticationException( "Wrong username or password" ) );
+        LogicalUser logicalUser = Catalog.snapshot().getUser( username ).orElseThrow( () -> new AuthenticationException( "Wrong username or password" ) );
         if ( Arrays.constantTimeAreEqual( logicalUser.password.getBytes( StandardCharsets.UTF_8 ), password.getBytes( StandardCharsets.UTF_8 ) ) ) {
             return logicalUser;
         } else {

--- a/dbms/src/main/java/org/polypheny/db/processing/ConstraintEnforceAttacher.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/ConstraintEnforceAttacher.java
@@ -643,7 +643,7 @@ public class ConstraintEnforceAttacher {
                             .getSnapshot()
                             .getNamespaces( null )
                             .stream()
-			.flatMap( n -> Catalog.snapshot().rel().getTables( n.id, null ).stream() )
+                            .flatMap( n -> Catalog.snapshot().rel().getTables( n.id, null ).stream() )
                             .filter( t -> t.entityType == EntityType.ENTITY && t.getDataModel() == DataModel.RELATIONAL )
                             .toList();
                     Transaction transaction = this.manager.startTransaction( Catalog.defaultUserId, false, "ConstraintEnforcement" );

--- a/dbms/src/main/java/org/polypheny/db/processing/ConstraintEnforceAttacher.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/ConstraintEnforceAttacher.java
@@ -643,7 +643,7 @@ public class ConstraintEnforceAttacher {
                             .getSnapshot()
                             .getNamespaces( null )
                             .stream()
-                            .flatMap( n -> Catalog.getInstance().getSnapshot().rel().getTables( n.id, null ).stream() )
+			.flatMap( n -> Catalog.snapshot().rel().getTables( n.id, null ).stream() )
                             .filter( t -> t.entityType == EntityType.ENTITY && t.getDataModel() == DataModel.RELATIONAL )
                             .toList();
                     Transaction transaction = this.manager.startTransaction( Catalog.defaultUserId, false, "ConstraintEnforcement" );

--- a/dbms/src/main/java/org/polypheny/db/processing/DataMigratorImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/DataMigratorImpl.java
@@ -409,7 +409,7 @@ public class DataMigratorImpl implements DataMigrator {
         List<String> columnNames = new LinkedList<>();
         List<RexNode> values = new ArrayList<>();
         for ( AllocationColumn ccp : to ) {
-            LogicalColumn logicalColumn = Catalog.getInstance().getSnapshot().rel().getColumn( ccp.columnId ).orElseThrow();
+            LogicalColumn logicalColumn = Catalog.snapshot().rel().getColumn( ccp.columnId ).orElseThrow();
             columnNames.add( ccp.getLogicalColumnName() );
             values.add( new RexDynamicParam( logicalColumn.getAlgDataType( typeFactory ), (int) logicalColumn.id ) );
         }
@@ -443,7 +443,7 @@ public class DataMigratorImpl implements DataMigrator {
         List<String> columnNames = new ArrayList<>();
         List<RexNode> values = new ArrayList<>();
         for ( AllocationColumn ccp : placements ) {
-            LogicalColumn logicalColumn = Catalog.getInstance().getSnapshot().rel().getColumn( ccp.columnId ).orElseThrow();
+            LogicalColumn logicalColumn = Catalog.snapshot().rel().getColumn( ccp.columnId ).orElseThrow();
             columnNames.add( ccp.getLogicalColumnName() );
             values.add( new RexDynamicParam( logicalColumn.getAlgDataType( typeFactory ), (int) logicalColumn.id ) );
         }
@@ -469,11 +469,11 @@ public class DataMigratorImpl implements DataMigrator {
 
         // build condition
         RexNode condition = null;
-        LogicalRelSnapshot snapshot = Catalog.getInstance().getSnapshot().rel();
+        LogicalRelSnapshot snapshot = Catalog.snapshot().rel();
         LogicalTable catalogTable = snapshot.getTable( to.get( 0 ).logicalTableId ).orElseThrow();
         LogicalPrimaryKey primaryKey = snapshot.getPrimaryKey( catalogTable.primaryKey ).orElseThrow();
         for ( long cid : primaryKey.fieldIds ) {
-            AllocationColumn ccp = Catalog.getInstance().getSnapshot().alloc().getColumn( to.get( 0 ).placementId, cid ).orElseThrow();
+            AllocationColumn ccp = Catalog.snapshot().alloc().getColumn( to.get( 0 ).placementId, cid ).orElseThrow();
             LogicalColumn logicalColumn = snapshot.getColumn( cid ).orElseThrow();
             RexNode c = builder.equals(
                     builder.field( ccp.getLogicalColumnName() ),
@@ -535,7 +535,7 @@ public class DataMigratorImpl implements DataMigrator {
         if ( targetTables.stream().anyMatch( t -> t.logicalId != sourceTables.get( 0 ).logicalId ) ) {
             throw new GenericRuntimeException( "Unsupported migration scenario. Table ID mismatch" );
         }
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
 
         // Add partition columns to select column list
         long partitionColumnId = targetProperty.partitionColumnId;

--- a/dbms/src/main/java/org/polypheny/db/routing/routers/DmlRouterImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/routing/routers/DmlRouterImpl.java
@@ -59,7 +59,6 @@ import org.polypheny.db.algebra.logical.relational.LogicalRelScan;
 import org.polypheny.db.algebra.logical.relational.LogicalRelValues;
 import org.polypheny.db.algebra.type.AlgDataType;
 import org.polypheny.db.algebra.type.AlgDataTypeField;
-import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.Entity;
 import org.polypheny.db.catalog.entity.allocation.AllocationColumn;
 import org.polypheny.db.catalog.entity.allocation.AllocationEntity;
@@ -890,7 +889,7 @@ public class DmlRouterImpl extends BaseRouter implements DmlRouter {
 
         builder = super.handleValues( values, builder );
 
-        List<LogicalColumn> columns = Catalog.snapshot().rel().getColumns( table.id );
+        List<LogicalColumn> columns = catalog.getSnapshot().rel().getColumns( table.id );
         if ( columns.size() == placements.size() ) { // full placement, no additional checks required
             return builder;
         } else if ( node.getTupleType().toString().equals( "RecordType(INTEGER ZERO)" ) ) {
@@ -951,7 +950,7 @@ public class DmlRouterImpl extends BaseRouter implements DmlRouter {
                 }
                 columnName = columnNames[1];
             } else if ( columnNames.length == 3 ) { // schemaName.tableName.columnName
-                if ( !Catalog.snapshot().getNamespace( catalogTable.id ).orElseThrow().name.equalsIgnoreCase( columnNames[0] ) ) {
+                if ( !catalog.getSnapshot().getNamespace( catalogTable.id ).orElseThrow().name.equalsIgnoreCase( columnNames[0] ) ) {
                     throw new GenericRuntimeException( "Schema name does not match expected schema name: " + field.getName() );
                 }
                 if ( !catalogTable.name.equalsIgnoreCase( columnNames[1] ) ) {
@@ -961,8 +960,8 @@ public class DmlRouterImpl extends BaseRouter implements DmlRouter {
             } else {
                 throw new GenericRuntimeException( "Invalid column name: " + field.getName() );
             }
-            column = Catalog.snapshot().rel().getColumn( catalogTable.id, columnName ).orElseThrow();
-            if ( Catalog.snapshot().alloc().getColumn( placements.get( 0 ).placementId, column.id ).isEmpty() ) {
+            column = catalog.getSnapshot().rel().getColumn( catalogTable.id, columnName ).orElseThrow();
+            if ( catalog.getSnapshot().alloc().getColumn( placements.get( 0 ).placementId, column.id ).isEmpty() ) {
                 throw new GenericRuntimeException( "Current implementation of vertical partitioning does not allow conditions on partitioned columns. " );
                 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 // TODO: Use indexes

--- a/dbms/src/main/java/org/polypheny/db/routing/strategies/CreateSinglePlacementStrategy.java
+++ b/dbms/src/main/java/org/polypheny/db/routing/strategies/CreateSinglePlacementStrategy.java
@@ -32,7 +32,7 @@ public class CreateSinglePlacementStrategy implements CreatePlacementStrategy {
 
     @Override
     public List<DataStore<?>> getDataStoresForNewRelField( LogicalColumn addedField ) {
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
         List<AllocationEntity> allocations = snapshot.alloc().getFromLogical( addedField.tableId );
         return ImmutableList.of( AdapterManager.getInstance().getStore( allocations.get( 0 ).adapterId ).orElseThrow() );
     }

--- a/dbms/src/main/java/org/polypheny/db/transaction/EntityAccessMap.java
+++ b/dbms/src/main/java/org/polypheny/db/transaction/EntityAccessMap.java
@@ -287,7 +287,7 @@ public class EntityAccessMap {
                 relevantAllocations = accessedPartitions.get( p.getEntity().id );
             } else {
                 if ( entity.dataModel == DataModel.RELATIONAL ) {
-                    List<AllocationEntity> allocations = Catalog.getInstance().getSnapshot().alloc().getFromLogical( entity.id );
+                    List<AllocationEntity> allocations = Catalog.snapshot().alloc().getFromLogical( entity.id );
                     relevantAllocations = allocations.stream().map( a -> a.id ).toList();
                 } else {
                     relevantAllocations = List.of();
@@ -344,7 +344,7 @@ public class EntityAccessMap {
         private void extractWriteConstraints( LogicalTable logicalTable ) {
 
             for ( long constraintTable : logicalTable.getConstraintIds() ) {
-                PartitionProperty property = Catalog.getInstance().getSnapshot().alloc().getPartitionProperty( logicalTable.id ).orElseThrow();
+                PartitionProperty property = Catalog.snapshot().alloc().getPartitionProperty( logicalTable.id ).orElseThrow();
                 for ( long constraintPartitionIds : property.partitionIds ) {
 
                     EntityIdentifier id = new EntityIdentifier( constraintTable, constraintPartitionIds, NamespaceLevel.ENTITY_LEVEL );

--- a/dbms/src/main/java/org/polypheny/db/transaction/TransactionImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/transaction/TransactionImpl.java
@@ -137,7 +137,7 @@ public class TransactionImpl implements Transaction, Comparable<Object> {
 
     @Override
     public Snapshot getSnapshot() {
-        return Catalog.getInstance().getSnapshot();
+        return Catalog.snapshot();
     }
 
 

--- a/dbms/src/main/java/org/polypheny/db/view/MaterializedViewManagerImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/view/MaterializedViewManagerImpl.java
@@ -106,7 +106,7 @@ public class MaterializedViewManagerImpl extends MaterializedViewManager {
     public synchronized Map<Long, MaterializedCriteria> updateMaterializedViewInfo() {
         List<Long> toRemove = new ArrayList<>();
         for ( long id : materializedInfo.keySet() ) {
-            if ( Catalog.getInstance().getSnapshot().getLogicalEntity( id ).isEmpty() ) {
+            if ( Catalog.snapshot().getLogicalEntity( id ).isEmpty() ) {
                 toRemove.add( id );
             }
         }
@@ -213,7 +213,7 @@ public class MaterializedViewManagerImpl extends MaterializedViewManager {
      * @param potentialInteresting id of underlying entity that was updated
      */
     public void materializedUpdate( long potentialInteresting ) {
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
         List<LogicalView> connectedViews = snapshot.rel().getConnectedViews( potentialInteresting );
 
         for ( LogicalView view : connectedViews ) {

--- a/dbms/src/test/java/org/polypheny/db/cypher/CypherTestTemplate.java
+++ b/dbms/src/test/java/org/polypheny/db/cypher/CypherTestTemplate.java
@@ -96,7 +96,7 @@ public class CypherTestTemplate {
 
     public static void deleteData( String graph ) {
         execute( format( "DROP DATABASE %s IF EXISTS", graph ) );
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
         AdapterCatalog adapterCatalog = Catalog.getInstance().getAdapterCatalog( 0 ).orElseThrow();
     }
 

--- a/dbms/src/test/java/org/polypheny/db/statistics/StatisticsTest.java
+++ b/dbms/src/test/java/org/polypheny/db/statistics/StatisticsTest.java
@@ -255,7 +255,7 @@ public class StatisticsTest {
                         true );
 
                 waiter.await( 20, TimeUnit.SECONDS );
-                Snapshot snapshot = Catalog.getInstance().getSnapshot();
+                Snapshot snapshot = Catalog.snapshot();
                 LogicalTable catalogTableNation = snapshot.rel().getTable( "statisticschema", "nation" ).orElseThrow();
                 LogicalTable catalogTableRegion = snapshot.rel().getTable( "statisticschema", "region" ).orElseThrow();
 

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/DashboardInformation.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/DashboardInformation.java
@@ -71,7 +71,7 @@ public class DashboardInformation {
 
 
     public void updateStatistic() {
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
         this.catalogPersistent = Catalog.getInstance().isPersistent;
 
         this.numberOfQueries = MonitoringServiceProvider.getInstance().getAllDataPoints( QueryDataPointImpl.class ).size();

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/QueryResult.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/QueryResult.java
@@ -41,7 +41,7 @@ public class QueryResult {
 
 
     public static QueryResult fromCatalogColumn( LogicalColumn column ) {
-        return new QueryResult( Catalog.getInstance().getSnapshot().rel().getTable( column.tableId ).orElseThrow(), column );
+        return new QueryResult( Catalog.snapshot().rel().getTable( column.tableId ).orElseThrow(), column );
     }
 
 }

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticQueryProcessor.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticQueryProcessor.java
@@ -83,7 +83,7 @@ public class StatisticQueryProcessor {
      * @return all the columns
      */
     public List<QueryResult> getAllColumns() {
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
         return snapshot.getNamespaces( null )
                 .stream()
                 .filter( n -> n.dataModel == DataModel.RELATIONAL )
@@ -99,7 +99,7 @@ public class StatisticQueryProcessor {
      * @return all the tables ids
      */
     public List<LogicalTable> getAllRelEntites() {
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
         return snapshot.getNamespaces( null ).stream().filter( n -> n.dataModel == DataModel.RELATIONAL )
                 .flatMap( n -> snapshot.rel().getTables( Pattern.of( n.name ), null ).stream().filter( t -> t.entityType != EntityType.VIEW ) ).collect( Collectors.toList() );
     }
@@ -111,7 +111,7 @@ public class StatisticQueryProcessor {
      * @return all columns
      */
     public List<QueryResult> getAllColumns( Long tableId ) {
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
         return snapshot.getNamespaces( null ).stream().flatMap( n -> snapshot.rel().getColumns( tableId ).stream() ).map( QueryResult::fromCatalogColumn ).collect( Collectors.toList() );
     }
 

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticRepository.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticRepository.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.polypheny.db.StatisticsManager;
 import org.polypheny.db.catalog.Catalog;
+import org.polypheny.db.catalog.snapshot.Snapshot;
 import org.polypheny.db.monitoring.events.MonitoringDataPoint;
 import org.polypheny.db.monitoring.events.MonitoringDataPoint.DataPointType;
 import org.polypheny.db.monitoring.events.MonitoringType;
@@ -87,11 +88,11 @@ public class StatisticRepository implements MonitoringRepository {
         if ( !dataPoint.getAvailableColumnsWithTable().isEmpty() ) {
             Set<Long> values = new HashSet<>( dataPoint.getAvailableColumnsWithTable().values() );
             boolean isOneTable = values.size() == 1;
-            Catalog catalog = Catalog.getInstance();
+            Snapshot snapshot = Catalog.snapshot();
 
             if ( isOneTable ) {
                 long tableId = values.stream().findFirst().get();
-                if ( catalog.getSnapshot().getLogicalEntity( tableId ).isPresent() ) {
+                if ( snapshot.getLogicalEntity( tableId ).isPresent() ) {
                     statisticsManager.setEntityCalls( tableId, dataPoint.getMonitoringType() );
 
                     // RowCount from UI is only used if there is no other possibility
@@ -105,7 +106,7 @@ public class StatisticRepository implements MonitoringRepository {
                 }
             } else {
                 for ( long id : values ) {
-                    if ( catalog.getSnapshot().getLogicalEntity( id ).isPresent() ) {
+                    if ( snapshot.getLogicalEntity( id ).isPresent() ) {
                         statisticsManager.setEntityCalls( id, dataPoint.getMonitoringType() );
                     }
                 }
@@ -122,12 +123,12 @@ public class StatisticRepository implements MonitoringRepository {
         Set<Long> values = new HashSet<>( dataPoint.getAvailableColumnsWithTable().values() );
         boolean isOneTable = values.size() == 1;
 
-        Catalog catalog = Catalog.getInstance();
+        Snapshot snapshot = Catalog.snapshot();
         if ( isOneTable ) {
             long tableId = values.stream().findFirst().get();
             statisticsManager.setEntityCalls( tableId, dataPoint.getMonitoringType() );
 
-            if ( catalog.getSnapshot().getLogicalEntity( tableId ).isEmpty() ) {
+            if ( snapshot.getLogicalEntity( tableId ).isEmpty() ) {
                 return;
             }
             if ( dataPoint.getMonitoringType() == MonitoringType.INSERT ) {
@@ -136,7 +137,7 @@ public class StatisticRepository implements MonitoringRepository {
                         tableId,
                         dataPoint.getChangedValues(),
                         dataPoint.getMonitoringType(),
-                        catalog.getSnapshot().getLogicalEntity( tableId ).orElseThrow().namespaceId );
+                        snapshot.getLogicalEntity( tableId ).orElseThrow().namespaceId );
                 statisticsManager.updateRowCountPerEntity( tableId, added, dataPoint.getMonitoringType() );
             } else if ( dataPoint.getMonitoringType() == MonitoringType.DELETE ) {
                 long deleted = dataPoint.getRowCount();
@@ -146,7 +147,7 @@ public class StatisticRepository implements MonitoringRepository {
             }
         } else {
             for ( long id : values ) {
-                if ( catalog.getSnapshot().getLogicalEntity( id ).isPresent() ) {
+                if ( snapshot.getLogicalEntity( id ).isPresent() ) {
                     statisticsManager.setEntityCalls( id, dataPoint.getMonitoringType() );
                 }
 

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticTable.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticTable.java
@@ -25,6 +25,7 @@ import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.logical.LogicalTable;
 import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.catalog.logistic.EntityType;
+import org.polypheny.db.catalog.snapshot.Snapshot;
 
 
 /**
@@ -70,9 +71,9 @@ public class StatisticTable {
     public StatisticTable( Long tableId ) {
         this.tableId = tableId;
 
-        Catalog catalog = Catalog.getInstance();
-        if ( catalog.getSnapshot().getLogicalEntity( tableId ).isPresent() ) {
-            LogicalTable catalogTable = catalog.getSnapshot().getLogicalEntity( tableId ).map( e -> e.unwrap( LogicalTable.class ) ).orElseThrow().orElseThrow();
+        Snapshot snapshot = Catalog.snapshot();
+        if ( snapshot.getLogicalEntity( tableId ).isPresent() ) {
+            LogicalTable catalogTable = snapshot.getLogicalEntity( tableId ).flatMap( e -> e.unwrap( LogicalTable.class ) ).orElseThrow();
             this.table = catalogTable.name;
             this.dataModel = catalogTable.dataModel;
             this.entityType = catalogTable.entityType;

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticsManagerImpl.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticsManagerImpl.java
@@ -186,7 +186,7 @@ public class StatisticsManagerImpl extends StatisticsManager {
 
     private void resetAllIsFull() {
         this.statisticFields.values().forEach( c -> {
-            assignUnique( c, this.prepareNode( QueryResult.fromCatalogColumn( Catalog.getInstance().getSnapshot().rel().getColumn( c.columnId ).orElseThrow() ), NodeType.UNIQUE_VALUE ) );
+		assignUnique( c, this.prepareNode( QueryResult.fromCatalogColumn( Catalog.snapshot().rel().getColumn( c.columnId ).orElseThrow() ), NodeType.UNIQUE_VALUE ) );
         } );
     }
 
@@ -235,7 +235,7 @@ public class StatisticsManagerImpl extends StatisticsManager {
         log.debug( "Reevaluate Row Count." );
 
         statisticQueryInterface.getAllRelEntites().forEach( table -> {
-            PolyInteger rowCount = getNumberColumnCount( this.prepareNode( new QueryResult( Catalog.getInstance().getSnapshot().getLogicalEntity( table.id ).orElseThrow(), null ), NodeType.ROW_COUNT_TABLE ) );
+		PolyInteger rowCount = getNumberColumnCount( this.prepareNode( new QueryResult( Catalog.snapshot().getLogicalEntity( table.id ).orElseThrow(), null ), NodeType.ROW_COUNT_TABLE ) );
             updateRowCountPerEntity( table.id, rowCount.value, MonitoringType.SET_ROW_COUNT );
         } );
     }
@@ -436,7 +436,7 @@ public class StatisticsManagerImpl extends StatisticsManager {
 
     private StatisticQueryResult prepareNode( QueryResult queryResult, NodeType nodeType ) {
         StatisticQueryResult statisticQueryColumn = null;
-        if ( Catalog.getInstance().getSnapshot().getLogicalEntity( queryResult.getEntity().id ).isPresent() ) {
+        if ( Catalog.snapshot().getLogicalEntity( queryResult.getEntity().id ).isPresent() ) {
             AlgNode queryNode = getQueryNode( queryResult, nodeType );
             statisticQueryColumn = statisticQueryInterface.selectOneColumnStat( queryNode, transaction, statement, queryResult );
         }
@@ -747,7 +747,7 @@ public class StatisticsManagerImpl extends StatisticsManager {
     private void workQueue() {
         while ( !this.tablesToUpdate.isEmpty() ) {
             long tableId = this.tablesToUpdate.poll();
-            if ( Catalog.getInstance().getSnapshot().getLogicalEntity( tableId ).isPresent() ) {
+            if ( Catalog.snapshot().getLogicalEntity( tableId ).isPresent() ) {
                 reevaluateEntity( tableId );
                 return;
             }
@@ -1098,7 +1098,7 @@ public class StatisticsManagerImpl extends StatisticsManager {
             } else if ( v.type.getFamily() == PolyTypeFamily.CHARACTER ) {
                 alphabeticInfo.add( (AlphabeticStatisticColumn) v );
                 statisticTable.setAlphabeticColumn( alphabeticInfo );
-            } else if ( PolyType.DATETIME_TYPES.contains( Catalog.getInstance().getSnapshot().rel().getColumn( k ).orElseThrow().type ) ) {
+            } else if ( PolyType.DATETIME_TYPES.contains( Catalog.snapshot().rel().getColumn( k ).orElseThrow().type ) ) {
                 temporalInfo.add( (TemporalStatisticColumn) v );
                 statisticTable.setTemporalColumn( temporalInfo );
             }

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticsManagerImpl.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticsManagerImpl.java
@@ -186,7 +186,7 @@ public class StatisticsManagerImpl extends StatisticsManager {
 
     private void resetAllIsFull() {
         this.statisticFields.values().forEach( c -> {
-		assignUnique( c, this.prepareNode( QueryResult.fromCatalogColumn( Catalog.snapshot().rel().getColumn( c.columnId ).orElseThrow() ), NodeType.UNIQUE_VALUE ) );
+            assignUnique( c, this.prepareNode( QueryResult.fromCatalogColumn( Catalog.snapshot().rel().getColumn( c.columnId ).orElseThrow() ), NodeType.UNIQUE_VALUE ) );
         } );
     }
 
@@ -235,7 +235,7 @@ public class StatisticsManagerImpl extends StatisticsManager {
         log.debug( "Reevaluate Row Count." );
 
         statisticQueryInterface.getAllRelEntites().forEach( table -> {
-		PolyInteger rowCount = getNumberColumnCount( this.prepareNode( new QueryResult( Catalog.snapshot().getLogicalEntity( table.id ).orElseThrow(), null ), NodeType.ROW_COUNT_TABLE ) );
+            PolyInteger rowCount = getNumberColumnCount( this.prepareNode( new QueryResult( Catalog.snapshot().getLogicalEntity( table.id ).orElseThrow(), null ), NodeType.ROW_COUNT_TABLE ) );
             updateRowCountPerEntity( table.id, rowCount.value, MonitoringType.SET_ROW_COUNT );
         } );
     }

--- a/plugins/cql-language/src/main/java/org/polypheny/db/cql/Combiner.java
+++ b/plugins/cql-language/src/main/java/org/polypheny/db/cql/Combiner.java
@@ -150,7 +150,7 @@ public class Combiner {
         LogicalTable rightCatalogTable = right.catalogTable;
         List<String> columnList = Arrays.asList( columnStrs );
 
-        LogicalRelSnapshot relSnapshot = Catalog.getInstance().getSnapshot().rel();
+        LogicalRelSnapshot relSnapshot = Catalog.snapshot().rel();
         List<String> lColumnNames = relSnapshot.getColumns( leftCatalogTable.id ).stream().map( c -> c.name ).toList();
         List<String> rColumnNames = relSnapshot.getColumns( rightCatalogTable.id ).stream().map( c -> c.name ).toList();
         if ( !new HashSet<>( lColumnNames ).containsAll( columnList ) || !new HashSet<>( rColumnNames ).containsAll( columnList ) ) {
@@ -170,7 +170,7 @@ public class Combiner {
         if ( log.isDebugEnabled() ) {
             log.debug( "Getting Common Columns between '{}' and '{}'.", table1.fullyQualifiedName, table2.fullyQualifiedName );
         }
-        LogicalRelSnapshot relSnapshot = Catalog.getInstance().getSnapshot().rel();
+        LogicalRelSnapshot relSnapshot = Catalog.snapshot().rel();
         List<String> table1Columns = relSnapshot.getColumns( table1.catalogTable.id ).stream().map( c -> c.name ).toList();
         List<String> table2Columns = relSnapshot.getColumns( table2.catalogTable.id ).stream().map( c -> c.name ).toList();
 

--- a/plugins/cql-language/src/main/java/org/polypheny/db/cql/Cql2AlgConverter.java
+++ b/plugins/cql-language/src/main/java/org/polypheny/db/cql/Cql2AlgConverter.java
@@ -148,7 +148,7 @@ public class Cql2AlgConverter {
                     if ( treeNode.isLeaf() ) {
                         LogicalTable table = treeNode.getExternalNode().catalogTable;
                         algBuilderAtomicReference.set(
-                                algBuilderAtomicReference.get().relScan( Catalog.getInstance().getSnapshot().getNamespace( table.namespaceId ).orElseThrow().name, table.name )
+						      algBuilderAtomicReference.get().relScan( Catalog.snapshot().getNamespace( table.namespaceId ).orElseThrow().name, table.name )
                         );
                     } else {
                         Combiner combiner = treeNode.getInternalNode();

--- a/plugins/cql-language/src/main/java/org/polypheny/db/cql/Cql2AlgConverter.java
+++ b/plugins/cql-language/src/main/java/org/polypheny/db/cql/Cql2AlgConverter.java
@@ -148,7 +148,7 @@ public class Cql2AlgConverter {
                     if ( treeNode.isLeaf() ) {
                         LogicalTable table = treeNode.getExternalNode().catalogTable;
                         algBuilderAtomicReference.set(
-						      algBuilderAtomicReference.get().relScan( Catalog.snapshot().getNamespace( table.namespaceId ).orElseThrow().name, table.name )
+                                algBuilderAtomicReference.get().relScan( Catalog.snapshot().getNamespace( table.namespaceId ).orElseThrow().name, table.name )
                         );
                     } else {
                         Combiner combiner = treeNode.getInternalNode();

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/ClientManager.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/ClientManager.java
@@ -69,12 +69,12 @@ class ClientManager {
             return authenticator.authenticate( username, password );
         } else if ( t.getPeer().isPresent() ) {
             String username = t.getPeer().get();
-            Optional<LogicalUser> catalogUser = Catalog.getInstance().getSnapshot().getUser( username );
+            Optional<LogicalUser> catalogUser = Catalog.snapshot().getUser( username );
             if ( catalogUser.isPresent() ) {
                 return catalogUser.get();
             } else {
                 if ( username.equals( System.getProperty( "user.name" ) ) ) {
-                    return Catalog.getInstance().getSnapshot().getUser( Catalog.USER_NAME ).orElseThrow();
+                    return Catalog.snapshot().getUser( Catalog.USER_NAME ).orElseThrow();
                 } else {
                     throw new AuthenticationException( "Peer authentication failed: No user with that name" );
                 }
@@ -126,7 +126,7 @@ class ClientManager {
         if ( connectionRequest.hasConnectionProperties() && connectionRequest.getConnectionProperties().hasNamespaceName() ) {
             namespaceName = connectionRequest.getConnectionProperties().getNamespaceName();
         }
-        Optional<LogicalNamespace> optionalNamespace = Catalog.getInstance().getSnapshot().getNamespace( namespaceName );
+        Optional<LogicalNamespace> optionalNamespace = Catalog.snapshot().getNamespace( namespaceName );
         if ( optionalNamespace.isEmpty() ) {
             throw new PIServiceException( "Getting namespace " + namespaceName + " failed." );
         }

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/DbMetaRetriever.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/DbMetaRetriever.java
@@ -73,7 +73,7 @@ class DbMetaRetriever {
 
     private static List<LogicalNamespace> getLogicalNamespaces( String namespacePattern, String namespaceType ) {
         Pattern catalogNamespacePattern = getPatternOrNull( namespacePattern );
-        List<LogicalNamespace> logicalNamespaces = Catalog.getInstance().getSnapshot().getNamespaces( catalogNamespacePattern );
+        List<LogicalNamespace> logicalNamespaces = Catalog.snapshot().getNamespaces( catalogNamespacePattern );
         if ( namespaceType == null ) {
             return logicalNamespaces;
         }
@@ -96,14 +96,14 @@ class DbMetaRetriever {
 
 
     public static Namespace getNamespace( String namespaceName ) {
-        return getNamespaceMeta( Catalog.getInstance().getSnapshot().getNamespace( namespaceName ).orElseThrow() );
+        return getNamespaceMeta( Catalog.snapshot().getNamespace( namespaceName ).orElseThrow() );
     }
 
 
     // Entity search by namespace
     static EntitiesResponse searchEntities( String namespaceName, String entityPattern ) {
         EntitiesResponse.Builder responseBuilder = EntitiesResponse.newBuilder();
-        LogicalNamespace namespace = Catalog.getInstance().getSnapshot().getNamespace( namespaceName ).orElseThrow();
+        LogicalNamespace namespace = Catalog.snapshot().getNamespace( namespaceName ).orElseThrow();
         return switch ( namespace.getDataModel() ) {
             case RELATIONAL -> responseBuilder.addAllEntities( getRelationalEntities( namespace.getId(), entityPattern ) ).build();
             case GRAPH -> responseBuilder.addAllEntities( getGraphEntities( namespace.getId(), entityPattern ) ).build();
@@ -115,7 +115,7 @@ class DbMetaRetriever {
     // Relational entities
     private static List<Entity> getRelationalEntities( long namespaceId, String entityPattern ) {
         Pattern catalogEntityPattern = getPatternOrNull( entityPattern );
-        final List<LogicalTable> tables = Catalog.getInstance().getSnapshot().rel().getTables( namespaceId, catalogEntityPattern );
+        final List<LogicalTable> tables = Catalog.snapshot().rel().getTables( namespaceId, catalogEntityPattern );
         return tables.stream().map( logicalTable -> buildEntityFromTable( getTableMeta( logicalTable ) ) ).toList();
     }
 
@@ -152,12 +152,12 @@ class DbMetaRetriever {
         if ( logicalTable.primaryKey == null ) {
             return false;
         }
-        return Catalog.getInstance().getSnapshot().rel().getPrimaryKey( logicalTable.primaryKey ).isPresent();
+        return Catalog.snapshot().rel().getPrimaryKey( logicalTable.primaryKey ).isPresent();
     }
 
 
     private static PrimaryKey getPrimaryKeyMeta( LogicalTable logicalTable ) {
-        LogicalPrimaryKey logicalPrimaryKey = Catalog.getInstance().getSnapshot().rel().getPrimaryKey( logicalTable.primaryKey ).orElseThrow();
+        LogicalPrimaryKey logicalPrimaryKey = Catalog.snapshot().rel().getPrimaryKey( logicalTable.primaryKey ).orElseThrow();
         return PrimaryKey.newBuilder()
                 .setDatabaseName( logicalPrimaryKey.getSchemaName() )
                 .setNamespaceName( logicalPrimaryKey.getSchemaName() )
@@ -191,7 +191,7 @@ class DbMetaRetriever {
 
 
     private static List<ForeignKey> getForeignKeys( LogicalTable logicalTable ) {
-        return Catalog.getInstance().getSnapshot().rel().getForeignKeys( logicalTable.getId() )
+        return Catalog.snapshot().rel().getForeignKeys( logicalTable.getId() )
                 .stream().map( DbMetaRetriever::getForeignKeyMeta ).toList();
     }
 
@@ -215,13 +215,13 @@ class DbMetaRetriever {
 
 
     private static List<ForeignKey> getExportedKeys( LogicalTable logicalTable ) {
-        return Catalog.getInstance().getSnapshot().rel().getExportedKeys( logicalTable.getId() )
+        return Catalog.snapshot().rel().getExportedKeys( logicalTable.getId() )
                 .stream().map( DbMetaRetriever::getForeignKeyMeta ).toList();
     }
 
 
     private static List<Index> getIndexes( LogicalTable logicalTable, boolean unique ) {
-        return Catalog.getInstance().getSnapshot().rel().getIndexes( logicalTable.getId(), unique )
+        return Catalog.snapshot().rel().getIndexes( logicalTable.getId(), unique )
                 .stream().map( DbMetaRetriever::getIndexMeta ).toList();
     }
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
@@ -514,7 +514,7 @@ class PIService {
         }
         if ( properties.hasNamespaceName() ) {
             String namespaceName = properties.getNamespaceName();
-            Optional<LogicalNamespace> optionalNamespace = Catalog.getInstance().getSnapshot().getNamespace( namespaceName );
+            Optional<LogicalNamespace> optionalNamespace = Catalog.snapshot().getNamespace( namespaceName );
             if ( optionalNamespace.isEmpty() ) {
                 throw new PIServiceException( "Getting namespace " + namespaceName + " failed." );
             }

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/StatementManager.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/StatementManager.java
@@ -49,7 +49,7 @@ public class StatementManager {
 
 
     private LogicalNamespace getNamespace( String namespaceName ) {
-        Optional<LogicalNamespace> optionalNamespace = Catalog.getInstance().getSnapshot().getNamespace( namespaceName );
+        Optional<LogicalNamespace> optionalNamespace = Catalog.snapshot().getNamespace( namespaceName );
 
         if ( optionalNamespace.isEmpty() ) {
             throw new PIServiceException( "Getting namespace " + namespaceName + " failed." );

--- a/plugins/rest-interface/src/main/java/org/polypheny/db/restapi/Rest.java
+++ b/plugins/rest-interface/src/main/java/org/polypheny/db/restapi/Rest.java
@@ -168,7 +168,7 @@ public class Rest {
         // Table Modify
 
         AlgPlanner planner = statement.getQueryProcessor().getPlanner();
-        AlgCluster cluster = AlgCluster.create( planner, rexBuilder, null, Catalog.getInstance().getSnapshot() );
+        AlgCluster cluster = AlgCluster.create( planner, rexBuilder, null, Catalog.snapshot() );
 
         // Values
         AlgDataType tableRowType = table.getTupleType();
@@ -225,7 +225,7 @@ public class Rest {
         // Table Modify
 
         AlgPlanner planner = statement.getQueryProcessor().getPlanner();
-        AlgCluster cluster = AlgCluster.create( planner, rexBuilder, null, Catalog.getInstance().getSnapshot() );
+        AlgCluster cluster = AlgCluster.create( planner, rexBuilder, null, Catalog.snapshot() );
 
         AlgNode algNode = algBuilder.build();
         RelModify<?> modify = new LogicalRelModify(
@@ -272,7 +272,7 @@ public class Rest {
         List<AlgDataTypeField> tableRows = tableRowType.getFields();
 
         AlgPlanner planner = statement.getQueryProcessor().getPlanner();
-        AlgCluster cluster = AlgCluster.create( planner, rexBuilder, null, Catalog.getInstance().getSnapshot() );
+        AlgCluster cluster = AlgCluster.create( planner, rexBuilder, null, Catalog.snapshot() );
 
         List<String> valueColumnNames = this.valuesColumnNames( insertValueRequest.values );
         List<RexNode> rexValues = this.valuesNode( statement, algBuilder, rexBuilder, insertValueRequest, tableRows, inputStreams ).get( 0 );

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/SqlProcessor.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/SqlProcessor.java
@@ -256,7 +256,7 @@ public class SqlProcessor extends Processor {
 
         if ( oldColumnList != null ) {
             LogicalTable catalogTable = getTable( transaction, (SqlIdentifier) insert.getTargetTable() );
-            DataModel dataModel = Catalog.getInstance().getSnapshot().getNamespace( catalogTable.namespaceId ).orElseThrow().dataModel;
+            DataModel dataModel = Catalog.snapshot().getNamespace( catalogTable.namespaceId ).orElseThrow().dataModel;
 
             catalogTable = getTable( transaction, (SqlIdentifier) insert.getTargetTable() );
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateMaterializedView.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateMaterializedView.java
@@ -66,8 +66,10 @@ public class SqlCreateMaterializedView extends SqlCreate implements ExecutableSt
     SqlNodeList columns;
     @Getter
     SqlNode query;
-    @Nullable List<SqlIdentifier> store;
-    @Nullable String freshnessType;
+    @Nullable
+    List<SqlIdentifier> store;
+    @Nullable
+    String freshnessType;
     Integer freshnessTime;
     SqlIdentifier freshnessId;
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateMaterializedView.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateMaterializedView.java
@@ -72,7 +72,7 @@ public class SqlCreateMaterializedView extends SqlCreate implements ExecutableSt
     SqlIdentifier freshnessId;
 
     private static final SqlOperator OPERATOR = new SqlSpecialOperator( "CREATE MATERIALIZED VIEW", Kind.CREATE_MATERIALIZED_VIEW );
-    Snapshot snapshot = Catalog.getInstance().getSnapshot();
+    Snapshot snapshot = Catalog.snapshot();
 
 
     /**

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateTable.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateTable.java
@@ -92,7 +92,7 @@ public class SqlCreateTable extends SqlCreate implements ExecutableStatement {
     List<List<SqlNode>> partitionQualifierList;
 
     private static final SqlOperator OPERATOR = new SqlSpecialOperator( "CREATE TABLE", Kind.CREATE_TABLE );
-    Snapshot snapshot = Catalog.getInstance().getSnapshot();
+    Snapshot snapshot = Catalog.snapshot();
 
 
     /**

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateView.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateView.java
@@ -64,7 +64,7 @@ public class SqlCreateView extends SqlCreate implements ExecutableStatement {
     private static final SqlOperator OPERATOR = new SqlSpecialOperator( "CREATE VIEW", Kind.CREATE_VIEW );
 
 
-    private final Snapshot snapshot = Catalog.getInstance().getSnapshot();
+    private final Snapshot snapshot = Catalog.snapshot();
 
 
     /**

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -1704,7 +1704,7 @@ public class Crud implements InformationObserver, PropertyChangeListener {
 
 
     private PlacementModel getPlacements( final IndexModel index ) {
-        Snapshot snapshot = Catalog.getInstance().getSnapshot();
+        Snapshot snapshot = Catalog.snapshot();
 
         LogicalTable table = Catalog.snapshot().rel().getTable( index.entityId ).orElseThrow();
         PlacementModel p = new PlacementModel( snapshot.alloc().getFromLogical( table.id ).size() > 1, snapshot.alloc().getPartitionGroupNames( table.id ), table.entityType );
@@ -1831,9 +1831,9 @@ public class Crud implements InformationObserver, PropertyChangeListener {
         // Check whether the selected partition function supports the selected partition column
         LogicalColumn partitionColumn;
 
-        LogicalNamespace namespace = Catalog.getInstance().getSnapshot().getNamespace( request.schemaName ).orElseThrow();
+        LogicalNamespace namespace = Catalog.snapshot().getNamespace( request.schemaName ).orElseThrow();
 
-        partitionColumn = Catalog.getInstance().getSnapshot().rel().getColumn( namespace.id, request.tableName, request.column ).orElseThrow();
+        partitionColumn = Catalog.snapshot().rel().getColumn( namespace.id, request.tableName, request.column ).orElseThrow();
 
         if ( !partitionManager.supportsColumnOfType( partitionColumn.type ) ) {
             ctx.json( new PartitionFunctionModel( "The partition function " + request.method + " does not support columns of type " + partitionColumn.type ) );

--- a/webui/src/main/java/org/polypheny/db/webui/WebSocket.java
+++ b/webui/src/main/java/org/polypheny/db/webui/WebSocket.java
@@ -160,7 +160,7 @@ public class WebSocket implements Consumer<WsConfig> {
                 } else {//TableRequest, is equal to UIRequest
                     UIRequest uiRequest = ctx.messageAsClass( UIRequest.class );
                     try {
-                        LogicalNamespace namespace = Catalog.getInstance().getSnapshot().getNamespace( uiRequest.namespace ).orElse( null );
+                        LogicalNamespace namespace = Catalog.snapshot().getNamespace( uiRequest.namespace ).orElse( null );
                         result = switch ( namespace == null ? DataModel.RELATIONAL : namespace.dataModel ) {
                             case RELATIONAL -> crud.getTable( uiRequest );
                             case DOCUMENT -> {

--- a/webui/src/main/java/org/polypheny/db/webui/crud/LanguageCrud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/crud/LanguageCrud.java
@@ -456,7 +456,7 @@ public class LanguageCrud {
      * as a query result
      */
     public void getDocumentDatabases( final Context ctx ) {
-        Map<String, String> names = Catalog.getInstance().getSnapshot()
+        Map<String, String> names = Catalog.snapshot()
                 .getNamespaces( null )
                 .stream()
                 .collect( Collectors.toMap( LogicalNamespace::getName, s -> s.dataModel.name() ) );

--- a/webui/src/main/java/org/polypheny/db/webui/crud/LanguageCrud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/crud/LanguageCrud.java
@@ -479,22 +479,17 @@ public class LanguageCrud {
     private PlacementModel getPlacements( final IndexModel index ) {
         Catalog catalog = Catalog.getInstance();
         LogicalGraph graph = Catalog.snapshot().graph().getGraph( index.namespaceId ).orElseThrow();
-        EntityType type = EntityType.ENTITY;
         PlacementModel p = new PlacementModel( false, List.of(), EntityType.ENTITY );
-        if ( type == EntityType.VIEW ) {
-            return p;
-        } else {
-            List<AllocationPlacement> placements = catalog.getSnapshot().alloc().getPlacementsFromLogical( graph.id );
-            for ( AllocationPlacement placement : placements ) {
-                Adapter<?> adapter = AdapterManager.getInstance().getAdapter( placement.adapterId ).orElseThrow();
-                p.addAdapter( new PlacementModel.GraphStore(
-                        adapter.getUniqueName(),
-                        adapter.getUniqueName(),
-                        catalog.getSnapshot().alloc().getFromLogical( placement.adapterId ),
-                        false ) );
-            }
-            return p;
+        List<AllocationPlacement> placements = catalog.getSnapshot().alloc().getPlacementsFromLogical( graph.id );
+        for ( AllocationPlacement placement : placements ) {
+            Adapter<?> adapter = AdapterManager.getInstance().getAdapter( placement.adapterId ).orElseThrow();
+            p.addAdapter( new PlacementModel.GraphStore(
+                    adapter.getUniqueName(),
+                    adapter.getUniqueName(),
+                    catalog.getSnapshot().alloc().getFromLogical( placement.adapterId ),
+                    false ) );
         }
+        return p;
 
     }
 

--- a/webui/src/main/java/org/polypheny/db/webui/crud/LanguageCrud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/crud/LanguageCrud.java
@@ -478,7 +478,7 @@ public class LanguageCrud {
 
     private PlacementModel getPlacements( final IndexModel index ) {
         Catalog catalog = Catalog.getInstance();
-        LogicalGraph graph = Catalog.snapshot().graph().getGraph( index.namespaceId ).orElseThrow();
+        LogicalGraph graph = catalog.getSnapshot().graph().getGraph( index.namespaceId ).orElseThrow();
         PlacementModel p = new PlacementModel( false, List.of(), EntityType.ENTITY );
         List<AllocationPlacement> placements = catalog.getSnapshot().alloc().getPlacementsFromLogical( graph.id );
         for ( AllocationPlacement placement : placements ) {
@@ -495,7 +495,6 @@ public class LanguageCrud {
 
 
     public void getFixedFields( Context context ) {
-        Catalog catalog = Catalog.getInstance();
         UIRequest request = context.bodyAsClass( UIRequest.class );
         RelationalResult result;
         List<UiColumnDefinition> cols = new ArrayList<>();

--- a/webui/src/main/java/org/polypheny/db/webui/crud/StatisticCrud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/crud/StatisticCrud.java
@@ -83,7 +83,7 @@ public class StatisticCrud {
 
     public void getTableStatistics( Context ctx ) {
         UIRequest request = ctx.bodyAsClass( UIRequest.class );
-        LogicalTable table = Catalog.getInstance().getSnapshot().rel().getTable( request.entityId ).orElseThrow();
+        LogicalTable table = Catalog.snapshot().rel().getTable( request.entityId ).orElseThrow();
 
         ctx.json( StatisticsManager.getInstance().getEntityStatistic( table.namespaceId, table.id ) );
     }

--- a/webui/src/main/java/org/polypheny/db/webui/models/requests/BatchUpdateRequest.java
+++ b/webui/src/main/java/org/polypheny/db/webui/models/requests/BatchUpdateRequest.java
@@ -33,6 +33,7 @@ import org.polypheny.db.algebra.type.AlgDataTypeFactory;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.logical.LogicalColumn;
 import org.polypheny.db.catalog.entity.logical.LogicalTable;
+import org.polypheny.db.catalog.snapshot.Snapshot;
 import org.polypheny.db.transaction.Statement;
 import org.polypheny.db.type.PolyTypeFamily;
 import org.polypheny.db.type.entity.category.PolyBlob;
@@ -60,11 +61,11 @@ public class BatchUpdateRequest {
             for ( Entry<String, Value> entry : newValues.entrySet() ) {
                 String fileName = entry.getValue().fileName;
                 String value = entry.getValue().value;
-                Catalog catalog = Catalog.getInstance();
                 String[] split = tableId.split( "\\." );
                 LogicalColumn logicalColumn;
-                LogicalTable table = catalog.getSnapshot().rel().getTable( split[0], split[1] ).orElseThrow();
-                logicalColumn = catalog.getSnapshot().rel().getColumn( table.id, entry.getKey() ).orElseThrow();
+                Snapshot snapshot = Catalog.snapshot();
+                LogicalTable table = snapshot.rel().getTable( split[0], split[1] ).orElseThrow();
+                logicalColumn = snapshot.rel().getColumn( table.id, entry.getKey() ).orElseThrow();
                 if ( fileName == null && value == null ) {
                     setClauses.add( String.format( "\"%s\"=NULL", entry.getKey() ) );
                 } else if ( value != null && fileName == null ) {


### PR DESCRIPTION
 - Replace `Catalog.getInstance().getSnapshot()` with `Catalog.snapshot`
 - Remove one unused method from the catalog
 - Remove an unecessary  `map` call
 - When the class has a catalog field, use that instead of `Catalog`
 - Remove a conditional that is always false
 - Create a local variable of type `Snapshot` instead of `Catalog` when only the snapshot is needed anyways