### PR TITLE
Rollback/restore with (materialized) views

### DIFF
--- a/core/src/main/java/org/polypheny/db/algebra/logical/relational/LogicalRelViewScan.java
+++ b/core/src/main/java/org/polypheny/db/algebra/logical/relational/LogicalRelViewScan.java
@@ -26,6 +26,7 @@ import org.polypheny.db.algebra.AlgCollationTraitDef;
 import org.polypheny.db.algebra.AlgNode;
 import org.polypheny.db.algebra.core.relational.RelScan;
 import org.polypheny.db.algebra.type.AlgDataType;
+import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.Entity;
 import org.polypheny.db.catalog.entity.logical.LogicalView;
 import org.polypheny.db.plan.AlgCluster;
@@ -63,7 +64,7 @@ public class LogicalRelViewScan extends RelScan<Entity> {
                                 } );
 
         LogicalView logicalView = entity.unwrap( LogicalView.class ).orElseThrow();
-        AlgCollation algCollation = logicalView.getAlgCollation();
+        AlgCollation algCollation = Catalog.snapshot().rel().getCollationInfo( entity.id );
 
         return new LogicalRelViewScan( cluster, traitSet, entity, logicalView.prepareView( cluster ), algCollation );
     }

--- a/core/src/main/java/org/polypheny/db/catalog/catalogs/LogicalRelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/catalogs/LogicalRelationalCatalog.java
@@ -326,7 +326,11 @@ public interface LogicalRelationalCatalog extends LogicalCatalog {
 
     Map<Long, LogicalConstraint> getConstraints();
 
+    void setNodeAndCollation( long id, AlgNode node, AlgCollation collation );
+
     Map<Long, AlgNode> getNodes();
+
+    Map<Long, AlgCollation> getCollations();
 
     void deleteKey( long id );
 

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalMaterializedView.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalMaterializedView.java
@@ -26,7 +26,6 @@ import java.util.Map.Entry;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
-import org.polypheny.db.algebra.AlgCollation;
 import org.polypheny.db.catalog.entity.MaterializedCriteria;
 import org.polypheny.db.catalog.logistic.EntityType;
 import org.polypheny.db.languages.QueryLanguage;
@@ -45,13 +44,26 @@ public class LogicalMaterializedView extends LogicalView {
 
 
     public LogicalMaterializedView(
+            long id,
+            String name,
+            long namespaceId,
+            String query,
+            Map<Long, List<Long>> underlyingTables,
+            QueryLanguage language,
+            MaterializedCriteria materializedCriteria,
+            boolean ordered
+    ) {
+        this( id, name, namespaceId, query, underlyingTables, language.serializedName(), materializedCriteria, ordered );
+    }
+
+
+    public LogicalMaterializedView(
             @Deserialize("id") long id,
             @Deserialize("name") String name,
             @Deserialize("namespaceId") long namespaceId,
-            @Deserialize("entityType") String query,
-            @Deserialize("algCollation") AlgCollation algCollation,
+            @Deserialize("query") String query,
             @Deserialize("underlyingTables") Map<Long, List<Long>> underlyingTables,
-            @Deserialize("language") QueryLanguage language,
+            @Deserialize("languageName") String languageName,
             @Deserialize("materializedCriteria") MaterializedCriteria materializedCriteria,
             @Deserialize("ordered") boolean ordered
     ) {
@@ -61,9 +73,8 @@ public class LogicalMaterializedView extends LogicalView {
                 namespaceId,
                 EntityType.MATERIALIZED_VIEW,
                 query,
-                algCollation,
                 underlyingTables,
-                language );
+                languageName );
 
         Map<Long, ImmutableList<Long>> map = new HashMap<>();
         for ( Entry<Long, List<Long>> e : underlyingTables.entrySet() ) {

--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalView.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalView.java
@@ -28,7 +28,6 @@ import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.experimental.SuperBuilder;
 import org.polypheny.db.algebra.AbstractAlgNode;
-import org.polypheny.db.algebra.AlgCollation;
 import org.polypheny.db.algebra.AlgNode;
 import org.polypheny.db.algebra.BiAlg;
 import org.polypheny.db.algebra.SingleAlg;
@@ -51,11 +50,22 @@ public class LogicalView extends LogicalTable {
     @Serialize
     public ImmutableMap<Long, List<Long>> underlyingTables;
     @Serialize
+    public String languageName;
     public QueryLanguage language;
     @Serialize
-    public AlgCollation algCollation;
-    @Serialize
     public String query;
+
+
+    public LogicalView(
+            long id,
+            String name,
+            long namespaceId,
+            EntityType entityType,
+            String query,
+            Map<Long, List<Long>> underlyingTables,
+            QueryLanguage language ) {
+        this( id, name, namespaceId, entityType, query, underlyingTables, language.serializedName() );
+    }
 
 
     public LogicalView(
@@ -64,9 +74,8 @@ public class LogicalView extends LogicalTable {
             @Deserialize("namespaceId") long namespaceId,
             @Deserialize("entityType") EntityType entityType,
             @Deserialize("query") String query,
-            @Deserialize("algCollation") AlgCollation algCollation,
             @Deserialize("underlyingTables") Map<Long, List<Long>> underlyingTables,
-            @Deserialize("language") QueryLanguage language ) {
+            @Deserialize("languageName") String languageName ) {
         super(
                 id,
                 name,
@@ -75,9 +84,9 @@ public class LogicalView extends LogicalTable {
                 null,
                 false );
         this.query = query;
-        this.algCollation = algCollation;
         this.underlyingTables = ImmutableMap.copyOf( underlyingTables );
-        this.language = language;
+        this.languageName = languageName;
+        this.language = QueryLanguage.from( languageName );
     }
 
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
+import org.polypheny.db.algebra.AlgCollation;
 import org.polypheny.db.algebra.AlgNode;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.LogicalConstraint;
@@ -288,6 +289,7 @@ public interface LogicalRelSnapshot {
 
 
     AlgNode getNodeInfo( long id );
+    AlgCollation getCollationInfo( long id );
 
     List<LogicalView> getConnectedViews( long id );
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
@@ -33,6 +33,7 @@ import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.polypheny.db.algebra.AlgCollation;
 import org.polypheny.db.algebra.AlgNode;
 import org.polypheny.db.catalog.catalogs.LogicalRelationalCatalog;
 import org.polypheny.db.catalog.entity.LogicalConstraint;
@@ -101,6 +102,8 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
 
     ImmutableMap<Long, AlgNode> nodes;
 
+    ImmutableMap<Long, AlgCollation> collations;
+
     ImmutableMap<Long, List<LogicalView>> connectedViews;
 
 
@@ -151,6 +154,8 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
 
         /// ALGNODES e.g. views and materializedViews
         this.nodes = ImmutableMap.copyOf( catalogs.values().stream().flatMap( c -> c.getNodes().entrySet().stream() ).collect( Collectors.toMap( Entry::getKey, Entry::getValue, getDuplicateError() ) ) );
+
+        this.collations = ImmutableMap.copyOf( catalogs.values().stream().flatMap( c -> c.getCollations().entrySet().stream() ).collect( Collectors.toMap( Entry::getKey, Entry::getValue, getDuplicateError() ) ) );
 
         this.views = buildViews();
 
@@ -523,6 +528,12 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
     @Override
     public AlgNode getNodeInfo( long id ) {
         return nodes.get( id );
+    }
+
+
+    @Override
+    public AlgCollation getCollationInfo( long id ) {
+        return collations.get( id );
     }
 
 

--- a/core/src/test/java/org/polypheny/db/snapshot/MockRelSnapshot.java
+++ b/core/src/test/java/org/polypheny/db/snapshot/MockRelSnapshot.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.polypheny.db.algebra.AlgCollation;
 import org.polypheny.db.algebra.AlgNode;
 import org.polypheny.db.catalog.entity.LogicalConstraint;
 import org.polypheny.db.catalog.entity.logical.LogicalColumn;
@@ -246,6 +247,12 @@ public class MockRelSnapshot implements LogicalRelSnapshot {
 
     @Override
     public AlgNode getNodeInfo( long id ) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
+    public AlgCollation getCollationInfo( long id ) {
         throw new UnsupportedOperationException();
     }
 

--- a/dbms/src/main/java/org/polypheny/db/view/MaterializedViewManagerImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/view/MaterializedViewManagerImpl.java
@@ -313,7 +313,7 @@ public class MaterializedViewManagerImpl extends MaterializedViewManager {
         DataMigrator dataMigrator = transaction.getDataMigrator();
         for ( AllocationEntity allocation : transaction.getSnapshot().alloc().getFromLogical( materializedView.id ) ) {
             Statement sourceStatement = transaction.createStatement();
-            prepareSourceAlg( sourceStatement, materializedView.getAlgCollation(), algRoot.alg );
+            prepareSourceAlg( sourceStatement, Catalog.snapshot().rel().getCollationInfo( materializedView.id ), algRoot.alg );
             Statement targetStatement = transaction.createStatement();
 
             if ( allocation.unwrap( AllocationTable.class ).isPresent() ) {

--- a/dbms/src/test/java/org/polypheny/db/sql/view/BasicMaterializedViewTest.java
+++ b/dbms/src/test/java/org/polypheny/db/sql/view/BasicMaterializedViewTest.java
@@ -1312,4 +1312,44 @@ public class BasicMaterializedViewTest {
         }
     }
 
+
+    @Test
+    public void testMaterializedViewRollback() throws SQLException {
+        try ( JdbcConnection polyphenyDbConnection = new JdbcConnection( false ) ) {
+            Connection connection = polyphenyDbConnection.getConnection();
+            try ( Statement statement = connection.createStatement() ) {
+                statement.executeUpdate( VIEW_TEST_EMP_TABLE_SQL );
+
+                try {
+                    statement.executeUpdate( "CREATE MATERIALIZED VIEW viewTestEmp AS SELECT * FROM viewTestEmpTable" );
+                    statement.executeUpdate( "CREATE MATERIALIZED VIEW viewTestEmp1 AS SELECT * FROM viewTestEmpTable" );
+
+                    statement.executeUpdate( VIEW_TEST_EMP_TABLE_DATA_SQL );
+                    // Rollback the catalog to test that views are correctly restored
+                    connection.rollback();
+
+                    statement.executeUpdate( VIEW_TEST_EMP_TABLE_DATA_SQL );
+                    statement.executeUpdate( "ALTER MATERIALIZED VIEW viewTestEmp FRESHNESS MANUAL" );
+                    connection.commit();
+
+                    TestHelper.checkResultSet(
+                            statement.executeQuery( "SELECT empId,firstName,lastName,depId FROM viewTestEmp ORDER BY empid" ),
+                            ImmutableList.of(
+                                    new Object[]{ 1, "Max", "Muster", 1 },
+                                    new Object[]{ 2, "Ernst", "Walter", 2 },
+                                    new Object[]{ 3, "Elsa", "Kuster", 3 }
+                            )
+                    );
+
+                    // Drop the materialized views
+                    statement.executeUpdate( "DROP MATERIALIZED VIEW viewTestEmp" );
+                    statement.executeUpdate( "DROP MATERIALIZED VIEW viewTestEmp1" );
+                } finally {
+                    statement.executeUpdate( "DROP TABLE viewTestEmpTable" );
+                    dropTables( statement );
+                }
+            }
+        }
+    }
+
 }

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateView.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/ddl/SqlCreateView.java
@@ -112,12 +112,11 @@ public class SqlCreateView extends SqlCreate implements ExecutableStatement {
 
         PlacementType placementType = PlacementType.AUTOMATIC;
 
-        QueryLanguage language = QueryLanguage.from( "sql" );
-        Processor sqlProcessor = statement.getTransaction().getProcessor( language );
+        Processor sqlProcessor = statement.getTransaction().getProcessor( query.getLanguage() );
         AlgRoot algRoot = sqlProcessor.translate( statement,
                 ParsedQueryContext.builder()
-                        .query( query.toString() )
-                        .language( language )
+                        .query( query.toSqlString( PolyphenyDbSqlDialect.DEFAULT ).toString() )
+                        .language( query.getLanguage() )
                         .queryNode(
                                 sqlProcessor.validate(
                                         statement.getTransaction(), this.query, RuntimeConfig.ADD_DEFAULT_VALUES_IN_INSERTS.getBoolean() ).left )


### PR DESCRIPTION
This PR fixes various issues with views during rollback and restore.

 - Views are now correctly serialized and restored to `LogicalView` or `LogicalMaterializedView` respectively.
 - The `collation` field was removed from `LogicalView` to make the serialization easier.  The content of the `collation` field is now stored in the `LogicalRelationalCatalog` in the `collations` map (like the `AlgNode`s related to a view are already stored in a `nodes` map).
 - When restoring the Catalog (when Polypheny is started), the `nodes` and `collations` maps are re-populated, as they are not serialized with the Catalog.
