### PR TITLE
Remove method `getNamespaceId `

### DIFF
--- a/core/src/main/java/org/polypheny/db/nodes/Node.java
+++ b/core/src/main/java/org/polypheny/db/nodes/Node.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.jetbrains.annotations.Nullable;
 import org.polypheny.db.algebra.constant.Kind;
-import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.languages.ParserPos;
 import org.polypheny.db.languages.QueryLanguage;
 import org.polypheny.db.util.Litmus;
@@ -94,10 +93,6 @@ public interface Node extends Cloneable, Visitable {
 
     default boolean isDdl() {
         return Kind.DDL.contains( getKind() );
-    }
-
-    default long getNamespaceId() {
-        return Catalog.defaultNamespaceId;
     }
 
     @Nullable

--- a/core/src/main/java/org/polypheny/db/processing/QueryContext.java
+++ b/core/src/main/java/org/polypheny/db/processing/QueryContext.java
@@ -107,7 +107,7 @@ public class QueryContext {
             long namespaceId = context.namespaceId;
 
             if ( queryNode != null && queryNode.getNamespaceName() != null ) {
-                namespaceId = Catalog.snapshot().getNamespace( queryNode.getNamespaceName() ).map( n -> n.id ).orElse( queryNode.getNamespaceId() );
+                namespaceId = Catalog.snapshot().getNamespace( queryNode.getNamespaceName() ).map( n -> n.id ).orElse( namespaceId );
             }
 
             if ( context.transactions.stream().anyMatch( t -> !t.isActive() ) ) {

--- a/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/MqlCreateView.java
+++ b/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/MqlCreateView.java
@@ -52,9 +52,7 @@ public class MqlCreateView extends MqlNode implements ExecutableStatement {
 
     @Override
     public void execute( Context context, Statement statement, ParsedQueryContext parsedQueryContext ) {
-        long database = parsedQueryContext.getQueryNode().orElseThrow().getNamespaceId();
-
-        long namespaceId = context.getSnapshot().getNamespace( database ).orElseThrow().id;
+        long namespaceId = context.getSnapshot().getNamespace( parsedQueryContext.getNamespaceId() ).orElseThrow().id;
 
         QueryContext queryContext = QueryContext.builder()
                 .query( buildQuery() )

--- a/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/MqlRenameCollection.java
+++ b/plugins/mql-language/src/main/java/org/polypheny/db/languages/mql/MqlRenameCollection.java
@@ -48,16 +48,13 @@ public class MqlRenameCollection extends MqlCollectionStatement implements Execu
 
     @Override
     public void execute( Context context, Statement statement, ParsedQueryContext parsedQueryContext ) {
-        long namespaceId = parsedQueryContext.getQueryNode().orElseThrow().getNamespaceId();
-
-        LogicalCollection collection = context.getSnapshot().doc().getCollection( namespaceId, getCollection() ).orElseThrow();
+        LogicalCollection collection = context.getSnapshot().doc().getCollection( parsedQueryContext.getNamespaceId(), getCollection() ).orElseThrow();
 
         if ( dropTarget ) {
             DdlManager.getInstance().dropCollection( collection, statement );
         }
 
         DdlManager.getInstance().renameCollection( collection, newName, statement );
-
     }
 
 


### PR DESCRIPTION
## Summary

`getNamespaceId` is never overridden and returns the default namespace id, which cannot be correct in general.  So remove it and replace all uses with other methods to get an appropriate namespace id.