### PR TITLE
Add indexes to MonetDB

### DIFF
--- a/core/src/main/java/org/polypheny/db/adapter/DataStore.java
+++ b/core/src/main/java/org/polypheny/db/adapter/DataStore.java
@@ -17,6 +17,7 @@
 package org.polypheny.db.adapter;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializer;
 import java.util.ArrayList;
@@ -54,7 +55,7 @@ public abstract class DataStore<S extends AdapterCatalog> extends Adapter<S> imp
     public abstract List<FunctionalIndexInfo> getFunctionalIndexes( LogicalTable catalogTable );
 
 
-    public record IndexMethodModel( String name, String displayName ) {
+    public record IndexMethodModel( @JsonProperty String name, @JsonProperty String displayName ) {
 
     }
 

--- a/plugins/monetdb-adapter/src/main/java/org/polypheny/db/adapter/monetdb/stores/MonetdbStore.java
+++ b/plugins/monetdb-adapter/src/main/java/org/polypheny/db/adapter/monetdb/stores/MonetdbStore.java
@@ -309,13 +309,13 @@ public class MonetdbStore extends AbstractJdbcStore {
     public List<IndexMethodModel> getAvailableIndexMethods() {
         // According to the MonetDB documentation, MonetDB takes create index statements only as an advice and often freely
         // neglects them. Indexes are created and removed automatically.
-        return ImmutableList.of( new IndexMethodModel( "index", "index" ) );
+        return ImmutableList.of( new IndexMethodModel( "advisory", "ADVISORY ONLY" ) );
     }
 
 
     @Override
     public IndexMethodModel getDefaultIndexMethod() {
-        return new IndexMethodModel( "index", "index" );
+        return getAvailableIndexMethods().get( 0 );
     }
 
 


### PR DESCRIPTION
According to the [MonetDB documentation](https://www.monetdb.org/documentation-Aug2024/user-guide/sql-manual/data-definition/index-definitions/), `CREATE INDEX` statements are treated as advice only.  Because of this it was previously it was an error to create an index on a MonetDB store.  With this PR this is not longer an error and we execute an appropriate `CREATE INDEX` statement on the MonetDB store (although MonetDB may treat it as advisory and ignore it).