### PR TITLE
AUTO_INCREMENT support for SQL

### DIFF
--- a/core/src/main/java/org/polypheny/db/adapter/DataSource.java
+++ b/core/src/main/java/org/polypheny/db/adapter/DataSource.java
@@ -60,6 +60,7 @@ public abstract class DataSource<S extends AdapterCatalog> extends Adapter<S> im
         public final String physicalColumnName;
         public final int physicalPosition;
         public final boolean primary;
+        public final boolean autoIncrement;
 
 
         public String getDisplayType() {

--- a/core/src/main/java/org/polypheny/db/adapter/RelationalModifyDelegate.java
+++ b/core/src/main/java/org/polypheny/db/adapter/RelationalModifyDelegate.java
@@ -112,8 +112,8 @@ public class RelationalModifyDelegate extends RelationalScanDelegate implements 
     @Override
     public List<PhysicalEntity> createCollection( Context context, LogicalCollection logical, AllocationCollection allocation ) {
         PhysicalTable physical = Scannable.createSubstitutionTable( modifiable, context, logical, allocation, "_doc_", List.of(
-                new ColumnContext( DocumentType.DOCUMENT_ID, null, PolyType.TEXT, false ),
-                new ColumnContext( DocumentType.DOCUMENT_DATA, null, PolyType.TEXT, true ) ), 1 );
+                new ColumnContext( DocumentType.DOCUMENT_ID, null, PolyType.TEXT, false, false ),
+                new ColumnContext( DocumentType.DOCUMENT_DATA, null, PolyType.TEXT, true, false ) ), 1 );
         catalog.addPhysical( allocation, physical );
 
         return List.of( physical );

--- a/core/src/main/java/org/polypheny/db/adapter/Scannable.java
+++ b/core/src/main/java/org/polypheny/db/adapter/Scannable.java
@@ -60,7 +60,7 @@ public interface Scannable {
 
         int i = 0;
         for ( ColumnContext col : columnsInformations ) {
-            LogicalColumn column = new LogicalColumn( builder.getNewFieldId(), col.name, table.id, table.namespaceId, i, col.type, null, col.precision, null, null, null, col.nullable, Collation.getDefaultCollation(), null );
+            LogicalColumn column = new LogicalColumn( builder.getNewFieldId(), col.name, table.id, table.namespaceId, i, col.type, null, col.precision, null, null, null, col.nullable, Collation.getDefaultCollation(), null, col.autoIncrement );
             columns.add( column );
             i++;
         }
@@ -170,24 +170,24 @@ public interface Scannable {
 
     static List<PhysicalEntity> createGraphSubstitute( Scannable scannable, Context context, LogicalGraph logical, AllocationGraph allocation ) {
         PhysicalEntity node = createSubstitutionEntity( scannable, context, logical, allocation, "_node_", List.of(
-                new ColumnContext( "id", GraphType.ID_SIZE, PolyType.VARCHAR, false ),
-                new ColumnContext( "label", null, PolyType.TEXT, false ) ), 2 );
+                new ColumnContext( "id", GraphType.ID_SIZE, PolyType.VARCHAR, false, false ),
+                new ColumnContext( "label", null, PolyType.TEXT, false, false ) ), 2 );
 
         PhysicalEntity nProperties = createSubstitutionEntity( scannable, context, logical, allocation, "_nProperties_", List.of(
-                new ColumnContext( "id", GraphType.ID_SIZE, PolyType.VARCHAR, false ),
-                new ColumnContext( "key", null, PolyType.TEXT, false ),
-                new ColumnContext( "value", null, PolyType.TEXT, true ) ), 2 );
+                new ColumnContext( "id", GraphType.ID_SIZE, PolyType.VARCHAR, false, false ),
+                new ColumnContext( "key", null, PolyType.TEXT, false, false ),
+                new ColumnContext( "value", null, PolyType.TEXT, true, false ) ), 2 );
 
         PhysicalEntity edge = createSubstitutionEntity( scannable, context, logical, allocation, "_edge_", List.of(
-                new ColumnContext( "id", GraphType.ID_SIZE, PolyType.VARCHAR, false ),
-                new ColumnContext( "label", null, PolyType.TEXT, true ),
-                new ColumnContext( "_l_id_", GraphType.ID_SIZE, PolyType.VARCHAR, true ),
-                new ColumnContext( "_r_id_", GraphType.ID_SIZE, PolyType.VARCHAR, true ) ), 1 );
+                new ColumnContext( "id", GraphType.ID_SIZE, PolyType.VARCHAR, false, false ),
+                new ColumnContext( "label", null, PolyType.TEXT, true, false ),
+                new ColumnContext( "_l_id_", GraphType.ID_SIZE, PolyType.VARCHAR, true, false ),
+                new ColumnContext( "_r_id_", GraphType.ID_SIZE, PolyType.VARCHAR, true, false ) ), 1 );
 
         PhysicalEntity eProperties = createSubstitutionEntity( scannable, context, logical, allocation, "_eProperties_", List.of(
-                new ColumnContext( "id", GraphType.ID_SIZE, PolyType.VARCHAR, false ),
-                new ColumnContext( "key", null, PolyType.TEXT, false ),
-                new ColumnContext( "value", null, PolyType.TEXT, true ) ), 2 );
+                new ColumnContext( "id", GraphType.ID_SIZE, PolyType.VARCHAR, false, false ),
+                new ColumnContext( "key", null, PolyType.TEXT, false, false ),
+                new ColumnContext( "value", null, PolyType.TEXT, true, false ) ), 2 );
 
         scannable.getCatalog().addPhysical( allocation, node, nProperties, edge, eProperties );
         return List.of( node, nProperties, edge, eProperties );
@@ -222,8 +222,8 @@ public interface Scannable {
 
     static List<PhysicalEntity> createCollectionSubstitute( Scannable scannable, Context context, LogicalCollection logical, AllocationCollection allocation ) {
         PhysicalEntity doc = createSubstitutionEntity( scannable, context, logical, allocation, "_doc_", List.of(
-                new ColumnContext( DocumentType.DOCUMENT_ID, null, PolyType.TEXT, false ),
-                new ColumnContext( DocumentType.DOCUMENT_DATA, null, PolyType.TEXT, false ) ), 1 );
+                new ColumnContext( DocumentType.DOCUMENT_ID, null, PolyType.TEXT, false, false ),
+                new ColumnContext( DocumentType.DOCUMENT_DATA, null, PolyType.TEXT, false, false ) ), 1 );
 
         scannable.getCatalog().addPhysical( allocation, doc );
         return List.of( doc );
@@ -250,7 +250,7 @@ public interface Scannable {
     void renameLogicalColumn( long id, String newColumnName );
 
 
-    record ColumnContext( String name, Integer precision, PolyType type, boolean nullable ) {
+    record ColumnContext( String name, Integer precision, PolyType type, boolean nullable, boolean autoIncrement ) {
 
     }
 

--- a/core/src/main/java/org/polypheny/db/algebra/type/AlgDataType.java
+++ b/core/src/main/java/org/polypheny/db/algebra/type/AlgDataType.java
@@ -130,6 +130,8 @@ public interface AlgDataType extends Wrapper, Expressible {
      */
     boolean isNullable();
 
+    boolean isAutoIncrement();
+
     /**
      * Gets the component type if this type is a collection, otherwise null.
      *

--- a/core/src/main/java/org/polypheny/db/algebra/type/AlgDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/polypheny/db/algebra/type/AlgDataTypeFactoryImpl.java
@@ -591,6 +591,11 @@ public abstract class AlgDataTypeFactoryImpl implements AlgDataTypeFactory {
             return nullable;
         }
 
+        @Override
+        public boolean isAutoIncrement() {
+            return false;
+        }
+
 
         @Override
         public AlgDataTypeFamily getFamily() {

--- a/core/src/main/java/org/polypheny/db/algebra/type/AlgDataTypeImpl.java
+++ b/core/src/main/java/org/polypheny/db/algebra/type/AlgDataTypeImpl.java
@@ -232,6 +232,11 @@ public abstract class AlgDataTypeImpl implements AlgDataType, AlgDataTypeFamily 
         return false;
     }
 
+    @Override
+    public boolean isAutoIncrement() {
+        return false;
+    }
+
 
     @Override
     public Charset getCharset() {

--- a/core/src/main/java/org/polypheny/db/algebra/type/DocumentType.java
+++ b/core/src/main/java/org/polypheny/db/algebra/type/DocumentType.java
@@ -183,6 +183,11 @@ public class DocumentType implements AlgDataType, AlgDataTypeFamily {
         return false;
     }
 
+    @Override
+    public boolean isAutoIncrement() {
+        return false;
+    }
+
 
     @Override
     public AlgDataType getComponentType() {

--- a/core/src/main/java/org/polypheny/db/algebra/type/GraphType.java
+++ b/core/src/main/java/org/polypheny/db/algebra/type/GraphType.java
@@ -131,6 +131,11 @@ public class GraphType implements Serializable, AlgDataType, AlgDataTypeFamily {
         return false;
     }
 
+    @Override
+    public boolean isAutoIncrement() {
+        return false;
+    }
+
 
     @Override
     public AlgDataType getComponentType() {

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/LogicalRelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/LogicalRelationalCatalog.java
@@ -121,7 +121,7 @@ public interface LogicalRelationalCatalog extends LogicalCatalog {
      * @param collation The collation of the field (if applicable, else null)
      * @return The id of the inserted column
      */
-    LogicalColumn addColumn( String name, long tableId, int position, PolyType type, PolyType collectionsType, Integer length, Integer scale, Integer dimension, Integer cardinality, boolean nullable, Collation collation );
+    LogicalColumn addColumn( String name, long tableId, int position, PolyType type, PolyType collectionsType, Integer length, Integer scale, Integer dimension, Integer cardinality, boolean nullable, Collation collation, boolean autoIncrement );
 
 
     /**

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalColumn.java
@@ -21,6 +21,7 @@ import io.activej.serializer.annotations.Deserialize;
 import io.activej.serializer.annotations.Serialize;
 import io.activej.serializer.annotations.SerializeNullable;
 import java.io.Serial;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.NonFinal;
@@ -93,6 +94,12 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
 
     @Serialize
     @JsonProperty
+    public boolean autoIncrement;
+
+    public AtomicLong currentValue = new AtomicLong(0l);
+
+    @Serialize
+    @JsonProperty
     public @SerializeNullable Collation collation;
 
     @Serialize
@@ -117,7 +124,8 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
             @Deserialize("cardinality") final Integer cardinality,
             @Deserialize("nullable") final boolean nullable,
             @Deserialize("collation") final Collation collation,
-            @Deserialize("defaultValue") final LogicalDefaultValue defaultValue ) {
+            @Deserialize("defaultValue") final LogicalDefaultValue defaultValue,
+            @Deserialize("autoIncrement") final boolean autoIncrement) {
         this.id = id;
         this.name = name;
         this.tableId = tableId;
@@ -132,6 +140,7 @@ public class LogicalColumn implements PolyObject, Comparable<LogicalColumn> {
         this.nullable = nullable;
         this.collation = collation;
         this.defaultValue = defaultValue;
+        this.autoIncrement = autoIncrement;
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -292,9 +292,9 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
 
 
     @Override
-    public LogicalColumn addColumn( String name, long tableId, int position, PolyType type, PolyType collectionsType, Integer length, Integer scale, Integer dimension, Integer cardinality, boolean nullable, Collation collation ) {
+    public LogicalColumn addColumn( String name, long tableId, int position, PolyType type, PolyType collectionsType, Integer length, Integer scale, Integer dimension, Integer cardinality, boolean nullable, Collation collation, boolean autoIncrement ) {
         long id = idBuilder.getNewFieldId();
-        LogicalColumn column = new LogicalColumn( id, name, tableId, logicalNamespace.id, position, type, collectionsType, length, scale, dimension, cardinality, nullable, collation, null );
+        LogicalColumn column = new LogicalColumn( id, name, tableId, logicalNamespace.id, position, type, collectionsType, length, scale, dimension, cardinality, nullable, collation, null, autoIncrement );
         columns.put( id, column );
         change( CatalogEvent.LOGICAL_REL_FIELD_CREATED, null, id );
         return column;

--- a/core/src/main/java/org/polypheny/db/ddl/DdlManager.java
+++ b/core/src/main/java/org/polypheny/db/ddl/DdlManager.java
@@ -626,6 +626,17 @@ public abstract class DdlManager {
             this.autoIncrement = autoIncrement == null ? false : autoIncrement;
         }
 
+        public ColumnTypeInformation(
+                PolyType type,
+                @Nullable PolyType collectionType,
+                Integer precision,
+                Integer scale,
+                Integer dimension,
+                Integer cardinality,
+                Boolean nullable ) {
+            this(type, collectionType, precision, scale, dimension, cardinality, nullable, false);
+        }
+
 
         public static ColumnTypeInformation fromDataTypeSpec( DataTypeSpec sqlDataType ) {
             return new ColumnTypeInformation(

--- a/core/src/main/java/org/polypheny/db/ddl/DdlManager.java
+++ b/core/src/main/java/org/polypheny/db/ddl/DdlManager.java
@@ -166,7 +166,7 @@ public abstract class DdlManager {
      * @param defaultValue a default value for the column; can be null
      * @param statement the query statement
      */
-    public abstract void createColumn( String columnName, LogicalTable table, String beforeColumnName, String afterColumnName, ColumnTypeInformation type, boolean nullable, PolyValue defaultValue, Statement statement );
+    public abstract void createColumn( String columnName, LogicalTable table, String beforeColumnName, String afterColumnName, ColumnTypeInformation type, boolean nullable, PolyValue defaultValue, Statement statement, boolean autoIncrement );
 
     /**
      * Add a foreign key to a table
@@ -605,7 +605,7 @@ public abstract class DdlManager {
      * decoupled from the used query language
      */
 
-    public record ColumnTypeInformation( PolyType type, @Nullable PolyType collectionType, Integer precision, Integer scale, Integer dimension, Integer cardinality, Boolean nullable ) {
+    public record ColumnTypeInformation( PolyType type, @Nullable PolyType collectionType, Integer precision, Integer scale, Integer dimension, Integer cardinality, Boolean nullable, Boolean autoIncrement ) {
 
         public ColumnTypeInformation(
                 PolyType type,
@@ -614,7 +614,8 @@ public abstract class DdlManager {
                 Integer scale,
                 Integer dimension,
                 Integer cardinality,
-                Boolean nullable ) {
+                Boolean nullable,
+                Boolean autoIncrement ) {
             this.type = type;
             this.collectionType = collectionType == type ? null : collectionType;
             this.precision = precision == null || precision == -1 ? null : precision;
@@ -622,6 +623,7 @@ public abstract class DdlManager {
             this.dimension = dimension == null || dimension == -1 ? null : dimension;
             this.cardinality = cardinality == null || cardinality == -1 ? null : cardinality;
             this.nullable = nullable;
+            this.autoIncrement = autoIncrement == null ? false : autoIncrement;
         }
 
 
@@ -633,7 +635,8 @@ public abstract class DdlManager {
                     sqlDataType.getScale(),
                     sqlDataType.getDimension(),
                     sqlDataType.getCardinality(),
-                    sqlDataType.getNullable() );
+                    sqlDataType.getNullable(),
+                    sqlDataType.getAutoIncrement());
         }
 
     }

--- a/core/src/main/java/org/polypheny/db/nodes/DataTypeSpec.java
+++ b/core/src/main/java/org/polypheny/db/nodes/DataTypeSpec.java
@@ -35,6 +35,8 @@ public interface DataTypeSpec extends Visitable {
 
     Boolean getNullable();
 
+    Boolean getAutoIncrement();
+
     Identifier getCollectionsTypeName();
 
     PolyType getCollectionsType();

--- a/core/src/main/java/org/polypheny/db/type/AbstractPolyType.java
+++ b/core/src/main/java/org/polypheny/db/type/AbstractPolyType.java
@@ -50,6 +50,7 @@ public abstract class AbstractPolyType extends AlgDataTypeImpl implements Clonea
 
     protected final PolyType typeName;
     protected boolean isNullable;
+    protected boolean isAutoIncrement;
 
 
     /**
@@ -77,6 +78,11 @@ public abstract class AbstractPolyType extends AlgDataTypeImpl implements Clonea
     @Override
     public boolean isNullable() {
         return isNullable;
+    }
+
+    @Override
+    public boolean isAutoIncrement() {
+        return isAutoIncrement;
     }
 
 

--- a/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
@@ -254,7 +254,8 @@ public class DdlManagerImpl extends DdlManager {
                         exportedColumn.dimension,
                         exportedColumn.cardinality,
                         exportedColumn.nullable,
-                        Collation.getDefaultCollation() );
+                        Collation.getDefaultCollation(),
+                        exportedColumn.autoIncrement);
 
                 AllocationColumn allocationColumn = catalog.getAllocRel( namespace ).addColumn(
                         placement.id,
@@ -408,7 +409,8 @@ public class DdlManagerImpl extends DdlManager {
                 exportedColumn.dimension,
                 exportedColumn.cardinality,
                 exportedColumn.nullable,
-                Collation.getDefaultCollation()
+                Collation.getDefaultCollation(),
+                exportedColumn.autoIncrement
         );
 
         // Add default value
@@ -455,7 +457,7 @@ public class DdlManagerImpl extends DdlManager {
 
 
     @Override
-    public void createColumn( String columnName, LogicalTable table, String beforeColumnName, String afterColumnName, ColumnTypeInformation type, boolean nullable, PolyValue defaultValue, Statement statement ) {
+    public void createColumn( String columnName, LogicalTable table, String beforeColumnName, String afterColumnName, ColumnTypeInformation type, boolean nullable, PolyValue defaultValue, Statement statement, boolean autoIncrement ) {
         columnName = adjustNameIfNeeded( columnName, table.namespaceId );
         // Check if the column either allows null values or has a default value defined.
         if ( defaultValue == null && !nullable ) {
@@ -484,7 +486,8 @@ public class DdlManagerImpl extends DdlManager {
                 type.dimension(),
                 type.cardinality(),
                 nullable,
-                Collation.getDefaultCollation()
+                Collation.getDefaultCollation(),
+                autoIncrement
         );
 
         // Add default value
@@ -1683,7 +1686,8 @@ public class DdlManagerImpl extends DdlManager {
                     column.typeInformation().dimension(),
                     column.typeInformation().cardinality(),
                     column.typeInformation().nullable(),
-                    column.collation() );
+                    column.collation(),
+                    column.typeInformation().autoIncrement());
         }
 
         catalog.updateSnapshot();
@@ -1973,7 +1977,8 @@ public class DdlManagerImpl extends DdlManager {
                             type.getScale(),
                             alg.getType().getPolyType() == PolyType.ARRAY ? (int) ((ArrayType) alg.getType()).getDimension() : -1,
                             alg.getType().getPolyType() == PolyType.ARRAY ? (int) ((ArrayType) alg.getType()).getCardinality() : -1,
-                            alg.getType().isNullable() ),
+                            alg.getType().isNullable(),
+                            alg.getType().isAutoIncrement()),
                     Collation.getDefaultCollation(),
                     null,
                     position ) );
@@ -1992,7 +1997,8 @@ public class DdlManagerImpl extends DdlManager {
                             -1,
                             -1,
                             -1,
-                            false ),
+                            false,
+                            false),
                     Collation.getDefaultCollation(),
                     null,
                     position ) );
@@ -2762,7 +2768,8 @@ public class DdlManagerImpl extends DdlManager {
                 typeInformation.dimension(),
                 typeInformation.cardinality(),
                 typeInformation.nullable(),
-                collation
+                collation,
+                typeInformation.autoIncrement()
         );
 
         // Add default value

--- a/dbms/src/test/java/org/polypheny/db/catalog/CatalogTransactionTest.java
+++ b/dbms/src/test/java/org/polypheny/db/catalog/CatalogTransactionTest.java
@@ -56,11 +56,11 @@ public class CatalogTransactionTest {
 
         LogicalTable table = catalog.getLogicalRel( namespaceId ).addTable( "testTable", EntityType.ENTITY, true );
 
-        catalog.getLogicalRel( namespaceId ).addColumn( "testCol1", table.id, 1, PolyType.BIGINT, null, null, null, null, null, false, null );
+        catalog.getLogicalRel( namespaceId ).addColumn( "testCol1", table.id, 1, PolyType.BIGINT, null, null, null, null, null, false, null, false );
 
         catalog.commit();
 
-        LogicalColumn id = catalog.getLogicalRel( namespaceId ).addColumn( "testCol4", table.id, 2, PolyType.BIGINT, null, null, null, null, null, true, null );
+        LogicalColumn id = catalog.getLogicalRel( namespaceId ).addColumn( "testCol4", table.id, 2, PolyType.BIGINT, null, null, null, null, null, true, null, false );
         catalog.rollback();
 
         assert (catalog.getSnapshot().rel().getColumn( id.id ).isEmpty());
@@ -77,13 +77,13 @@ public class CatalogTransactionTest {
 
         LogicalTable table = catalog.getLogicalRel( namespaceId ).addTable( "testTable", EntityType.ENTITY, true );
 
-        catalog.getLogicalRel( namespaceId ).addColumn( "testCol1", table.id, 1, PolyType.BIGINT, null, null, null, null, null, false, null );
-        catalog.getLogicalRel( namespaceId ).addColumn( "testCol2", table.id, 2, PolyType.VARCHAR, null, 2646, 5, 2, 2, true, Collation.CASE_INSENSITIVE );
+        catalog.getLogicalRel( namespaceId ).addColumn( "testCol1", table.id, 1, PolyType.BIGINT, null, null, null, null, null, false, null, false );
+        catalog.getLogicalRel( namespaceId ).addColumn( "testCol2", table.id, 2, PolyType.VARCHAR, null, 2646, 5, 2, 2, true, Collation.CASE_INSENSITIVE, false );
         // catalog.getLogicalRel( namespaceId ).createColumn( "testCol3", table.id, 3, PolyType.BIGINT, null,null, null, null, null, true, null ); 127
 
         catalog.commit();
 
-        LogicalColumn id = catalog.getLogicalRel( namespaceId ).addColumn( "testCol4", table.id, 3, PolyType.BIGINT, null, null, null, null, null, true, null );
+        LogicalColumn id = catalog.getLogicalRel( namespaceId ).addColumn( "testCol4", table.id, 3, PolyType.BIGINT, null, null, null, null, null, true, null, false );
         catalog.rollback();
 
         assert (catalog.getSnapshot().rel().getColumn( id.id ).isEmpty());

--- a/dbms/src/test/java/org/polypheny/db/sql/clause/SimpleSqlTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/clause/SimpleSqlTest.java
@@ -60,17 +60,17 @@ public class SimpleSqlTest {
         try ( TestHelper.JdbcConnection polyphenyDbConnection = new TestHelper.JdbcConnection( true ) ) {
             Connection connection = polyphenyDbConnection.getConnection();
             try ( Statement statement = connection.createStatement() ) {
-                statement.executeUpdate( "DROP TABLE IF EXISTS TableA" );
-                statement.executeUpdate( "CREATE TABLE TableA(ID INTEGER NOT NULL AUTO_INCREMENT, YAC INTEGER NOT NULL AUTO_INCREMENT, PRIMARY KEY (ID))" );
-                statement.executeUpdate( "INSERT INTO TableA VALUES (1, 61), (2, 62)" );
-                statement.executeUpdate( "INSERT INTO TableA(YAC) VALUES (63)" );
-                statement.executeUpdate( "INSERT INTO TableA VALUES (100, 120)" );
-                statement.executeUpdate( "INSERT INTO TableA(YAC) VALUES (121)" );
-                statement.executeUpdate( "INSERT INTO TableA VALUES (4, 64)" );
-                statement.executeUpdate( "INSERT INTO TableA(YAC) VALUES (122)" );
-                statement.executeUpdate( "INSERT INTO TableA(ID) VALUES (103)" );
+                statement.executeUpdate( "DROP TABLE IF EXISTS TableAutoInc" );
+                statement.executeUpdate( "CREATE TABLE TableAutoInc(ID INTEGER NOT NULL AUTO_INCREMENT, YAC INTEGER NOT NULL AUTO_INCREMENT, PRIMARY KEY (ID))" );
+                statement.executeUpdate( "INSERT INTO TableAutoInc VALUES (1, 61), (2, 62)" );
+                statement.executeUpdate( "INSERT INTO TableAutoInc(YAC) VALUES (63)" );
+                statement.executeUpdate( "INSERT INTO TableAutoInc VALUES (100, 120)" );
+                statement.executeUpdate( "INSERT INTO TableAutoInc(YAC) VALUES (121)" );
+                statement.executeUpdate( "INSERT INTO TableAutoInc VALUES (4, 64)" );
+                statement.executeUpdate( "INSERT INTO TableAutoInc(YAC) VALUES (122)" );
+                statement.executeUpdate( "INSERT INTO TableAutoInc(ID) VALUES (103)" );
                 TestHelper.checkResultSet(
-                        statement.executeQuery( "SELECT ID, YAC FROM TableA" ),
+                        statement.executeQuery( "SELECT ID, YAC FROM TableAutoInc" ),
                         ImmutableList.of(
                                 new Object[]{1, 61},
                                 new Object[]{2, 62},
@@ -82,7 +82,7 @@ public class SimpleSqlTest {
                                 new Object[]{103, 123}
                         )
                 );
-                statement.executeUpdate( "DROP TABLE TableA" );
+                statement.executeUpdate( "DROP TABLE TableAutoInc" );
                 connection.commit();
             }
 

--- a/dbms/src/test/java/org/polypheny/db/sql/clause/SimpleSqlTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/clause/SimpleSqlTest.java
@@ -60,6 +60,7 @@ public class SimpleSqlTest {
         try ( TestHelper.JdbcConnection polyphenyDbConnection = new TestHelper.JdbcConnection( true ) ) {
             Connection connection = polyphenyDbConnection.getConnection();
             try ( Statement statement = connection.createStatement() ) {
+                statement.executeUpdate( "DROP TABLE IF EXISTS TableA" );
                 statement.executeUpdate( "CREATE TABLE TableA(ID INTEGER NOT NULL AUTO_INCREMENT, YAC INTEGER NOT NULL AUTO_INCREMENT, PRIMARY KEY (ID))" );
                 statement.executeUpdate( "INSERT INTO TableA VALUES (1, 61), (2, 62)" );
                 statement.executeUpdate( "INSERT INTO TableA(YAC) VALUES (63)" );

--- a/dbms/src/test/java/org/polypheny/db/sql/clause/SimpleSqlTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/clause/SimpleSqlTest.java
@@ -61,16 +61,15 @@ public class SimpleSqlTest {
             Connection connection = polyphenyDbConnection.getConnection();
             try ( Statement statement = connection.createStatement() ) {
                 statement.executeUpdate( "DROP TABLE IF EXISTS TableAutoInc" );
-                statement.executeUpdate( "CREATE TABLE TableAutoInc(ID INTEGER NOT NULL AUTO_INCREMENT, YAC INTEGER NOT NULL AUTO_INCREMENT, PRIMARY KEY (ID))" );
+                statement.executeUpdate( "CREATE TABLE TableAutoInc(RID INTEGER NOT NULL AUTO_INCREMENT, YAC INTEGER NOT NULL, PRIMARY KEY (RID))" );
                 statement.executeUpdate( "INSERT INTO TableAutoInc VALUES (1, 61), (2, 62)" );
                 statement.executeUpdate( "INSERT INTO TableAutoInc(YAC) VALUES (63)" );
                 statement.executeUpdate( "INSERT INTO TableAutoInc VALUES (100, 120)" );
                 statement.executeUpdate( "INSERT INTO TableAutoInc(YAC) VALUES (121)" );
                 statement.executeUpdate( "INSERT INTO TableAutoInc VALUES (4, 64)" );
                 statement.executeUpdate( "INSERT INTO TableAutoInc(YAC) VALUES (122)" );
-                statement.executeUpdate( "INSERT INTO TableAutoInc(ID) VALUES (103)" );
                 TestHelper.checkResultSet(
-                        statement.executeQuery( "SELECT ID, YAC FROM TableAutoInc" ),
+                        statement.executeQuery( "SELECT RID, YAC FROM TableAutoInc" ),
                         ImmutableList.of(
                                 new Object[]{1, 61},
                                 new Object[]{2, 62},
@@ -78,8 +77,7 @@ public class SimpleSqlTest {
                                 new Object[]{100, 120},
                                 new Object[]{101, 121},
                                 new Object[]{4, 64},
-                                new Object[]{102, 122},
-                                new Object[]{103, 123}
+                                new Object[]{102, 122}
                         )
                 );
                 statement.executeUpdate( "DROP TABLE TableAutoInc" );

--- a/dbms/src/test/java/org/polypheny/db/sql/clause/SimpleSqlTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/clause/SimpleSqlTest.java
@@ -57,6 +57,11 @@ public class SimpleSqlTest {
 
     @Test
     public void autoIncrement() throws SQLException {
+        // skip this test if store.default.equals("file")
+        String store = System.getProperty( "store.default" );
+        if ( store != null && store.equals( "file" ) ) {
+            return;
+        }
         try ( TestHelper.JdbcConnection polyphenyDbConnection = new TestHelper.JdbcConnection( true ) ) {
             Connection connection = polyphenyDbConnection.getConnection();
             try ( Statement statement = connection.createStatement() ) {

--- a/plugins/csv-adapter/src/main/java/org/polypheny/db/adapter/csv/CsvSource.java
+++ b/plugins/csv-adapter/src/main/java/org/polypheny/db/adapter/csv/CsvSource.java
@@ -264,7 +264,8 @@ public class CsvSource extends DataSource<RelAdapterCatalog> {
                             physicalTableName,
                             name,
                             position,
-                            position == 1 ) );
+                            position == 1,
+                            false) );
                     position++;
                 }
             } catch ( IOException e ) {

--- a/plugins/ethereum-adapter/src/main/java/org/polypheny/db/adapter/ethereum/EthereumPlugin.java
+++ b/plugins/ethereum-adapter/src/main/java/org/polypheny/db/adapter/ethereum/EthereumPlugin.java
@@ -188,7 +188,8 @@ public class EthereumPlugin extends PolyPlugin {
                         "block",
                         blockCol,
                         position,
-                        position == 0 ) );
+                        position == 0,
+                        false) );
                 position++;
 
             }
@@ -209,7 +210,8 @@ public class EthereumPlugin extends PolyPlugin {
                         "transaction",
                         transactCol,
                         position,
-                        position == 0 ) );
+                        position == 0,
+                        false) );
                 position++;
             }
             map.put( "transaction", transactCols );

--- a/plugins/excel-adapter/src/main/java/org/polypheny/db/adapter/excel/ExcelSource.java
+++ b/plugins/excel-adapter/src/main/java/org/polypheny/db/adapter/excel/ExcelSource.java
@@ -326,7 +326,8 @@ public class ExcelSource extends DataSource<RelAdapterCatalog> {
                                     physicalTableName,
                                     name,
                                     position,
-                                    position == 1 ) ); // TODO
+                                    position == 1,
+                                    false) ); // TODO
 
                             position++;
                         } catch ( Exception e ) {

--- a/plugins/file-adapter/src/main/java/org/polypheny/db/adapter/file/source/Qfs.java
+++ b/plugins/file-adapter/src/main/java/org/polypheny/db/adapter/file/source/Qfs.java
@@ -244,7 +244,8 @@ public class Qfs extends DataSource<RelAdapterCatalog> {
                 physTableName,
                 "path",
                 1,
-                true
+                true,
+                false
         ) );
 
         columns.add( new ExportedColumn(
@@ -260,6 +261,7 @@ public class Qfs extends DataSource<RelAdapterCatalog> {
                 physTableName,
                 "name",
                 2,
+                false,
                 false
         ) );
 
@@ -276,6 +278,7 @@ public class Qfs extends DataSource<RelAdapterCatalog> {
                 physTableName,
                 "size",
                 3,
+                false,
                 false
         ) );
 
@@ -292,6 +295,7 @@ public class Qfs extends DataSource<RelAdapterCatalog> {
                 physTableName,
                 "file",
                 4,
+                false,
                 false
         ) );
 

--- a/plugins/google-sheet-adapter/src/main/java/org/polypheny/db/adapter/googlesheet/GoogleSheetSource.java
+++ b/plugins/google-sheet-adapter/src/main/java/org/polypheny/db/adapter/googlesheet/GoogleSheetSource.java
@@ -297,7 +297,8 @@ public class GoogleSheetSource extends DataSource<RelAdapterCatalog> {
                         tableName,
                         col.toString(),
                         position,
-                        position == 0
+                        position == 0,
+                        false
                 ) );
                 position++;
             }

--- a/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/sources/AbstractJdbcSource.java
+++ b/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/sources/AbstractJdbcSource.java
@@ -296,7 +296,8 @@ public abstract class AbstractJdbcSource extends DataSource<RelAdapterCatalog> i
                                 row.getString( "TABLE_NAME" ),
                                 row.getString( "COLUMN_NAME" ),
                                 row.getInt( "ORDINAL_POSITION" ),
-                                primaryKeyColumns.contains( row.getString( "COLUMN_NAME" ) )
+                                primaryKeyColumns.contains( row.getString( "COLUMN_NAME" )),
+                                false
                         ) );
                     }
                     map.put( tableName, list );

--- a/plugins/sql-language/src/main/codegen/Parser.jj
+++ b/plugins/sql-language/src/main/codegen/Parser.jj
@@ -8233,6 +8233,7 @@ void NonReservedKeyWord0of3() :
     |    <ASSIGNMENT>
     |    <ATTRIBUTE>
     |    <ATTRIBUTES>
+    |   < AUTO_INCREMENT>
     |    <BEFORE>
     |    <BERNOULLI>
     |    <BREADTH>

--- a/plugins/sql-language/src/main/codegen/Parser.jj
+++ b/plugins/sql-language/src/main/codegen/Parser.jj
@@ -1951,6 +1951,7 @@ void TableElement(List<SqlNode> list) :
     SqlIdentifier refTable;
     SqlIdentifier refColumn;
     final boolean primary;
+    final boolean auto_increment;
 }
 {
     id = SimpleIdentifier()
@@ -1976,6 +1977,15 @@ void TableElement(List<SqlNode> list) :
             {
               nullable = true;
               primary = false;
+            }
+        )
+        (
+            <AUTO_INCREMENT> {
+                auto_increment = true;
+            }
+            |
+            {
+                auto_increment = false;
             }
         )
         (
@@ -2013,7 +2023,7 @@ void TableElement(List<SqlNode> list) :
                 }
         )
         {
-            list.add( SqlDdlNodes.column(s.add(id).end(this), id, type.withNullable(nullable), collation, e, strategy));
+            list.add( SqlDdlNodes.column(s.add(id).end(this), id, type.withNullable(nullable).withAutoIncrement(auto_increment), collation, e, strategy));
             if ( primary ) {
                 list.add( SqlDdlNodes.primary( s.add(id ).end( this ), id, new SqlNodeList( List.of( id ), s.end(this) ) ) );
             }
@@ -7508,6 +7518,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < ATTRIBUTE: "ATTRIBUTE" >
 |   < ATTRIBUTES: "ATTRIBUTES" >
 |   < AUTHORIZATION: "AUTHORIZATION" >
+|   < AUTO_INCREMENT: "AUTO_INCREMENT" >
 |   < AVG: "AVG" >
 |   < BEFORE: "BEFORE" >
 |   < BEGIN: "BEGIN" >

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDataTypeSpec.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDataTypeSpec.java
@@ -74,6 +74,8 @@ public class SqlDataTypeSpec extends SqlNode implements DataTypeSpec {
      */
     private Boolean nullable;
 
+    private Boolean autoIncrement = false;
+
 
     /**
      * Creates a type specification representing a regular, non-collection type.
@@ -151,6 +153,48 @@ public class SqlDataTypeSpec extends SqlNode implements DataTypeSpec {
         this.nullable = nullable;
     }
 
+    public SqlDataTypeSpec(
+            SqlIdentifier collectionsTypeName,
+            SqlIdentifier typeName,
+            SqlIdentifier baseTypeName,
+            int precision,
+            int scale,
+            int dimension,
+            int cardinality,
+            String charSetName,
+            TimeZone timeZone,
+            Boolean nullable,
+            ParserPos pos,
+            boolean autoIncrement) {
+        super( pos );
+        this.collectionsTypeName = collectionsTypeName;
+        this.typeName = typeName;
+        this.baseTypeName = baseTypeName;
+        this.precision = precision;
+        this.scale = scale;
+        this.dimension = dimension;
+        this.cardinality = cardinality;
+        this.charSetName = charSetName;
+        this.timeZone = timeZone;
+        this.nullable = nullable;
+        this.autoIncrement = autoIncrement;
+    }
+
+    public SqlDataTypeSpec(
+            SqlIdentifier collectionsTypeName,
+            SqlIdentifier typeName,
+            int precision,
+            int scale,
+            int dimension,
+            int cardinality,
+            String charSetName,
+            TimeZone timeZone,
+            Boolean nullable,
+            ParserPos pos,
+            boolean autoIncrement) {
+        this( collectionsTypeName, typeName, typeName, precision, scale, dimension, cardinality, charSetName, timeZone, nullable, pos, autoIncrement );
+    }
+
 
     @Override
     public SqlNode clone( ParserPos pos ) {
@@ -196,6 +240,13 @@ public class SqlDataTypeSpec extends SqlNode implements DataTypeSpec {
             return this;
         }
         return new SqlDataTypeSpec( collectionsTypeName, typeName, precision, scale, dimension, cardinality, charSetName, timeZone, nullable, getPos() );
+    }
+
+    public SqlDataTypeSpec withAutoIncrement( boolean autoIncrement ) {
+        if ( Objects.equals( autoIncrement, this.autoIncrement ) ) {
+            return this;
+        }
+        return new SqlDataTypeSpec( collectionsTypeName, typeName, precision, scale, dimension, cardinality, charSetName, timeZone, nullable, getPos(), autoIncrement );
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlColumnDeclaration.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlColumnDeclaration.java
@@ -53,6 +53,9 @@ public class SqlColumnDeclaration extends SqlCall {
     final ColumnStrategy strategy;
     final String collation;
 
+    @Getter
+    final boolean auto_increment;
+
 
     /**
      * Creates a SqlColumnDeclaration; use {@link SqlDdlNodes#column}.
@@ -64,6 +67,17 @@ public class SqlColumnDeclaration extends SqlCall {
         this.expression = expression;
         this.strategy = strategy;
         this.collation = collation;
+        this.auto_increment = false;
+    }
+
+    SqlColumnDeclaration( ParserPos pos, SqlIdentifier name, SqlDataTypeSpec dataType, String collation, SqlNode expression, ColumnStrategy strategy, boolean auto_increment ) {
+        super( pos );
+        this.name = name;
+        this.dataType = dataType;
+        this.expression = expression;
+        this.strategy = strategy;
+        this.collation = collation;
+        this.auto_increment = auto_increment;
     }
 
 

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddColumn.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/altertable/SqlAlterTableAddColumn.java
@@ -148,7 +148,8 @@ public class SqlAlterTableAddColumn extends SqlAlterTable {
                 ColumnTypeInformation.fromDataTypeSpec( type ),
                 nullable,
                 defaultValue == null ? null : SqlLiteral.toPoly( defaultValue ),
-                statement );
+                statement,
+                false);
     }
 
 }

--- a/plugins/sql-language/src/test/java/org/polypheny/db/sql/SqlLanguageDependent.java
+++ b/plugins/sql-language/src/test/java/org/polypheny/db/sql/SqlLanguageDependent.java
@@ -107,9 +107,9 @@ public class SqlLanguageDependent {
         DdlManager manager = DdlManager.getInstance();
 
         List<FieldInformation> columns = List.of(
-                new FieldInformation( "deptno", new ColumnTypeInformation( PolyType.INTEGER, null, null, null, null, null, false ), null, null, 0 ),
-                new FieldInformation( "name", new ColumnTypeInformation( PolyType.VARCHAR, null, 20, null, null, null, false ), null, null, 1 ),
-                new FieldInformation( "loc", new ColumnTypeInformation( PolyType.VARCHAR, null, 50, null, null, null, true ), null, null, 2 )
+                new FieldInformation( "deptno", new ColumnTypeInformation( PolyType.INTEGER, null, null, null, null, null, false, false ), null, null, 0 ),
+                new FieldInformation( "name", new ColumnTypeInformation( PolyType.VARCHAR, null, 20, null, null, null, false, false ), null, null, 1 ),
+                new FieldInformation( "loc", new ColumnTypeInformation( PolyType.VARCHAR, null, 50, null, null, null, true, false ), null, null, 2 )
         );
 
         List<ConstraintInformation> constraints = List.of(
@@ -133,9 +133,9 @@ public class SqlLanguageDependent {
         DdlManager manager = DdlManager.getInstance();
 
         List<FieldInformation> columns = List.of(
-                new FieldInformation( "deptno", new ColumnTypeInformation( PolyType.INTEGER, null, null, null, null, null, false ), null, null, 0 ),
-                new FieldInformation( "name", new ColumnTypeInformation( PolyType.VARCHAR, null, 20, null, null, null, false ), null, null, 1 ),
-                new FieldInformation( "loc", new ColumnTypeInformation( PolyType.VARCHAR, null, 50, null, null, null, true ), null, null, 2 )
+                new FieldInformation( "deptno", new ColumnTypeInformation( PolyType.INTEGER, null, null, null, null, null, false, false ), null, null, 0 ),
+                new FieldInformation( "name", new ColumnTypeInformation( PolyType.VARCHAR, null, 20, null, null, null, false, false ), null, null, 1 ),
+                new FieldInformation( "loc", new ColumnTypeInformation( PolyType.VARCHAR, null, 50, null, null, null, true, false ), null, null, 2 )
         );
 
         List<ConstraintInformation> constraints = List.of(
@@ -146,13 +146,13 @@ public class SqlLanguageDependent {
 
         // "CREATE TABLE employee( empid BIGINT NOT NULL, ename VARCHAR(20), job VARCHAR(10), mgr INTEGER, hiredate DATE, salary DECIMAL(7,2), commission DECIMAL(7,2), deptno INTEGER NOT NULL, PRIMARY KEY (empid)) "
         columns = List.of(
-                new FieldInformation( "empid", new ColumnTypeInformation( PolyType.BIGINT, null, null, null, null, null, false ), null, null, 0 ),
-                new FieldInformation( "ename", new ColumnTypeInformation( PolyType.VARCHAR, null, 20, null, null, null, true ), null, null, 1 ),
-                new FieldInformation( "job", new ColumnTypeInformation( PolyType.VARCHAR, null, 10, null, null, null, true ), null, null, 2 ),
-                new FieldInformation( "mgr", new ColumnTypeInformation( PolyType.INTEGER, null, null, null, null, null, true ), null, null, 3 ),
-                new FieldInformation( "hiredate", new ColumnTypeInformation( PolyType.DATE, null, null, null, null, null, true ), null, null, 4 ),
-                new FieldInformation( "salary", new ColumnTypeInformation( PolyType.DECIMAL, null, null, 7, 2, null, true ), null, null, 5 ),
-                new FieldInformation( "deptno", new ColumnTypeInformation( PolyType.INTEGER, null, null, null, null, null, true ), null, null, 6 )
+                new FieldInformation( "empid", new ColumnTypeInformation( PolyType.BIGINT, null, null, null, null, null, false, false ), null, null, 0 ),
+                new FieldInformation( "ename", new ColumnTypeInformation( PolyType.VARCHAR, null, 20, null, null, null, true, false ), null, null, 1 ),
+                new FieldInformation( "job", new ColumnTypeInformation( PolyType.VARCHAR, null, 10, null, null, null, true, false ), null, null, 2 ),
+                new FieldInformation( "mgr", new ColumnTypeInformation( PolyType.INTEGER, null, null, null, null, null, true, false ), null, null, 3 ),
+                new FieldInformation( "hiredate", new ColumnTypeInformation( PolyType.DATE, null, null, null, null, null, true, false ), null, null, 4 ),
+                new FieldInformation( "salary", new ColumnTypeInformation( PolyType.DECIMAL, null, null, 7, 2, null, true, false ), null, null, 5 ),
+                new FieldInformation( "deptno", new ColumnTypeInformation( PolyType.INTEGER, null, null, null, null, null, true, false ), null, null, 6 )
         );
 
         constraints = List.of(
@@ -165,7 +165,7 @@ public class SqlLanguageDependent {
         long id = manager.createNamespace( "customer", DataModel.RELATIONAL, true, false, transaction.createStatement() );
 
         columns = List.of(
-                new FieldInformation( "fname", new ColumnTypeInformation( PolyType.VARCHAR, null, 50, null, null, null, false ), null, null, 0 )
+                new FieldInformation( "fname", new ColumnTypeInformation( PolyType.VARCHAR, null, 50, null, null, null, false, false ), null, null, 0 )
         );
 
         constraints = List.of(


### PR DESCRIPTION
<!--
Please fill in all headings that are applicable to your pull request and make sure to label this it accordingly.
-->

## Summary

This PR adds AUTO_INCREMENT keyword support to both primary and non-primary columns of relational models which have integer or long types. 

### Changes

- Added AUTO_INCREMENT keyword

### Tests

- org.polypheny.db.sql.clause.SimpleSqlTest.autoIncrement