### PR TITLE
Log Prism Error Responses in Benchmark Mode

### DIFF
--- a/core/src/main/java/org/polypheny/db/algebra/core/SetOp.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/SetOp.java
@@ -49,7 +49,6 @@ import org.polypheny.db.algebra.type.AlgDataType;
 import org.polypheny.db.plan.AlgCluster;
 import org.polypheny.db.plan.AlgOptUtil;
 import org.polypheny.db.plan.AlgTraitSet;
-import org.polypheny.db.util.Util;
 
 
 /**
@@ -124,7 +123,7 @@ public abstract class SetOp extends AbstractAlgNode {
         final List<AlgDataType> inputRowTypes = Lists.transform( inputs, AlgNode::getTupleType );
         final AlgDataType rowType = getCluster().getTypeFactory().leastRestrictive( inputRowTypes );
         if ( rowType == null ) {
-            throw new IllegalArgumentException( "Cannot compute compatible row type for arguments to set op: " + Util.sepList( inputRowTypes, ", " ) );
+            throw new IllegalArgumentException( "Cannot compute compatible row type for arguments to set op: " + String.join( ", ", inputRowTypes.stream().map( Object::toString ).toList() ) );
         }
         return rowType;
     }

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -398,20 +398,15 @@ public class PolyCatalog extends Catalog implements PolySerializable {
         long id = idBuilder.getNewLogicalId();
         LogicalNamespace namespace = new LogicalNamespace( id, name, dataModel, caseSensitive );
 
-        switch ( dataModel ) {
-            case RELATIONAL:
-                logicalCatalogs.put( id, new RelationalCatalog( namespace ) );
-                allocationCatalogs.put( id, new PolyAllocRelCatalog( namespace ) );
-                break;
-            case DOCUMENT:
-                logicalCatalogs.put( id, new DocumentCatalog( namespace ) );
-                allocationCatalogs.put( id, new PolyAllocDocCatalog( namespace ) );
-                break;
-            case GRAPH:
-                logicalCatalogs.put( id, new GraphCatalog( namespace ) );
-                allocationCatalogs.put( id, new PolyAllocGraphCatalog( namespace ) );
-                break;
-        }
+        Pair<LogicalCatalog, AllocationCatalog> catalogs = switch ( dataModel ) {
+            case RELATIONAL -> Pair.of( new RelationalCatalog( namespace ), new PolyAllocRelCatalog( namespace ) );
+            case DOCUMENT -> Pair.of( new DocumentCatalog( namespace ), new PolyAllocDocCatalog( namespace ) );
+            case GRAPH -> Pair.of( new GraphCatalog( namespace ), new PolyAllocGraphCatalog( namespace ) );
+        };
+
+        logicalCatalogs.put( id, catalogs.left );
+        allocationCatalogs.put( id, catalogs.right );
+
         change();
         return id;
     }

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -16,9 +16,7 @@
 
 package org.polypheny.db.catalog.impl;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;

--- a/core/src/main/java/org/polypheny/db/catalog/logistic/DataModel.java
+++ b/core/src/main/java/org/polypheny/db/catalog/logistic/DataModel.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.catalog.logistic;
 
 import lombok.Getter;
-import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.schema.trait.ModelTrait;
 
 @Getter
@@ -42,13 +41,10 @@ public enum DataModel {
 
 
     public ModelTrait getModelTrait() {
-        if ( this == DataModel.RELATIONAL ) {
-            return ModelTrait.RELATIONAL;
-        } else if ( this == DataModel.DOCUMENT ) {
-            return ModelTrait.DOCUMENT;
-        } else if ( this == DataModel.GRAPH ) {
-            return ModelTrait.GRAPH;
-        }
-        throw new GenericRuntimeException( "Not found a suitable NamespaceType." );
+        return switch ( this ) {
+            case RELATIONAL -> ModelTrait.RELATIONAL;
+            case DOCUMENT -> ModelTrait.DOCUMENT;
+            case GRAPH -> ModelTrait.GRAPH;
+        };
     }
 }

--- a/core/src/main/java/org/polypheny/db/rex/RexBuilder.java
+++ b/core/src/main/java/org/polypheny/db/rex/RexBuilder.java
@@ -470,15 +470,6 @@ public class RexBuilder {
                 if ( Objects.requireNonNull( typeName ) == PolyType.INTERVAL ) {
                     assert value.isInterval();
                     typeName = type.getPolyType();
-                    switch ( typeName ) {
-                        case BIGINT:
-                        case INTEGER:
-                        case SMALLINT:
-                        case TINYINT:
-                        case FLOAT:
-                        case REAL:
-                        case DECIMAL:
-                    }
 
                     // Not all types are allowed for literals
                     if ( typeName == PolyType.INTEGER ) {

--- a/core/src/main/java/org/polypheny/db/rex/RexUnknownAs.java
+++ b/core/src/main/java/org/polypheny/db/rex/RexUnknownAs.java
@@ -95,14 +95,11 @@ public enum RexUnknownAs {
 
 
     public boolean toBoolean() {
-        switch ( this ) {
-            case FALSE:
-                return false;
-            case TRUE:
-                return true;
-            default:
-                throw new IllegalArgumentException( "unknown" );
-        }
+        return switch ( this ) {
+            case FALSE -> false;
+            case TRUE -> true;
+            case UNKNOWN -> throw new IllegalArgumentException( "unknown" );
+        };
     }
 }
 

--- a/core/src/main/java/org/polypheny/db/rex/RexUnknownAs.java
+++ b/core/src/main/java/org/polypheny/db/rex/RexUnknownAs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The Polypheny Project
+ * Copyright 2019-2024 The Polypheny Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,4 +102,3 @@ public enum RexUnknownAs {
         };
     }
 }
-

--- a/core/src/main/java/org/polypheny/db/util/MonikerImpl.java
+++ b/core/src/main/java/org/polypheny/db/util/MonikerImpl.java
@@ -77,7 +77,7 @@ public class MonikerImpl implements Moniker {
 
 
     public String toString() {
-        return Util.sepList( names, "." );
+        return String.join( ".", names );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/util/MonikerImpl.java
+++ b/core/src/main/java/org/polypheny/db/util/MonikerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 The Polypheny Project
+ * Copyright 2019-2024 The Polypheny Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,4 +87,3 @@ public class MonikerImpl implements Moniker {
     }
 
 }
-

--- a/core/src/main/java/org/polypheny/db/util/NameMatchers.java
+++ b/core/src/main/java/org/polypheny/db/util/NameMatchers.java
@@ -140,7 +140,7 @@ public class NameMatchers {
 
         @Override
         public String bestString() {
-            return Util.sepList( toStar( bestMatch() ), "." );
+            return String.join( ".", toStar( bestMatch() ) );
         }
 
 

--- a/core/src/main/java/org/polypheny/db/util/PrecedenceClimbingParser.java
+++ b/core/src/main/java/org/polypheny/db/util/PrecedenceClimbingParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The Polypheny Project
+ * Copyright 2019-2024 The Polypheny Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -282,6 +282,7 @@ public class PrecedenceClimbingParser {
         public Token copy() {
             return new Token( type, o, left, right );
         }
+
     }
 
 
@@ -299,6 +300,7 @@ public class PrecedenceClimbingParser {
         public Token copy() {
             return new Op( type, o, left, right );
         }
+
     }
 
 
@@ -320,6 +322,7 @@ public class PrecedenceClimbingParser {
         public Token copy() {
             return new SpecialOp( o, left, right, special );
         }
+
     }
 
 
@@ -395,6 +398,7 @@ public class PrecedenceClimbingParser {
             }
             return b;
         }
+
     }
 
 
@@ -407,6 +411,7 @@ public class PrecedenceClimbingParser {
          * Given an occurrence of this operator, identifies the range of tokens to be collapsed into a call of this operator, and the arguments to that call.
          */
         Result apply( PrecedenceClimbingParser parser, SpecialOp op );
+
     }
 
 
@@ -425,6 +430,7 @@ public class PrecedenceClimbingParser {
             this.last = last;
             this.replacement = replacement;
         }
+
     }
 
 
@@ -476,6 +482,7 @@ public class PrecedenceClimbingParser {
         public PrecedenceClimbingParser build() {
             return new PrecedenceClimbingParser( tokens );
         }
+
     }
 
 
@@ -539,6 +546,7 @@ public class PrecedenceClimbingParser {
             }
             return t;
         }
-    }
-}
 
+    }
+
+}

--- a/core/src/main/java/org/polypheny/db/util/PrecedenceClimbingParser.java
+++ b/core/src/main/java/org/polypheny/db/util/PrecedenceClimbingParser.java
@@ -142,7 +142,7 @@ public class PrecedenceClimbingParser {
 
     @Override
     public String toString() {
-        return Util.commaList( all() );
+        return String.join( ", ", all().stream().map( Object::toString ).toList() );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/util/Util.java
+++ b/core/src/main/java/org/polypheny/db/util/Util.java
@@ -575,39 +575,10 @@ public class Util {
 
 
     /**
-     * Converts a list of a string, with commas between elements.
-     * <p>
-     * For example,
-     * <code>commaList(Arrays.asList({"a", "b"}))</code>
-     * returns "a, b".
-     *
-     * @param list List
-     * @return String representation of string
-     */
-    public static <T> String commaList( List<T> list ) {
-        return sepList( list, ", " );
-    }
-
-
-    /**
      * Converts a list of a string, with a given separator between elements.
      */
-    public static <T> String sepList( List<T> list, String sep ) {
-        final int max = list.size() - 1;
-        switch ( max ) {
-            case -1:
-                return "";
-            case 0:
-                return list.get( 0 ).toString();
-        }
-        final StringBuilder buf = new StringBuilder();
-        for ( int i = 0; ; i++ ) {
-            buf.append( list.get( i ) );
-            if ( i == max ) {
-                return buf.toString();
-            }
-            buf.append( sep );
-        }
+    public static <T> String sepList( List<T> list, CharSequence sep ) {
+        return String.join( sep, list.stream().map( Object::toString ).toList() );
     }
 
 

--- a/core/src/test/java/org/polypheny/db/util/UtilTest.java
+++ b/core/src/test/java/org/polypheny/db/util/UtilTest.java
@@ -986,24 +986,6 @@ public class UtilTest {
 
 
     /**
-     * Tests {@link Util#commaList(java.util.List)}.
-     */
-    @Test
-    public void testCommaList() {
-        try {
-            String s = Util.commaList( null );
-            fail( "expected NPE, got " + s );
-        } catch ( NullPointerException e ) {
-            // ok
-        }
-        assertThat( Util.commaList( ImmutableList.of() ), equalTo( "" ) );
-        assertThat( Util.commaList( ImmutableList.of( 1 ) ), equalTo( "1" ) );
-        assertThat( Util.commaList( ImmutableList.of( 2, 3 ) ), equalTo( "2, 3" ) );
-        assertThat( Util.commaList( Arrays.asList( 2, null, 3 ) ), equalTo( "2, null, 3" ) );
-    }
-
-
-    /**
      * Unit test for {@link Util#firstDuplicate(java.util.List)}.
      */
     @Test

--- a/plugins/mongodb-adapter/src/main/java/org/polypheny/db/adapter/mongodb/util/RexToMongoTranslator.java
+++ b/plugins/mongodb-adapter/src/main/java/org/polypheny/db/adapter/mongodb/util/RexToMongoTranslator.java
@@ -44,7 +44,6 @@ import org.polypheny.db.rex.RexNameRef;
 import org.polypheny.db.rex.RexNode;
 import org.polypheny.db.rex.RexVisitorImpl;
 import org.polypheny.db.type.PolyType;
-import org.polypheny.db.util.Util;
 
 /**
  * Translator from {@link RexNode} to strings in MongoDB's expression language.
@@ -161,7 +160,7 @@ public class RexToMongoTranslator extends RexVisitorImpl<String> {
                     strings.add( " { \"$strLenCP\":" + strings.get( 0 ) + "}" );
                 }
             }
-            return "{" + stdOperator + ": [" + Util.commaList( strings ) + "]}";
+            return "{" + stdOperator + ": [" + String.join( ", ", strings ) + "]}";
         }
         if ( call.getOperator().getOperatorName() == OperatorName.ITEM ) {
             final RexNode op1 = call.operands.get( 1 );

--- a/plugins/neo4j-adapter/src/main/java/org/polypheny/db/adapter/neo4j/util/NeoUtil.java
+++ b/plugins/neo4j-adapter/src/main/java/org/polypheny/db/adapter/neo4j/util/NeoUtil.java
@@ -90,71 +90,37 @@ public interface NeoUtil {
     }
 
     static Function1<Value, PolyValue> getUnnullableTypeFunction( NestedPolyType type, boolean isNested ) {
-
-        switch ( type.getType() ) {
-            case NULL:
-                return o -> PolyNull.NULL;
-            case BOOLEAN:
-                return value -> PolyBoolean.of( value.asBoolean() );
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-                return v -> PolyInteger.of( v.asNumber() );
-            case DATE:
-                return v -> PolyDate.of( v.asNumber() );
-            case TIME:
-                return v -> PolyTime.of( v.asNumber() );
-            case TIMESTAMP:
-                return v -> PolyTimestamp.of( v.asNumber() );
-            case BIGINT:
-                return v -> PolyBigDecimal.of( v.asLong() );
-            case DECIMAL:
-                return v -> v instanceof StringValue ? PolyBigDecimal.of( v.asString() ) : PolyBigDecimal.of( v.asDouble() );
-            case FLOAT:
-            case REAL:
-                return v -> v instanceof StringValue ? PolyFloat.of( Float.valueOf( v.asString() ) ) : PolyFloat.of( v.asNumber() );
-            case DOUBLE:
-                return v -> v instanceof StringValue ? PolyDouble.of( Double.valueOf( v.asString() ) ) : PolyDouble.of( v.asNumber() );
-            case INTERVAL:
-                break;
-            case ANY:
-                return v -> PolyString.of( v.asObject().toString() );
-            case CHAR:
-            case VARCHAR:
-            case TEXT:
-                return v -> PolyString.of( v.asString() );
-            case BINARY:
-            case VARBINARY:
-                return v -> PolyBinary.of( v.asByteArray() );
-            case FILE:
-            case IMAGE:
-            case VIDEO:
-            case AUDIO:
-                return v -> PolyBlob.of( v.asByteArray() );
-            case SYMBOL:
-                return v -> PolySymbol.of( v.asObject() );
-            case ARRAY:
+        return switch ( type.getType() ) {
+            case NULL -> o -> PolyNull.NULL;
+            case BOOLEAN -> v -> PolyBoolean.of( v.asBoolean() );
+            case TINYINT, SMALLINT, INTEGER -> v -> PolyInteger.of( v.asNumber() );
+            case DATE -> v -> PolyDate.of( v.asNumber() );
+            case TIME -> v -> PolyTime.of( v.asNumber() );
+            case TIMESTAMP -> v -> PolyTimestamp.of( v.asNumber() );
+            case BIGINT -> v -> PolyBigDecimal.of( v.asLong() );
+            case DECIMAL -> v -> v instanceof StringValue ? PolyBigDecimal.of( v.asString() ) : PolyBigDecimal.of( v.asDouble() );
+            case FLOAT, REAL -> v -> v instanceof StringValue ? PolyFloat.of( Float.valueOf( v.asString() ) ) : PolyFloat.of( v.asNumber() );
+            case DOUBLE -> v -> v instanceof StringValue ? PolyDouble.of( Double.valueOf( v.asString() ) ) : PolyDouble.of( v.asNumber() );
+            case ANY -> v -> PolyString.of( v.asObject().toString() );
+            case CHAR, VARCHAR, TEXT -> v -> PolyString.of( v.asString() );
+            case BINARY, VARBINARY -> v -> PolyBinary.of( v.asByteArray() );
+            case FILE, IMAGE, VIDEO, AUDIO -> v -> PolyBlob.of( v.asByteArray() );
+            case SYMBOL -> v -> PolySymbol.of( v.asObject() );
+            case ARRAY -> {
                 if ( isNested ) {
-                    return v -> PolyValue.fromTypedJson( v.asString(), PolyList.class );
+                    yield v -> PolyValue.fromTypedJson( v.asString(), PolyList.class );
                 }
                 Function1<Value, PolyValue> componentFunc = getTypeFunction( type.asList().types.get( 0 ), true );
-                return el -> PolyList.of( el.asList( componentFunc::apply ) );
-            case MAP:
-                return value -> PolyString.of( value.asString() );
-            case DOCUMENT:
-            case JSON:
-                return value -> PolyDocument.deserialize( value.asString() );
-            case GRAPH:
-                return o -> (PolyValue) o;
-            case NODE:
-                return o -> asPolyNode( o.asNode() );
-            case EDGE:
-                return o -> asPolyEdge( o.asRelationship() );
-            case PATH:
-                return o -> asPolyPath( o.asPath() );
-        }
-
-        throw new GenericRuntimeException( String.format( "Object of type %s was not transformable.", type ) );
+                yield el -> PolyList.of( el.asList( componentFunc::apply ) );
+            }
+            case MAP -> v -> PolyString.of( v.asString() );
+            case DOCUMENT, JSON -> value -> PolyDocument.deserialize( value.asString() );
+            case GRAPH -> o -> (PolyValue) o;
+            case NODE -> o -> asPolyNode( o.asNode() );
+            case EDGE -> o -> asPolyEdge( o.asRelationship() );
+            case PATH -> o -> asPolyPath( o.asPath() );
+            case INTERVAL, MULTISET, DISTINCT, STRUCTURED, ROW, OTHER, USER_DEFINED_TYPE, CURSOR, COLUMN_LIST, DYNAMIC_STAR, GEOMETRY -> throw new GenericRuntimeException( String.format( "Object of type %s was not transformable.", type ) );
+        };
     }
 
     static PolyPath asPolyPath( Path path ) {
@@ -200,8 +166,8 @@ public interface NeoUtil {
             return null;
         }
         Object obj = e.asObject();
-        if ( obj instanceof PolyValue ) {
-            return (PolyValue) obj;
+        if ( obj instanceof PolyValue value ) {
+            return value;
         }
 
         return asPolyValue( e );
@@ -215,7 +181,7 @@ public interface NeoUtil {
         } else if ( value instanceof FloatValue ) {
             return PolyString.of( String.valueOf( value.asDouble() ) );
         } else if ( value instanceof ListValue ) {
-            return new PolyList<>( (value).asList( NeoUtil::getComparableOrString ) );
+            return new PolyList<>( value.asList( NeoUtil::getComparableOrString ) );
         }
         throw new NotImplementedException( "Type not supported" );
     }
@@ -270,215 +236,110 @@ public interface NeoUtil {
         if ( ob == null ) {
             return null;
         }
-        switch ( literal.getPolyType() ) {
-            case BOOLEAN:
-                return literal.value.asBoolean().toString();
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-            case DATE:
-            case TIME:
-                return literal.value.asNumber().toString();
-            case BIGINT:
-            case INTERVAL:
-                return literal.getValue().toString();
-            case TIMESTAMP:
-                return literal.value.asTemporal().getMillisSinceEpoch().toString();
-            case DECIMAL:
-            case FLOAT:
-            case REAL:
-            case DOUBLE:
-                return literal.getValue().toString();
-            case CHAR:
-            case VARCHAR:
+        return switch ( literal.getPolyType() ) {
+            case BOOLEAN -> literal.value.asBoolean().toString();
+            case TINYINT, SMALLINT, INTEGER, DATE, TIME -> literal.value.asNumber().toString();
+            case BIGINT, INTERVAL -> literal.getValue().toString();
+            case TIMESTAMP -> literal.value.asTemporal().getMillisSinceEpoch().toString();
+            case DECIMAL, FLOAT, REAL, DOUBLE -> literal.getValue().toString();
+            case CHAR, VARCHAR -> {
                 if ( isLiteral ) {
-                    return "'" + literal.value.asString() + "'";
+                    yield "'" + literal.value.asString() + "'";
                 }
-                return literal.value.asString().value;
-            case MAP:
-            case DOCUMENT:
-            case ARRAY:
-                return literal.value.asList().toString();
-            case BINARY:
-            case VARBINARY:
-                return literal.value.asBinary().as64String();
-            case FILE:
-            case IMAGE:
-            case VIDEO:
-            case AUDIO:
-                return Arrays.toString( literal.value.asBlob().asByteArray() );
-            case NULL:
-                return null;
-            case GRAPH:
-            case PATH:
-            case DISTINCT:
-            case STRUCTURED:
-            case ROW:
-            case OTHER:
-            case CURSOR:
-            case COLUMN_LIST:
-            case DYNAMIC_STAR:
-            case GEOMETRY:
-            case JSON:
-                break;
-            case NODE:
+                yield literal.value.asString().value;
+            }
+            case MAP, DOCUMENT, ARRAY -> literal.value.asList().toString();
+            case BINARY, VARBINARY -> literal.value.asBinary().as64String();
+            case FILE, IMAGE, VIDEO, AUDIO -> Arrays.toString( literal.value.asBlob().asByteArray() );
+            case NULL -> null;
+            case NODE -> {
                 PolyNode node = literal.value.asNode();
                 if ( node.isVariable() ) {
-                    return node_( node, null, false ).build();
+                    yield node_( node, null, false ).build();
                 }
-                return node_( node, PolyString.of( mappingLabel ), isLiteral ).build();
-            case EDGE:
-                return edge_( literal.value.asEdge(), isLiteral ).build();
-            case SYMBOL:
-                return literal.getValue().toString();
-        }
-        throw new UnsupportedOperationException( "Type is not supported by the Neo4j adapter." );
+                yield node_( node, PolyString.of( mappingLabel ), isLiteral ).build();
+            }
+            case EDGE -> edge_( literal.value.asEdge(), isLiteral ).build();
+            case SYMBOL -> literal.getValue().toString();
+            case GRAPH, PATH, DISTINCT, STRUCTURED, ROW, OTHER, CURSOR, COLUMN_LIST, DYNAMIC_STAR, GEOMETRY, JSON, TEXT, ANY, MULTISET, USER_DEFINED_TYPE -> throw new UnsupportedOperationException( "Type is not supported by the Neo4j adapter." );
+        };
     }
 
     static Function1<List<String>, String> getOpAsNeo( OperatorName operatorName, List<RexNode> operands, AlgDataType returnType ) {
-        switch ( operatorName ) {
-            case AND:
-                return o -> o.stream().map( e -> String.format( "(%s)", e ) ).collect( Collectors.joining( " AND " ) );
-            case DIVIDE:
-                return handleDivide( operatorName, operands, returnType );
-            case DIVIDE_INTEGER:
-                return o -> String.format( "%s / %s", o.get( 0 ), o.get( 1 ) );
-            case EQUALS:
-            case IS_DISTINCT_FROM:
-                return o -> String.format( "%s = %s", o.get( 0 ), o.get( 1 ) );
-            case GREATER_THAN:
-                return o -> String.format( "%s > %s", o.get( 0 ), o.get( 1 ) );
-            case GREATER_THAN_OR_EQUAL:
-                return o -> String.format( "%s >= %s", o.get( 0 ), o.get( 1 ) );
-            case LESS_THAN:
-                return o -> String.format( "%s < %s", o.get( 0 ), o.get( 1 ) );
-            case LESS_THAN_OR_EQUAL:
-                return o -> String.format( "%s <= %s", o.get( 0 ), o.get( 1 ) );
-            case MINUS:
-                return o -> String.format( "%s - %s", o.get( 0 ), o.get( 1 ) );
-            case MULTIPLY:
-                return o -> String.format( "%s * %s", o.get( 0 ), o.get( 1 ) );
-            case NOT_EQUALS:
-            case IS_NOT_DISTINCT_FROM:
-                return o -> String.format( "%s <> %s", o.get( 0 ), o.get( 1 ) );
-            case OR:
-                return o -> o.stream().map( e -> String.format( "(%s)", e ) ).collect( Collectors.joining( " OR " ) );
-            case PLUS:
-                return o -> String.format( "%s + %s", o.get( 0 ), o.get( 1 ) );
-            case IS_NOT_NULL:
-                return o -> String.format( "%s IS NOT NULL ", o.get( 0 ) );
-            case IS_NULL:
-                return o -> String.format( "%s IS NULL", o.get( 0 ) );
-            case IS_NOT_TRUE:
-            case IS_FALSE:
-                return o -> String.format( "NOT %s", o.get( 0 ) );
-            case IS_TRUE:
-            case IS_NOT_FALSE:
-                return o -> String.format( "%s", o.get( 0 ) );
-            case IS_EMPTY:
-                return o -> String.format( "%s = []", o.get( 0 ) );
-            case IS_NOT_EMPTY:
-                return o -> String.format( "%s <> []", o.get( 0 ) );
-            case EXISTS:
-                return o -> String.format( "exists(%s)", o.get( 0 ) );
-            case NOT:
-                return o -> String.format( "NOT %s", o.get( 0 ) );
-            case UNARY_MINUS:
-                return o -> String.format( "-%s", o.get( 0 ) );
-            case UNARY_PLUS:
-                return o -> o.get( 0 );
-            case COALESCE:
-                return o -> "coalesce(" + String.join( ", ", o ) + ")";
-            case NOT_LIKE:
-                return handleLike( operands, true );
-            case CYPHER_LIKE:
-                return o -> String.format( "%s =~ '%s'", o.get( 0 ), maybeUnquote( getAsRegex( o.get( 1 ) ) ) );
-            case LIKE:
-                return handleLike( operands, false );
-            case POWER:
-                return o -> String.format( "%s^%s", o.get( 0 ), o.get( 1 ) );
-            case SQRT:
-                return o -> String.format( "sqrt(%s)", o.get( 0 ) );
-            case MOD:
-                return o -> o.get( 0 ) + " % " + o.get( 1 );
-            case LOG10:
-                return o -> String.format( "log10(toFloat(%s))", o.get( 0 ) );
-            case ABS:
-                return o -> String.format( "abs(toFloat(%s))", o.get( 0 ) );
-            case ACOS:
-                return o -> String.format( "acos(toFloat(%s))", o.get( 0 ) );
-            case ASIN:
-                return o -> String.format( "asin(toFloat(%s))", o.get( 0 ) );
-            case ATAN:
-                return o -> String.format( "atan(toFloat(%s))", o.get( 0 ) );
-            case ATAN2:
-                return o -> String.format( "atan2(toFloat(%s), toFloat(%s))", o.get( 0 ), o.get( 1 ) );
-            case COS:
-                return o -> String.format( "cos(toFloat(%s))", o.get( 0 ) );
-            case COT:
-                return o -> String.format( "cot(toFloat(%s))", o.get( 0 ) );
-            case RADIANS:
-                return o -> String.format( "radians(toFloat(%s))", o.get( 0 ) );
-            case ROUND:
+        return switch ( operatorName ) {
+            case AND -> o -> o.stream().map( e -> String.format( "(%s)", e ) ).collect( Collectors.joining( " AND " ) );
+            case DIVIDE -> handleDivide( operatorName, operands, returnType );
+            case DIVIDE_INTEGER -> o -> String.format( "%s / %s", o.get( 0 ), o.get( 1 ) );
+            case EQUALS, IS_DISTINCT_FROM -> o -> String.format( "%s = %s", o.get( 0 ), o.get( 1 ) );
+            case GREATER_THAN -> o -> String.format( "%s > %s", o.get( 0 ), o.get( 1 ) );
+            case GREATER_THAN_OR_EQUAL -> o -> String.format( "%s >= %s", o.get( 0 ), o.get( 1 ) );
+            case LESS_THAN -> o -> String.format( "%s < %s", o.get( 0 ), o.get( 1 ) );
+            case LESS_THAN_OR_EQUAL -> o -> String.format( "%s <= %s", o.get( 0 ), o.get( 1 ) );
+            case MINUS -> o -> String.format( "%s - %s", o.get( 0 ), o.get( 1 ) );
+            case MULTIPLY -> o -> String.format( "%s * %s", o.get( 0 ), o.get( 1 ) );
+            case NOT_EQUALS, IS_NOT_DISTINCT_FROM -> o -> String.format( "%s <> %s", o.get( 0 ), o.get( 1 ) );
+            case OR -> o -> o.stream().map( e -> String.format( "(%s)", e ) ).collect( Collectors.joining( " OR " ) );
+            case PLUS -> o -> String.format( "%s + %s", o.get( 0 ), o.get( 1 ) );
+            case IS_NOT_NULL -> o -> String.format( "%s IS NOT NULL ", o.get( 0 ) );
+            case IS_NULL -> o -> String.format( "%s IS NULL", o.get( 0 ) );
+            case IS_NOT_TRUE, IS_FALSE -> o -> String.format( "NOT %s", o.get( 0 ) );
+            case IS_TRUE, IS_NOT_FALSE -> o -> String.format( "%s", o.get( 0 ) );
+            case IS_EMPTY -> o -> String.format( "%s = []", o.get( 0 ) );
+            case IS_NOT_EMPTY -> o -> String.format( "%s <> []", o.get( 0 ) );
+            case EXISTS -> o -> String.format( "exists(%s)", o.get( 0 ) );
+            case NOT -> o -> String.format( "NOT %s", o.get( 0 ) );
+            case UNARY_MINUS -> o -> String.format( "-%s", o.get( 0 ) );
+            case UNARY_PLUS -> o -> o.get( 0 );
+            case COALESCE -> o -> "coalesce(" + String.join( ", ", o ) + ")";
+            case NOT_LIKE -> handleLike( operands, true );
+            case CYPHER_LIKE -> o -> String.format( "%s =~ '%s'", o.get( 0 ), maybeUnquote( getAsRegex( o.get( 1 ) ) ) );
+            case LIKE -> handleLike( operands, false );
+            case POWER -> o -> String.format( "%s^%s", o.get( 0 ), o.get( 1 ) );
+            case SQRT -> o -> String.format( "sqrt(%s)", o.get( 0 ) );
+            case MOD -> o -> o.get( 0 ) + " % " + o.get( 1 );
+            case LOG10 -> o -> String.format( "log10(toFloat(%s))", o.get( 0 ) );
+            case ABS -> o -> String.format( "abs(toFloat(%s))", o.get( 0 ) );
+            case ACOS -> o -> String.format( "acos(toFloat(%s))", o.get( 0 ) );
+            case ASIN -> o -> String.format( "asin(toFloat(%s))", o.get( 0 ) );
+            case ATAN -> o -> String.format( "atan(toFloat(%s))", o.get( 0 ) );
+            case ATAN2 -> o -> String.format( "atan2(toFloat(%s), toFloat(%s))", o.get( 0 ), o.get( 1 ) );
+            case COS -> o -> String.format( "cos(toFloat(%s))", o.get( 0 ) );
+            case COT -> o -> String.format( "cot(toFloat(%s))", o.get( 0 ) );
+            case RADIANS -> o -> String.format( "radians(toFloat(%s))", o.get( 0 ) );
+            case ROUND -> {
                 if ( operands.size() == 1 ) {
-                    return o -> String.format( "round(toFloat(%s))", o.get( 0 ) );
+                    yield o -> String.format( "round(toFloat(%s))", o.get( 0 ) );
                 } else {
-                    return o -> String.format( "round(toFloat(%s), toInteger(%s))", o.get( 0 ), o.get( 1 ) );
+                    yield o -> String.format( "round(toFloat(%s), toInteger(%s))", o.get( 0 ), o.get( 1 ) );
                 }
-            case SIGN:
-                return o -> String.format( "sign(toFloat(%s))", o.get( 0 ) );
-            case SIN:
-                return o -> String.format( "sin(toFloat(%s))", o.get( 0 ) );
-            case TAN:
-                return o -> String.format( "tan(toFloat(%s))", o.get( 0 ) );
-            case CAST:
-                return handleCast( operands );
-            case ITEM:
-                return o -> String.format( "%s[toInteger(%s - 1)]", o.get( 0 ), o.get( 1 ) );
-            case ARRAY_VALUE_CONSTRUCTOR:
-                return o -> "[" + String.join( ", ", o ) + "]";
-            case CYPHER_EXTRACT_FROM_PATH:
-                return o -> o.get( 0 );
-            case CYPHER_ADJUST_EDGE:
-                return o -> String.format( "%s%s%s", o.get( 1 ), o.get( 0 ), o.get( 2 ) );
-            case CYPHER_REMOVE_LABELS:
-                return Object::toString;
-            case CYPHER_SET_LABELS:
-                return o -> {
-                    String name = o.get( 0 );
-                    for ( int i = 1; i < o.size(); i++ ) {
-                        name += ":" + o.get( i );
-                    }
-                    return name;
-                };
-            case CYPHER_SET_PROPERTIES:
-                throw new GenericRuntimeException( "No values should land here" );
-            case CYPHER_SET_PROPERTY:
-                return o -> String.format( "%s.%s = %s", o.get( 0 ), maybeUnquote( o.get( 1 ) ), o.get( 2 ) );
-            case CYPHER_EXTRACT_PROPERTY:
-                return o -> {
-                    String name = o.get( 0 );
-                    if ( name.contains( "." ) ) {
-                        name = name.split( "\\." )[0];
-                    }
-                    return String.format( "%s.%s", name, NeoUtil.maybeUnquote( o.get( 1 ) ) );
-                };
-            case CYPHER_EXTRACT_ID:
-                return o -> String.format( " %s.id ", o.get( 0 ) );
-            case CYPHER_HAS_PROPERTY:
-                return o -> String.format( " EXISTS(%s.%s) ", o.get( 0 ), NeoUtil.maybeUnquote( o.get( 1 ) ) );
-            case COUNT:
-                return o -> String.format( "count(%s)", String.join( ",", o ) );
-            case AVG:
-                return o -> String.format( "avg(%s)", o.get( 0 ) );
-            case MIN:
-                return o -> String.format( "min(%s)", o.get( 0 ) );
-            case MAX:
-                return o -> String.format( "max(%s)", o.get( 0 ) );
-            default:
-                return null;
-        }
-
+            }
+            case SIGN -> o -> String.format( "sign(toFloat(%s))", o.get( 0 ) );
+            case SIN -> o -> String.format( "sin(toFloat(%s))", o.get( 0 ) );
+            case TAN -> o -> String.format( "tan(toFloat(%s))", o.get( 0 ) );
+            case CAST -> handleCast( operands );
+            case ITEM -> o -> String.format( "%s[toInteger(%s - 1)]", o.get( 0 ), o.get( 1 ) );
+            case ARRAY_VALUE_CONSTRUCTOR -> o -> "[" + String.join( ", ", o ) + "]";
+            case CYPHER_EXTRACT_FROM_PATH -> o -> o.get( 0 );
+            case CYPHER_ADJUST_EDGE -> o -> String.format( "%s%s%s", o.get( 1 ), o.get( 0 ), o.get( 2 ) );
+            case CYPHER_REMOVE_LABELS -> Object::toString;
+            case CYPHER_SET_LABELS -> o -> String.join( ":", o );
+            case CYPHER_SET_PROPERTIES -> throw new GenericRuntimeException( "No values should land here" );
+            case CYPHER_SET_PROPERTY -> o -> String.format( "%s.%s = %s", o.get( 0 ), maybeUnquote( o.get( 1 ) ), o.get( 2 ) );
+            case CYPHER_EXTRACT_PROPERTY -> o -> {
+                String name = o.get( 0 );
+                if ( name.contains( "." ) ) {
+                    name = name.split( "\\." )[0];
+                }
+                return String.format( "%s.%s", name, NeoUtil.maybeUnquote( o.get( 1 ) ) );
+            };
+            case CYPHER_EXTRACT_ID -> o -> String.format( " %s.id ", o.get( 0 ) );
+            case CYPHER_HAS_PROPERTY -> o -> String.format( " EXISTS(%s.%s) ", o.get( 0 ), NeoUtil.maybeUnquote( o.get( 1 ) ) );
+            case COUNT -> o -> String.format( "count(%s)", String.join( ",", o ) );
+            case AVG -> o -> String.format( "avg(%s)", o.get( 0 ) );
+            case MIN -> o -> String.format( "min(%s)", o.get( 0 ) );
+            case MAX -> o -> String.format( "max(%s)", o.get( 0 ) );
+            default -> null;
+        };
     }
 
     static String maybeUnquote( String key ) {
@@ -546,9 +407,7 @@ public interface NeoUtil {
         }
 
         NeoSupportVisitor visitor = new NeoSupportVisitor();
-        for ( RexNode project : p.getProjects() ) {
-            project.accept( visitor );
-        }
+        p.getProjects().forEach( project -> project.accept( visitor ) );
         return visitor.supports && !UnsupportedRexCallVisitor.containsModelItem( p.getProjects() );
     }
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/DbMetaRetriever.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/DbMetaRetriever.java
@@ -104,18 +104,11 @@ class DbMetaRetriever {
     static EntitiesResponse searchEntities( String namespaceName, String entityPattern ) {
         EntitiesResponse.Builder responseBuilder = EntitiesResponse.newBuilder();
         LogicalNamespace namespace = Catalog.getInstance().getSnapshot().getNamespace( namespaceName ).orElseThrow();
-        switch ( namespace.getDataModel() ) {
-            case RELATIONAL:
-                responseBuilder.addAllEntities( getRelationalEntities( namespace.getId(), entityPattern ) );
-                break;
-            case GRAPH:
-                responseBuilder.addAllEntities( getGraphEntities( namespace.getId(), entityPattern ) );
-                break;
-            case DOCUMENT:
-                responseBuilder.addAllEntities( getDocumentEntities( namespace.getId(), entityPattern ) );
-                break;
-        }
-        return responseBuilder.build();
+        return switch ( namespace.getDataModel() ) {
+            case RELATIONAL -> responseBuilder.addAllEntities( getRelationalEntities( namespace.getId(), entityPattern ) ).build();
+            case GRAPH -> responseBuilder.addAllEntities( getGraphEntities( namespace.getId(), entityPattern ) ).build();
+            case DOCUMENT -> responseBuilder.addAllEntities( getDocumentEntities( namespace.getId(), entityPattern ) ).build();
+        };
     }
 
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/relational/RelationalMetaRetriever.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/relational/RelationalMetaRetriever.java
@@ -165,18 +165,15 @@ public class RelationalMetaRetriever {
 
 
     private static AlgDataType retrieveAlgDataType( PolyImplementation polyImplementation ) {
-        switch ( polyImplementation.getKind() ) {
-            case INSERT:
-            case DELETE:
-            case UPDATE:
-            case EXPLAIN:
+        return switch ( polyImplementation.getKind() ) {
+            case INSERT, DELETE, UPDATE, EXPLAIN -> {
                 // FIXME: getValidatedNodeType is wrong for DML
                 Kind kind = polyImplementation.getKind();
                 JavaTypeFactory typeFactory = polyImplementation.getStatement().getTransaction().getTypeFactory();
-                return AlgOptUtil.createDmlRowType( kind, typeFactory );
-            default:
-                return polyImplementation.tupleType;
-        }
+                yield AlgOptUtil.createDmlRowType( kind, typeFactory );
+            }
+            default -> polyImplementation.tupleType;
+        };
     }
 
 }

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlIdentifier.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlIdentifier.java
@@ -148,7 +148,7 @@ public class SqlIdentifier extends SqlNode implements Identifier {
      * Converts a list of strings to a qualified identifier.
      */
     public static String getString( List<String> names ) {
-        return Util.sepList( toStar( names ), "." );
+        return String.join( ".", toStar( names ) );
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/IdentifierNamespace.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/validate/IdentifierNamespace.java
@@ -150,16 +150,15 @@ public class IdentifierNamespace extends AbstractNamespace {
 
             LogicalNamespace namespace = optionalNamespace.orElseThrow();
 
-            Entity entity = null;
-            if ( namespace.dataModel == DataModel.RELATIONAL ) {
-                entity = validator.snapshot.rel().getTable( namespace.id, entityName ).orElse( null );
-            } else if ( namespace.dataModel == DataModel.DOCUMENT ) {
-                entity = validator.snapshot.doc().getCollection( namespace.id, entityName ).orElse( null );
-            } else if ( namespace.dataModel == DataModel.GRAPH ) {
-                // we use a subgraph to define label which is used as table
-                final String finalEntityName = entityName;
-                entity = validator.snapshot.graph().getGraph( namespace.id ).map( g -> new SubstitutionGraph( g.id, ns.get( 1 ), false, g.caseSensitive, List.of( PolyString.of( finalEntityName ) ) ) ).orElse( null );
-            }
+            Entity entity = switch ( namespace.dataModel ) {
+                case RELATIONAL -> validator.snapshot.rel().getTable( namespace.id, entityName ).orElse( null );
+                case DOCUMENT -> validator.snapshot.doc().getCollection( namespace.id, entityName ).orElse( null );
+                case GRAPH -> {
+                    // we use a subgraph to define label which is used as table
+                    final String finalEntityName = entityName;
+                    yield validator.snapshot.graph().getGraph( namespace.id ).map( g -> new SubstitutionGraph( g.id, ns.get( 1 ), false, g.caseSensitive, List.of( PolyString.of( finalEntityName ) ) ) ).orElse( null );
+                }
+            };
 
             return new EntityNamespace( validator, entity );
         }

--- a/plugins/sql-language/src/test/java/org/polypheny/db/sql/language/utils/AbstractSqlTester.java
+++ b/plugins/sql-language/src/test/java/org/polypheny/db/sql/language/utils/AbstractSqlTester.java
@@ -530,7 +530,7 @@ public abstract class AbstractSqlTester implements SqlTester, AutoCloseable {
         if ( values.isEmpty() ) {
             values.add( Pair.of( "1", "p0" ) );
         }
-        return "select " + sql2.substring( "values (".length(), sql2.length() - 1 ) + " from (values (" + Util.commaList( Pair.left( values ) ) + ")) as t(" + Util.commaList( Pair.right( values ) ) + ")";
+        return "select " + sql2.substring( "values (".length(), sql2.length() - 1 ) + " from (values (" + String.join( ", ", Pair.left( values ) ) + ")) as t(" + String.join( ", ", Pair.right( values ) ) + ")";
     }
 
 

--- a/webui/src/main/java/org/polypheny/db/webui/crud/CatalogCrud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/crud/CatalogCrud.java
@@ -89,15 +89,9 @@ public class CatalogCrud {
 
             if ( request.depth > 1 ) {
                 switch ( namespace.dataModel ) {
-                    case RELATIONAL:
-                        attachTreeElements( namespace, request, schemaTree );
-                        break;
-                    case DOCUMENT:
-                        attachDocumentTreeElements( namespace, request, schemaTree );
-                        break;
-                    case GRAPH:
-                        schemaTree.setRouterLink( request.routerLinkRoot + "/" + namespace.name );
-                        break;
+                    case RELATIONAL -> attachTreeElements( namespace, request, schemaTree );
+                    case DOCUMENT -> attachDocumentTreeElements( namespace, request, schemaTree );
+                    case GRAPH -> schemaTree.setRouterLink( request.routerLinkRoot + "/" + namespace.name );
                 }
             }
 


### PR DESCRIPTION
This PR adds log statements during benchmarks when error responses are returned in the prism interface.

Usually, we do not want to log error messages that are returned to the user via the interface since errors are very common (e.g., typo in an entity name or wrong syntax). However, in benchmarks, there should be no wrong queries.

Included are also some conversions of switch statements to switch expressions and replacing a `Util` method with a method included in the standard library.