### PR TITLE
Fix Neo4j remote deployment

### DIFF
--- a/core/src/main/java/org/polypheny/db/adapter/AdapterManager.java
+++ b/core/src/main/java/org/polypheny/db/adapter/AdapterManager.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.jetbrains.annotations.NotNull;
+import org.polypheny.db.adapter.DeployMode.DeploySetting;
 import org.polypheny.db.adapter.annotations.AdapterProperties;
 import org.polypheny.db.adapter.java.AdapterTemplate;
 import org.polypheny.db.catalog.Catalog;
@@ -175,6 +176,13 @@ public class AdapterManager {
         }
 
         AdapterTemplate adapterTemplate = AdapterTemplate.fromString( adapterName, adapterType );
+
+
+        for ( AbstractAdapterSetting setting : adapterTemplate.settings ) {
+            if ( setting.appliesTo.stream().noneMatch( s -> s.appliesTo( mode ) ) ) {
+                settings.remove( setting.name );
+            }
+        }
 
         long adapterId = Catalog.getInstance().createAdapter( uniqueName, adapterName, adapterType, settings, mode );
         try {

--- a/core/src/main/java/org/polypheny/db/adapter/DeployMode.java
+++ b/core/src/main/java/org/polypheny/db/adapter/DeployMode.java
@@ -35,17 +35,6 @@ public enum DeployMode {
     }
 
 
-    public static DeployMode fromString( String mode ) {
-        if ( mode.equals( "remote" ) ) {
-            return REMOTE;
-        } else if ( mode.equals( "docker" ) ) {
-            return DOCKER;
-        } else {
-            return EMBEDDED;
-        }
-    }
-
-
     public enum DeploySetting {
         REMOTE( DeployMode.REMOTE ),
         DOCKER( DeployMode.DOCKER ),
@@ -81,6 +70,11 @@ public enum DeployMode {
             } else {
                 return Collections.singletonList( mode );
             }
+        }
+
+
+        boolean appliesTo( DeployMode mode ) {
+            return usedByAll || this.mode.equals( mode );
         }
 
     }

--- a/plugins/neo4j-adapter/src/main/java/org/polypheny/db/adapter/neo4j/Neo4jPlugin.java
+++ b/plugins/neo4j-adapter/src/main/java/org/polypheny/db/adapter/neo4j/Neo4jPlugin.java
@@ -43,8 +43,11 @@ import org.polypheny.db.adapter.AdapterManager;
 import org.polypheny.db.adapter.DataStore;
 import org.polypheny.db.adapter.DataStore.IndexMethodModel;
 import org.polypheny.db.adapter.DeployMode;
+import org.polypheny.db.adapter.DeployMode.DeploySetting;
 import org.polypheny.db.adapter.GraphModifyDelegate;
 import org.polypheny.db.adapter.annotations.AdapterProperties;
+import org.polypheny.db.adapter.annotations.AdapterSettingInteger;
+import org.polypheny.db.adapter.annotations.AdapterSettingString;
 import org.polypheny.db.adapter.neo4j.types.NestedSingleType;
 import org.polypheny.db.adapter.neo4j.util.NeoUtil;
 import org.polypheny.db.catalog.catalogs.GraphAdapterCatalog;
@@ -130,12 +133,16 @@ public class Neo4jPlugin extends PolyPlugin {
 
 
     @Slf4j
+    @Extension
     @AdapterProperties(
             name = "Neo4j",
             description = "Neo4j is a graph-model based database system. It stores data in a graph structure which consists of nodes and edges.",
             usedModes = { DeployMode.DOCKER, DeployMode.REMOTE },
             defaultMode = DeployMode.DOCKER)
-    @Extension
+    @AdapterSettingString(name = "host", defaultValue = "localhost", appliesTo = DeploySetting.REMOTE)
+    @AdapterSettingInteger(name = "port", defaultValue = 7687, appliesTo = DeploySetting.REMOTE)
+    @AdapterSettingString(name = "user", defaultValue = "neo4j", appliesTo = DeploySetting.REMOTE)
+    @AdapterSettingString(name = "password", defaultValue = "neo4j", appliesTo = DeploySetting.REMOTE)
     public static class Neo4jStore extends DataStore<GraphAdapterCatalog> {
 
         private final String DEFAULT_DATABASE = "public";
@@ -173,7 +180,6 @@ public class Neo4jPlugin extends PolyPlugin {
             this.auth = AuthTokens.basic( this.user, this.pass );
 
             if ( deployMode == DeployMode.DOCKER ) {
-
                 if ( settings.getOrDefault( "deploymentId", "" ).isEmpty() ) {
                     int instanceId = Integer.parseInt( settings.get( "instanceId" ) );
                     DockerInstance instance = DockerManager.getInstance().getInstanceById( instanceId )
@@ -206,7 +212,9 @@ public class Neo4jPlugin extends PolyPlugin {
                 this.host = settings.get( "host" );
                 this.port = Integer.parseInt( settings.get( "port" ) );
                 this.container = null;
-
+                if ( !testConnection() ) {
+                    throw new GenericRuntimeException( "Could not connect to neo4j database" );
+                }
             } else {
                 throw new GenericRuntimeException( "Not supported deploy mode: " + deployMode.name() );
             }
@@ -233,13 +241,11 @@ public class Neo4jPlugin extends PolyPlugin {
          * Test if a connection to the provided Neo4j database is possible.
          */
         private boolean testConnection() {
-            if ( container == null ) {
-                return false;
+            if ( container != null ) {
+                HostAndPort hp = container.connectToContainer( 7687 );
+                this.host = hp.host();
+                this.port = hp.port();
             }
-
-            HostAndPort hp = container.connectToContainer( 7687 );
-            this.host = hp.host();
-            this.port = hp.port();
 
             try {
                 this.db = GraphDatabase.driver( new URI( String.format( "bolt://%s:%s", host, port ) ), auth );

--- a/plugins/neo4j-adapter/src/main/java/org/polypheny/db/adapter/neo4j/Neo4jPlugin.java
+++ b/plugins/neo4j-adapter/src/main/java/org/polypheny/db/adapter/neo4j/Neo4jPlugin.java
@@ -159,9 +159,6 @@ public class Neo4jPlugin extends PolyPlugin {
         @Getter
         private NeoNamespace currentNamespace;
 
-        @Getter
-        private NeoGraph currentGraph;
-
         private final TransactionProvider transactionProvider;
         private String host;
 


### PR DESCRIPTION
## Summary

With this change it is again possible to connect to use remote neo4j stores (i.e. not managed by Polypheny via Docker) .  This also exposed an issue where settings are taken as-is when creating an adapter, even when they contain entries which do not apply to the current deploy mode (e.g. password when deploying via Docker).  So fix this by filtering out all entries that do not apply to the deploy mode when creating an adapter.

## Fixes
 - Remote deployment of neo4j stores
 - Filter out settings that do not apply to the current mode when creating an adapter