### PR TITLE
Add TCP_NODELAY to proxy connections and PolyphenyTlsClient

### DIFF
--- a/core/src/main/java/org/polypheny/db/docker/DockerContainer.java
+++ b/core/src/main/java/org/polypheny/db/docker/DockerContainer.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.StandardSocketOptions;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -218,6 +219,7 @@ public final class DockerContainer {
                 while ( true ) {
                     try {
                         Socket local = server.accept();
+                        local.setOption( StandardSocketOptions.TCP_NODELAY, true );
                         DockerInstance dockerInstance = getDockerInstance().orElseThrow( () -> new IOException( "Not connected to docker host" ) );
                         startProxyForConnection( dockerInstance, local, port );
                     } catch ( IOException e ) {

--- a/core/src/main/java/org/polypheny/db/docker/PolyphenyTlsClient.java
+++ b/core/src/main/java/org/polypheny/db/docker/PolyphenyTlsClient.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.StandardSocketOptions;
 import java.security.SecureRandom;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -85,6 +86,7 @@ final class PolyphenyTlsClient {
         byte[] serverCertificate = PolyphenyCertificateManager.loadServerCertificate( context, hostname );
         Socket s = new Socket();
         s.connect( new InetSocketAddress( hostname, port ), 5000 );
+        s.setOption( StandardSocketOptions.TCP_NODELAY, true );
         try {
             PolyphenyTlsClient client = new PolyphenyTlsClient( kp, serverCertificate, s.getInputStream(), s.getOutputStream() );
             client.socket = s;


### PR DESCRIPTION
This sets TCP_NODELAY on sockets used to communicate with stores deployed on Docker.  This leads to a massive speedup (e.g. the YCSB benchmark shows a 4-5 time speedup for stores deployed on Docker).