### PR TITLE
Improve transaction handling in Prism Driver & Decimal validation

### DIFF
--- a/core/src/main/java/org/polypheny/db/algebra/core/CorrelationId.java
+++ b/core/src/main/java/org/polypheny/db/algebra/core/CorrelationId.java
@@ -109,7 +109,7 @@ public class CorrelationId implements Cloneable, Comparable<CorrelationId> {
 
     @Override
     public int compareTo( CorrelationId other ) {
-        return id - other.id;
+        return Integer.compare( id, other.id );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/functions/Functions.java
+++ b/core/src/main/java/org/polypheny/db/functions/Functions.java
@@ -2137,7 +2137,7 @@ public class Functions {
      * NULL &rarr; NULL, FALSE &rarr; TRUE, TRUE &rarr; FALSE.
      */
     public static PolyBoolean not( PolyBoolean b ) {
-        return PolyBoolean.of( !b.value );
+        return b == null ? PolyBoolean.of( null ): PolyBoolean.of( !b.value );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/functions/Functions.java
+++ b/core/src/main/java/org/polypheny/db/functions/Functions.java
@@ -2137,7 +2137,7 @@ public class Functions {
      * NULL &rarr; NULL, FALSE &rarr; TRUE, TRUE &rarr; FALSE.
      */
     public static PolyBoolean not( PolyBoolean b ) {
-        return b == null ? PolyBoolean.of( null ): PolyBoolean.of( !b.value );
+        return b == null ? PolyBoolean.of( null ) : PolyBoolean.of( !b.value );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/languages/LanguageManager.java
+++ b/core/src/main/java/org/polypheny/db/languages/LanguageManager.java
@@ -164,7 +164,6 @@ public class LanguageManager {
                     implementation = processor.prepareDdl( statement, (ExecutableStatement) parsed.getQueryNode().get(), parsed );
                     previousDdl = true;
                 } else {
-                    // as long as we directly commit the transaction, we cannot reuse the same transaction
                     previousDdl = false;
                     if ( parsed.getLanguage().validatorSupplier() != null ) {
                         if ( transaction.isAnalyze() ) {

--- a/core/src/main/java/org/polypheny/db/languages/LanguageManager.java
+++ b/core/src/main/java/org/polypheny/db/languages/LanguageManager.java
@@ -195,6 +195,10 @@ public class LanguageManager {
                     if ( transaction.isAnalyze() ) {
                         statement.getOverviewDuration().stop( "Translation" );
                     }
+
+                    if ( !statement.getTransaction().isActive() ) {
+                        log.warn( "Transaction is not active" );
+                    }
                     implementation = statement.getQueryProcessor().prepareQuery( root, true );
                 }
                 // queries are able to switch the context of the following queries

--- a/core/src/main/java/org/polypheny/db/languages/LanguageManager.java
+++ b/core/src/main/java/org/polypheny/db/languages/LanguageManager.java
@@ -130,6 +130,11 @@ public class LanguageManager {
         String changedNamespace = null;
         for ( ParsedQueryContext parsed : parsedQueries ) {
             if ( i != 0 ) {
+                // as long as we directly commit the transaction, we cannot reuse the same transaction
+                if ( previousDdl && !transaction.isActive() ) {
+                    transaction = parsed.getTransactionManager().startTransaction( transaction.getUser().id, transaction.getDefaultNamespace().id, transaction.isAnalyze(), transaction.getOrigin() );
+                    parsed.addTransaction( transaction );
+                }
                 statement = transaction.createStatement();
             }
             if ( changedNamespace != null ) {
@@ -155,22 +160,11 @@ public class LanguageManager {
                                 new GenericRuntimeException( "DDL statement is not executable" ),
                                 implementationContexts );
                     }
-                    // as long as we directly commit the transaction, we cannot reuse the same transaction
-                    if ( previousDdl && !transaction.isActive() ) {
-                        transaction = parsed.getTransactionManager().startTransaction( transaction.getUser().id, transaction.getDefaultNamespace().id, transaction.isAnalyze(), transaction.getOrigin() );
-                        statement = transaction.createStatement();
-                        parsed.addTransaction( transaction );
-                    }
 
                     implementation = processor.prepareDdl( statement, (ExecutableStatement) parsed.getQueryNode().get(), parsed );
                     previousDdl = true;
                 } else {
                     // as long as we directly commit the transaction, we cannot reuse the same transaction
-                    if ( previousDdl && !transaction.isActive() ) {
-                        transaction = parsed.getTransactionManager().startTransaction( transaction.getUser().id, transaction.getDefaultNamespace().id, transaction.isAnalyze(), transaction.getOrigin() );
-                        statement = transaction.createStatement();
-                        parsed.addTransaction( transaction );
-                    }
                     previousDdl = false;
                     if ( parsed.getLanguage().validatorSupplier() != null ) {
                         if ( transaction.isAnalyze() ) {

--- a/core/src/main/java/org/polypheny/db/type/entity/PolyValue.java
+++ b/core/src/main/java/org/polypheny/db/type/entity/PolyValue.java
@@ -799,6 +799,8 @@ public abstract class PolyValue implements Expressible, Comparable<PolyValue>, P
     public PolyNumber asNumber() {
         if ( isNumber() ) {
             return (PolyNumber) this;
+        }else if( isString() ){
+            return PolyFloat.convert( this.asString() );
         }
         throw cannotParse( this, PolyNumber.class );
     }

--- a/core/src/main/java/org/polypheny/db/type/entity/PolyValue.java
+++ b/core/src/main/java/org/polypheny/db/type/entity/PolyValue.java
@@ -799,7 +799,7 @@ public abstract class PolyValue implements Expressible, Comparable<PolyValue>, P
     public PolyNumber asNumber() {
         if ( isNumber() ) {
             return (PolyNumber) this;
-        }else if( isString() ){
+        } else if ( isString() ) {
             return PolyFloat.convert( this.asString() );
         }
         throw cannotParse( this, PolyNumber.class );

--- a/core/src/main/java/org/polypheny/db/util/ByteString.java
+++ b/core/src/main/java/org/polypheny/db/util/ByteString.java
@@ -103,7 +103,7 @@ public class ByteString implements Comparable<ByteString>, Serializable {
                 return c1 - c2;
             }
         }
-        return v1.length - v2.length;
+        return Integer.compare( v1.length, v2.length );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/util/CaseInsensitiveComparator.java
+++ b/core/src/main/java/org/polypheny/db/util/CaseInsensitiveComparator.java
@@ -83,11 +83,11 @@ class CaseInsensitiveComparator implements Comparator, Serializable {
         if ( c != 0 ) {
             return c;
         }
-        if ( o1 instanceof Key ) {
-            return ((Key) o1).compareResult;
+        if ( o1 instanceof Key key ) {
+            return key.compareResult;
         }
-        if ( o2 instanceof Key ) {
-            return -((Key) o2).compareResult;
+        if ( o2 instanceof Key key ) {
+            return -key.compareResult;
         }
         return s1.compareTo( s2 );
     }

--- a/dbms/src/main/java/org/polypheny/db/processing/DataContextImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/processing/DataContextImpl.java
@@ -148,7 +148,7 @@ public class DataContextImpl implements DataContext {
 
         switch ( type.getPolyType() ) {
             case DECIMAL -> {
-                if ( value.asNumber().toString().replace( ".", "" ).replace( "-", "" ).length() > type.getPrecision() ) {
+                if ( value.asNumber().toString().replaceFirst( "^0", "" ).replace( ".", "" ).replace( "-", "" ).length() > type.getPrecision() ) {
                     throw new GenericRuntimeException( "Numeric value is too long" );
                 }
             }

--- a/dbms/src/main/java/org/polypheny/db/transaction/LockManager.java
+++ b/dbms/src/main/java/org/polypheny/db/transaction/LockManager.java
@@ -38,7 +38,7 @@ public class LockManager {
     public static final LockManager INSTANCE = new LockManager();
 
     private boolean isExclusive = false;
-    private final Set<Long> owners = new HashSet<>();
+    private final Set<Xid> owners = new HashSet<>();
     private final ConcurrentLinkedQueue<Thread> waiters = new ConcurrentLinkedQueue<>();
     private final ReentrantLock lock = new ReentrantLock();
     private final Condition condition = lock.newCondition();
@@ -54,7 +54,7 @@ public class LockManager {
             if ( owners.isEmpty() ) {
                 handleLockOrThrow( mode, transaction );
                 return;
-            } else if ( owners.contains( transaction.getId() ) && (mode == LockMode.SHARED || isExclusive) ) {
+            } else if ( owners.contains( transaction.getXid() ) && (mode == LockMode.SHARED || isExclusive) ) {
                 log.debug( "already locked {}", transaction.getXid() );
                 // already have the required lock
                 return;
@@ -69,7 +69,7 @@ public class LockManager {
             lock.lock();
             try {
                 while ( waiters.peek() != thread ) {
-                    log.debug( "wait {} ", transaction.getId() );
+                    log.debug( "wait {} ", transaction.getXid() );
                     boolean successful = condition.await( RuntimeConfig.LOCKING_MAX_TIMEOUT_SECONDS.getInteger(), TimeUnit.SECONDS );
                     if ( !successful ) {
                         cleanup( thread );
@@ -120,7 +120,7 @@ public class LockManager {
     private synchronized boolean handleSimpleLock( @NonNull LockMode mode, Transaction transaction ) {
         if ( mode == LockMode.EXCLUSIVE ) {
             // get w
-            if ( owners.isEmpty() || (owners.size() == 1 && owners.contains( transaction.getId() )) ) {
+            if ( owners.isEmpty() || (owners.size() == 1 && owners.contains( transaction.getXid() )) ) {
                 if ( isExclusive ) {
                     log.debug( "lock already exclusive" );
                     return true;
@@ -128,15 +128,15 @@ public class LockManager {
 
                 log.debug( "x lock {}", transaction.getXid() );
                 isExclusive = true;
-                owners.add( transaction.getId() );
+                owners.add( transaction.getXid() );
                 return true;
             }
 
         } else {
             // get r
-            if ( !isExclusive || owners.contains( transaction.getId() ) ) {
+            if ( !isExclusive || owners.contains( transaction.getXid() ) ) {
                 log.debug( "r lock {}", transaction.getXid() );
-                owners.add( transaction.getId() );
+                owners.add( transaction.getXid() );
                 return true;
             }
 
@@ -158,7 +158,7 @@ public class LockManager {
 
 
     public synchronized void unlock( @NonNull Transaction transaction ) {
-        if ( !owners.contains( transaction.getId() ) ) {
+        if ( !owners.contains( transaction.getXid() ) ) {
             log.debug( "Transaction is no owner" );
             return;
         }
@@ -167,7 +167,7 @@ public class LockManager {
             isExclusive = false;
         }
         log.debug( "release {}", transaction.getXid() );
-        owners.remove( transaction.getId() );
+        owners.remove( transaction.getXid() );
 
         // wake up waiters
         signalAll();

--- a/dbms/src/main/java/org/polypheny/db/transaction/TransactionImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/transaction/TransactionImpl.java
@@ -292,7 +292,7 @@ public class TransactionImpl implements Transaction, Comparable<Object> {
     @Override
     public int compareTo( @NonNull Object o ) {
         Transaction that = (Transaction) o;
-        return this.xid.hashCode() - that.getXid().hashCode();
+        return Integer.compare( this.xid.hashCode(), that.getXid().hashCode() );
     }
 
 

--- a/dbms/src/main/java/org/polypheny/db/transaction/TransactionImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/transaction/TransactionImpl.java
@@ -199,6 +199,9 @@ public class TransactionImpl implements Transaction, Comparable<Object> {
             for ( Adapter<?> adapter : involvedAdapters ) {
                 adapter.commit( xid );
             }
+            if ( involvedAdapters.isEmpty() ) {
+                log.debug( "No adapter used." );
+            }
 
             this.statements.forEach( statement -> {
                 if ( statement.getMonitoringEvent() != null ) {

--- a/dbms/src/main/java/org/polypheny/db/transaction/TransactionImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/transaction/TransactionImpl.java
@@ -283,6 +283,9 @@ public class TransactionImpl implements Transaction, Comparable<Object> {
 
     @Override
     public StatementImpl createStatement() {
+        if ( !isActive() ) {
+            throw new IllegalStateException( "Transaction is not active!" );
+        }
         StatementImpl statement = new StatementImpl( this );
         statements.add( statement );
         return statement;

--- a/dbms/src/test/java/org/polypheny/db/sql/view/ComplexViewTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/view/ComplexViewTest.java
@@ -1498,6 +1498,7 @@ public class ComplexViewTest {
         }
     }
 
+
     @Test
     public void testCast() throws SQLException {
         try ( JdbcConnection polyphenyDbConnection = new JdbcConnection( true ) ) {

--- a/dbms/src/test/java/org/polypheny/db/sql/view/ComplexViewTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/view/ComplexViewTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.Date;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import lombok.extern.slf4j.Slf4j;
@@ -774,7 +775,7 @@ public class ComplexViewTest {
                                 SUM(l_extendedprice) AS sum_base_price,
                                 SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
                                 SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-                                AVG(l_quantity) AS avg_qty,
+                                AVG(l_quantity) AS avg_Fqty,
                                 AVG(l_extendedprice) AS avg_price,
                                 AVG(l_discount) AS avg_disc,
                                 COUNT(*) AS count_order
@@ -1491,6 +1492,33 @@ public class ComplexViewTest {
                 } finally {
                     connection.rollback();
                     statement.executeUpdate( "DROP VIEW IF EXISTS q14_VIEW" );
+                    dropTables( statement );
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCast() throws SQLException {
+        try ( JdbcConnection polyphenyDbConnection = new JdbcConnection( true ) ) {
+            Connection connection = polyphenyDbConnection.getConnection();
+            try ( Statement statement = connection.createStatement() ) {
+                initTables( statement );
+
+                try {
+                    String query = """
+                            SELECT l_extendedprice
+                            FROM
+                                lineitem
+                            WHERE
+                                l_extendedprice >= cast(? as Integer)""";
+
+                    PreparedStatement prepare = connection.prepareStatement( query );
+                    prepare.setString( 1, "3" );
+                    prepare.execute();
+                    connection.commit();
+                } finally {
+                    connection.rollback();
                     dropTables( statement );
                 }
             }

--- a/dbms/src/test/java/org/polypheny/db/sql/view/ComplexViewTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/view/ComplexViewTest.java
@@ -775,7 +775,7 @@ public class ComplexViewTest {
                                 SUM(l_extendedprice) AS sum_base_price,
                                 SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
                                 SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-                                AVG(l_quantity) AS avg_Fqty,
+                                AVG(l_quantity) AS avg_qty,
                                 AVG(l_extendedprice) AS avg_price,
                                 AVG(l_discount) AS avg_disc,
                                 COUNT(*) AS count_order

--- a/plugins/cottontail-adapter/src/main/java/org/polypheny/db/adapter/cottontail/util/CottontailTypeUtil.java
+++ b/plugins/cottontail-adapter/src/main/java/org/polypheny/db/adapter/cottontail/util/CottontailTypeUtil.java
@@ -277,6 +277,8 @@ public class CottontailTypeUtil {
             case DECIMAL: {
                 if ( value.isNumber() ) {
                     return builder.setStringData( value.asNumber().BigDecimalValue().toString() ).build();
+                } else if ( value.isString() ) {
+                    return builder.setStringData( value.asString().value ).build();
                 }
                 break;
             }

--- a/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/ResultSetEnumerable.java
+++ b/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/ResultSetEnumerable.java
@@ -411,7 +411,7 @@ public class ResultSetEnumerable extends AbstractEnumerable<PolyValue[]> {
                 int updateCount = statement.getUpdateCount();
                 return Linq4j.singletonEnumerator( new PolyValue[]{ PolyLong.of( updateCount ) } );
             }
-        } catch ( SQLException e ) {
+        } catch ( Throwable e ) {
             throw Static.RESOURCE.exceptionWhilePerformingQueryOnJdbcSubSchema( sql ).ex( e );
         } finally {
             closeIfPossible( statement );
@@ -439,7 +439,7 @@ public class ResultSetEnumerable extends AbstractEnumerable<PolyValue[]> {
                     return Linq4j.singletonEnumerator( new PolyValue[]{ PolyLong.of( updateCount ) } );
                 }
             }
-        } catch ( SQLException e ) {
+        } catch ( Throwable e ) {
             throw Static.RESOURCE.exceptionWhilePerformingQueryOnJdbcSubSchema( sql ).ex( e );
         } finally {
             closeIfPossible( preparedStatement );

--- a/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/stores/AbstractJdbcStore.java
+++ b/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/stores/AbstractJdbcStore.java
@@ -466,7 +466,7 @@ public abstract class AbstractJdbcStore extends DataStore<RelAdapterCatalog> imp
         if ( connectionFactory.hasConnectionHandler( xid ) ) {
             try {
                 connectionFactory.getConnectionHandler( xid ).commit();
-            } catch ( ConnectionHandlerException e ) {
+            } catch ( Throwable e ) {
                 throw new GenericRuntimeException( e );
             }
         } else {

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIClient.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIClient.java
@@ -32,6 +32,8 @@ public class PIClient {
     @Getter
     private final String clientUUID;
     private final LogicalUser catalogUser;
+    @Getter
+    @Setter
     private Transaction currentTransaction;
     private final TransactionManager transactionManager;
     @Getter
@@ -94,7 +96,7 @@ public class PIClient {
         }
         try {
             currentTransaction.commit();
-        } catch ( TransactionException e ) {
+        } catch ( Throwable e ) {
             throw new PIServiceException( "Committing current transaction failed: " + e.getMessage() );
         } finally {
             clearCurrentTransaction();

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
@@ -429,12 +429,6 @@ class PIService {
     private Response executeIndexedStatement( ExecuteIndexedStatementRequest request, ResponseMaker<StatementResult> responseObserver ) {
         PIClient client = getClient();
         PIPreparedIndexedStatement statement = client.getStatementManager().getIndexedPreparedStatement( request.getStatementId() );
-        if ( statement != null && statement.getTransaction() != null && client.getCurrentTransaction() != null && statement.getTransaction().getId() != client.getCurrentTransaction().getId() ) {
-            if ( !statement.getTransaction().isActive() ){ // todo @gartens @tobiashafner fix
-                log.debug( "This definitely should not happen! {}", statement.getTransaction().getId() );
-                statement.setStatement( client.getCurrentTransaction().createStatement() );
-            }
-        }
         int fetchSize = request.hasFetchSize()
                 ? request.getFetchSize()
                 : PropertyUtils.DEFAULT_FETCH_SIZE;

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIService.java
@@ -429,6 +429,12 @@ class PIService {
     private Response executeIndexedStatement( ExecuteIndexedStatementRequest request, ResponseMaker<StatementResult> responseObserver ) {
         PIClient client = getClient();
         PIPreparedIndexedStatement statement = client.getStatementManager().getIndexedPreparedStatement( request.getStatementId() );
+        if ( statement != null && statement.getTransaction() != null && client.getCurrentTransaction() != null && statement.getTransaction().getId() != client.getCurrentTransaction().getId() ) {
+            if ( !statement.getTransaction().isActive() ){ // todo @gartens @tobiashafner fix
+                log.debug( "This definitely should not happen! {}", statement.getTransaction().getId() );
+                statement.setStatement( client.getCurrentTransaction().createStatement() );
+            }
+        }
         int fetchSize = request.hasFetchSize()
                 ? request.getFetchSize()
                 : PropertyUtils.DEFAULT_FETCH_SIZE;

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statementProcessing/StatementProcessor.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statementProcessing/StatementProcessor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import org.polypheny.db.algebra.type.AlgDataType;
+import org.polypheny.db.algebra.type.AlgDataTypeField;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.languages.LanguageManager;
@@ -143,6 +144,7 @@ public class StatementProcessor {
         Pair<Node, AlgDataType> validated = queryProcessor.validate( transaction, parsed, false );
         AlgDataType parameterRowType = queryProcessor.getParameterRowType( validated.left );
         piStatement.setParameterMetas( RelationalMetaRetriever.retrieveParameterMetas( parameterRowType ) );
+        piStatement.setParameterPolyTypes( parameterRowType.getFields().stream().map( AlgDataTypeField::getType ).toList() );
     }
 
 }

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedIndexedStatement.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedIndexedStatement.java
@@ -39,6 +39,7 @@ import org.polypheny.prism.StatementResult;
 public class PIPreparedIndexedStatement extends PIPreparedStatement {
 
     private final String query;
+    @Setter
     private Statement statement;
     @Setter
     private PolyImplementation implementation;
@@ -173,7 +174,7 @@ public class PIPreparedIndexedStatement extends PIPreparedStatement {
 
     @Override
     public Transaction getTransaction() {
-        return statement.getTransaction();
+        return statement != null ? statement.getTransaction() : null;
     }
 
 }

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedNamedStatement.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedNamedStatement.java
@@ -39,6 +39,7 @@ public class PIPreparedNamedStatement extends PIPreparedStatement {
     @Setter
     private PolyImplementation implementation;
     @Getter
+    @Setter
     private Statement statement;
     private final NamedValueProcessor namedValueProcessor;
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedStatement.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedStatement.java
@@ -19,17 +19,19 @@ package org.polypheny.db.prisminterface.statements;
 import java.util.List;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+import org.polypheny.db.algebra.type.AlgDataType;
 import org.polypheny.db.catalog.entity.logical.LogicalNamespace;
 import org.polypheny.db.languages.QueryLanguage;
 import org.polypheny.db.prisminterface.PIClient;
 import org.polypheny.db.prisminterface.statementProcessing.StatementProcessor;
+import org.polypheny.db.type.PolyType;
 import org.polypheny.prism.ParameterMeta;
 
 @Setter
 public abstract class PIPreparedStatement extends PIStatement implements Signaturizable {
 
     protected List<ParameterMeta> parameterMetas;
-
+    protected List<AlgDataType> parameterPolyTypes;
 
     public List<ParameterMeta> getParameterMetas() {
         if ( parameterMetas == null ) {

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedStatement.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIPreparedStatement.java
@@ -24,7 +24,6 @@ import org.polypheny.db.catalog.entity.logical.LogicalNamespace;
 import org.polypheny.db.languages.QueryLanguage;
 import org.polypheny.db.prisminterface.PIClient;
 import org.polypheny.db.prisminterface.statementProcessing.StatementProcessor;
-import org.polypheny.db.type.PolyType;
 import org.polypheny.prism.ParameterMeta;
 
 @Setter
@@ -32,6 +31,7 @@ public abstract class PIPreparedStatement extends PIStatement implements Signatu
 
     protected List<ParameterMeta> parameterMetas;
     protected List<AlgDataType> parameterPolyTypes;
+
 
     public List<ParameterMeta> getParameterMetas() {
         if ( parameterMetas == null ) {

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIStatement.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIStatement.java
@@ -74,6 +74,8 @@ public abstract class PIStatement {
 
     public abstract void setImplementation( PolyImplementation implementation );
 
+    public abstract void setStatement( Statement statement );
+
     public abstract Statement getStatement();
 
     public abstract String getQuery();

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIUnparameterizedStatement.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/statements/PIUnparameterizedStatement.java
@@ -33,6 +33,7 @@ import org.polypheny.prism.StatementResult;
 public class PIUnparameterizedStatement extends PIStatement {
 
     private final String query;
+    @Setter
     private Statement statement;
     @Setter
     private PolyImplementation implementation;


### PR DESCRIPTION
The main contribution of this PR are improvements to transaction handling in the Prism driver and decimal validation:
 - Ensure that statements objects used in the Prism driver belong to the current transaction (with a test that would have exposed this)
 - Ignore leading 0 in decimal number validation to match the documentation
 - Throw an exception when trying to create a statement for an inactive transaction (this exposed an issue in `anyPrepareQuery`)
 - Improve type derivation in prepared statements
 - Replace a few subtractions with the more appropriate `Integer.compare`