### PR TITLE
Improve set related operations

### DIFF
--- a/core/src/main/java/org/polypheny/db/functions/Functions.java
+++ b/core/src/main/java/org/polypheny/db/functions/Functions.java
@@ -2277,7 +2277,7 @@ public class Functions {
     public static <E> Collection<E> multisetIntersectDistinct( Collection<E> c1, Collection<E> c2 ) {
         final Set<E> result = new HashSet<>( c1 );
         result.retainAll( c2 );
-        return new ArrayList<>( result );
+        return result;
     }
 
 
@@ -2314,7 +2314,7 @@ public class Functions {
     public static <E> Collection<E> multisetExceptDistinct( Collection<E> c1, Collection<E> c2 ) {
         final Set<E> result = new HashSet<>( c1 );
         result.removeAll( c2 );
-        return new ArrayList<>( result );
+        return result;
     }
 
 
@@ -2363,7 +2363,7 @@ public class Functions {
         Set<String> resultCollection = new HashSet<>( Math.max( (int) ((collection1.size() + collection2.size()) / .75f) + 1, 16 ) );
         resultCollection.addAll( collection1 );
         resultCollection.addAll( collection2 );
-        return new ArrayList<>( resultCollection );
+        return resultCollection;
     }
 
 

--- a/core/src/main/java/org/polypheny/db/rex/RexSimplify.java
+++ b/core/src/main/java/org/polypheny/db/rex/RexSimplify.java
@@ -1255,7 +1255,7 @@ public class RexSimplify {
         // Example #1. x AND y AND z AND NOT (x AND y)  - not satisfiable
         // Example #2. x AND y AND NOT (x AND y)        - not satisfiable
         // Example #3. x AND y AND NOT (x AND y AND z)  - may be satisfiable
-        final Set<RexNode> termsSet = new HashSet<>( terms );
+        final Set<RexNode> termsSet = Set.copyOf( terms );
         for ( RexNode notDisjunction : notTerms ) {
             if ( !RexUtil.isDeterministic( notDisjunction ) ) {
                 continue;
@@ -1439,7 +1439,7 @@ public class RexSimplify {
             // Analyzer cannot handle this expression currently
             return simplified;
         }
-        if ( !new HashSet<>( foo0.variables ).containsAll( foo1.variables ) ) {
+        if ( !Set.copyOf( foo0.variables ).containsAll( foo1.variables ) ) {
             throw new AssertionError( "variable mismatch: " + before + " has " + foo0.variables + ", " + simplified + " has " + foo1.variables );
         }
         assignment_loop:

--- a/core/src/main/java/org/polypheny/db/util/EquivalenceSet.java
+++ b/core/src/main/java/org/polypheny/db/util/EquivalenceSet.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
@@ -169,7 +170,7 @@ public class EquivalenceSet<E extends Comparable<E>> {
      * Returns the number of equivalence classes in this equivalence set.
      */
     public int classCount() {
-        return new HashSet<>( parents.values() ).size();
+        return Set.copyOf( parents.values() ).size();
     }
 
 }

--- a/core/src/test/java/org/polypheny/db/util/ImmutableBitSetTest.java
+++ b/core/src/test/java/org/polypheny/db/util/ImmutableBitSetTest.java
@@ -232,7 +232,7 @@ public class ImmutableBitSetTest {
             assertEquals( list1, listView );
             assertThat( list1.hashCode(), equalTo( listView.hashCode() ) );
 
-            final Set<Integer> set = new HashSet<>( list1 );
+            final Set<Integer> set = Set.copyOf( list1 );
             assertThat( setView.hashCode(), is( set.hashCode() ) );
             assertThat( setView, equalTo( set ) );
 

--- a/core/src/test/java/org/polypheny/db/util/UtilTest.java
+++ b/core/src/test/java/org/polypheny/db/util/UtilTest.java
@@ -808,7 +808,7 @@ public class UtilTest {
         final Set<Integer> set = IntegerIntervalSet.of( s );
         assertEquals( set.size(), ints.length );
         List<Integer> list = new ArrayList<>( set );
-        assertEquals( new HashSet<>( Ints.asList( ints ) ), set );
+        assertEquals( Set.copyOf( Ints.asList( ints ) ), set );
         return list;
     }
 
@@ -980,7 +980,7 @@ public class UtilTest {
     private void checkCompositeMap( String[] beatles, Map<String, Integer> map ) {
         assertThat( 4, equalTo( map.size() ) );
         assertThat( false, equalTo( map.isEmpty() ) );
-        assertThat( map.keySet(), equalTo( (Set<String>) new HashSet<>( Arrays.asList( beatles ) ) ) );
+        assertThat( map.keySet(), equalTo(  Set.copyOf( Arrays.asList( beatles ) ) ) );
         assertThat( ImmutableMultiset.copyOf( map.values() ), equalTo( ImmutableMultiset.copyOf( Arrays.asList( 4, 4, 6, 5 ) ) ) );
     }
 

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticRepository.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/statistics/StatisticRepository.java
@@ -17,7 +17,6 @@
 package org.polypheny.db.monitoring.statistics;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.polypheny.db.StatisticsManager;
@@ -86,7 +85,7 @@ public class StatisticRepository implements MonitoringRepository {
 
     private void updateQueryStatistics( QueryDataPointImpl dataPoint, StatisticsManager statisticsManager ) {
         if ( !dataPoint.getAvailableColumnsWithTable().isEmpty() ) {
-            Set<Long> values = new HashSet<>( dataPoint.getAvailableColumnsWithTable().values() );
+            Set<Long> values = Set.copyOf( dataPoint.getAvailableColumnsWithTable().values() );
             boolean isOneTable = values.size() == 1;
             Snapshot snapshot = Catalog.snapshot();
 
@@ -120,7 +119,7 @@ public class StatisticRepository implements MonitoringRepository {
             return;
         }
 
-        Set<Long> values = new HashSet<>( dataPoint.getAvailableColumnsWithTable().values() );
+        Set<Long> values = Set.copyOf( dataPoint.getAvailableColumnsWithTable().values() );
         boolean isOneTable = values.size() == 1;
 
         Snapshot snapshot = Catalog.snapshot();

--- a/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDialect.java
+++ b/plugins/sql-language/src/main/java/org/polypheny/db/sql/language/SqlDialect.java
@@ -18,15 +18,12 @@ package org.polypheny.db.sql.language;
 
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.NonNull;
 import lombok.Value;
@@ -51,7 +48,6 @@ import org.polypheny.db.algebra.type.AlgDataTypeSystem;
 import org.polypheny.db.algebra.type.AlgDataTypeSystemImpl;
 import org.polypheny.db.languages.OperatorRegistry;
 import org.polypheny.db.languages.ParserPos;
-import org.polypheny.db.nodes.Operator;
 import org.polypheny.db.nodes.TimeUnitRange;
 import org.polypheny.db.sql.language.dialect.JethroDataSqlDialect;
 import org.polypheny.db.sql.language.dialect.JethroDataSqlDialect.JethroInfo;
@@ -83,60 +79,6 @@ public class SqlDialect {
      * Empty context.
      */
     public static final Context EMPTY_CONTEXT = emptyContext();
-
-    /**
-     * Built-in scalar functions and operators common for every dialect.
-     */
-    protected static final Set<Operator> BUILT_IN_OPERATORS_LIST =
-            ImmutableSet.<Operator>builder()
-                    .add( OperatorRegistry.get( OperatorName.ABS ) )
-                    .add( OperatorRegistry.get( OperatorName.ACOS ) )
-                    .add( OperatorRegistry.get( OperatorName.AND ) )
-                    .add( OperatorRegistry.get( OperatorName.ASIN ) )
-                    .add( OperatorRegistry.get( OperatorName.BETWEEN ) )
-                    .add( OperatorRegistry.get( OperatorName.CASE ) )
-                    .add( OperatorRegistry.get( OperatorName.CAST ) )
-                    .add( OperatorRegistry.get( OperatorName.CEIL ) )
-                    .add( OperatorRegistry.get( OperatorName.CHAR_LENGTH ) )
-                    .add( OperatorRegistry.get( OperatorName.CHARACTER_LENGTH ) )
-                    .add( OperatorRegistry.get( OperatorName.COALESCE ) )
-                    .add( OperatorRegistry.get( OperatorName.CONCAT ) )
-                    .add( OperatorRegistry.get( OperatorName.COS ) )
-                    .add( OperatorRegistry.get( OperatorName.COT ) )
-                    .add( OperatorRegistry.get( OperatorName.DIVIDE ) )
-                    .add( OperatorRegistry.get( OperatorName.EQUALS ) )
-                    .add( OperatorRegistry.get( OperatorName.FLOOR ) )
-                    .add( OperatorRegistry.get( OperatorName.GREATER_THAN ) )
-                    .add( OperatorRegistry.get( OperatorName.GREATER_THAN_OR_EQUAL ) )
-                    .add( OperatorRegistry.get( OperatorName.IN ) )
-                    .add( OperatorRegistry.get( OperatorName.IS_NOT_NULL ) )
-                    .add( OperatorRegistry.get( OperatorName.IS_NULL ) )
-                    .add( OperatorRegistry.get( OperatorName.LESS_THAN ) )
-                    .add( OperatorRegistry.get( OperatorName.LESS_THAN_OR_EQUAL ) )
-                    .add( OperatorRegistry.get( OperatorName.LIKE ) )
-                    .add( OperatorRegistry.get( OperatorName.LN ) )
-                    .add( OperatorRegistry.get( OperatorName.LOG10 ) )
-                    .add( OperatorRegistry.get( OperatorName.MINUS ) )
-                    .add( OperatorRegistry.get( OperatorName.MOD ) )
-                    .add( OperatorRegistry.get( OperatorName.MULTIPLY ) )
-                    .add( OperatorRegistry.get( OperatorName.NOT ) )
-                    .add( OperatorRegistry.get( OperatorName.NOT_BETWEEN ) )
-                    .add( OperatorRegistry.get( OperatorName.NOT_EQUALS ) )
-                    .add( OperatorRegistry.get( OperatorName.NOT_IN ) )
-                    .add( OperatorRegistry.get( OperatorName.NOT_LIKE ) )
-                    .add( OperatorRegistry.get( OperatorName.OR ) )
-                    .add( OperatorRegistry.get( OperatorName.PI ) )
-                    .add( OperatorRegistry.get( OperatorName.PLUS ) )
-                    .add( OperatorRegistry.get( OperatorName.POWER ) )
-                    .add( OperatorRegistry.get( OperatorName.RAND ) )
-                    .add( OperatorRegistry.get( OperatorName.ROUND ) )
-                    .add( OperatorRegistry.get( OperatorName.ROW ) )
-                    .add( OperatorRegistry.get( OperatorName.SIN ) )
-                    .add( OperatorRegistry.get( OperatorName.SQRT ) )
-                    .add( OperatorRegistry.get( OperatorName.SUBSTRING ) )
-                    .add( OperatorRegistry.get( OperatorName.TAN ) )
-                    .build();
-
 
     @NonNull
     String name;
@@ -749,7 +691,7 @@ public class SqlDialect {
 
 
     public List<OperatorName> supportedGeoFunctions() {
-        return ImmutableList.of();
+        return List.of();
     }
 
 

--- a/plugins/sql-language/src/test/java/org/polypheny/db/sql/language/FunctionsTest.java
+++ b/plugins/sql-language/src/test/java/org/polypheny/db/sql/language/FunctionsTest.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.polypheny.db.TestHelper;
@@ -796,41 +797,41 @@ public class FunctionsTest {
     public void testMultiset() {
         final List<String> abacee = Arrays.asList( "a", "b", "a", "c", "e", "e" );
         final List<String> adaa = Arrays.asList( "a", "d", "a", "a" );
-        final List<String> addc = Arrays.asList( "a", "d", "c", "d", "c" );
+        final List<String> adcdc = Arrays.asList( "a", "d", "c", "d", "c" );
         final List<String> z = Collections.emptyList();
-        assertThat( Functions.multisetExceptAll( abacee, addc ), is( Arrays.asList( "b", "a", "e", "e" ) ) );
+        assertThat( Functions.multisetExceptAll( abacee, adcdc ), is( Arrays.asList( "b", "a", "e", "e" ) ) );
         assertThat( Functions.multisetExceptAll( abacee, z ), is( abacee ) );
         assertThat( Functions.multisetExceptAll( z, z ), is( z ) );
-        assertThat( Functions.multisetExceptAll( z, addc ), is( z ) );
+        assertThat( Functions.multisetExceptAll( z, adcdc ), is( z ) );
 
-        assertThat( Functions.multisetExceptDistinct( abacee, addc ), is( Arrays.asList( "b", "e" ) ) );
-        assertThat( Functions.multisetExceptDistinct( abacee, z ), is( Arrays.asList( "a", "b", "c", "e" ) ) );
-        assertThat( Functions.multisetExceptDistinct( z, z ), is( z ) );
-        assertThat( Functions.multisetExceptDistinct( z, addc ), is( z ) );
+        assertThat( Functions.multisetExceptDistinct( abacee, adcdc ), is( Set.of( "b", "e" ) ) );
+        assertThat( Functions.multisetExceptDistinct( abacee, z ), is( Set.of( "a", "b", "c", "e" ) ) );
+        assertThat( Functions.multisetExceptDistinct( z, z ), is( Set.of() ) );
+        assertThat( Functions.multisetExceptDistinct( z, adcdc ), is( Set.of() ) );
 
-        assertThat( Functions.multisetIntersectAll( abacee, addc ), is( Arrays.asList( "a", "c" ) ) );
+        assertThat( Functions.multisetIntersectAll( abacee, adcdc ), is( Arrays.asList( "a", "c" ) ) );
         assertThat( Functions.multisetIntersectAll( abacee, adaa ), is( Arrays.asList( "a", "a" ) ) );
         assertThat( Functions.multisetIntersectAll( adaa, abacee ), is( Arrays.asList( "a", "a" ) ) );
         assertThat( Functions.multisetIntersectAll( abacee, z ), is( z ) );
         assertThat( Functions.multisetIntersectAll( z, z ), is( z ) );
-        assertThat( Functions.multisetIntersectAll( z, addc ), is( z ) );
+        assertThat( Functions.multisetIntersectAll( z, adcdc ), is( z ) );
 
-        assertThat( Functions.multisetIntersectDistinct( abacee, addc ), is( Arrays.asList( "a", "c" ) ) );
-        assertThat( Functions.multisetIntersectDistinct( abacee, adaa ), is( Collections.singletonList( "a" ) ) );
-        assertThat( Functions.multisetIntersectDistinct( adaa, abacee ), is( Collections.singletonList( "a" ) ) );
-        assertThat( Functions.multisetIntersectDistinct( abacee, z ), is( z ) );
-        assertThat( Functions.multisetIntersectDistinct( z, z ), is( z ) );
-        assertThat( Functions.multisetIntersectDistinct( z, addc ), is( z ) );
+        assertThat( Functions.multisetIntersectDistinct( abacee, adcdc ), is( Set.of( "a", "c" ) ) );
+        assertThat( Functions.multisetIntersectDistinct( abacee, adaa ), is( Set.of( "a" ) ) );
+        assertThat( Functions.multisetIntersectDistinct( adaa, abacee ), is( Set.of( "a" ) ) );
+        assertThat( Functions.multisetIntersectDistinct( abacee, z ), is( Set.of() ) );
+        assertThat( Functions.multisetIntersectDistinct( z, z ), is( Set.of() ) );
+        assertThat( Functions.multisetIntersectDistinct( z, adcdc ), is( Set.of() ) );
 
-        assertThat( Functions.multisetUnionAll( abacee, addc ), is( Arrays.asList( "a", "b", "a", "c", "e", "e", "a", "d", "c", "d", "c" ) ) );
+        assertThat( Functions.multisetUnionAll( abacee, adcdc ), is( Arrays.asList( "a", "b", "a", "c", "e", "e", "a", "d", "c", "d", "c" ) ) );
         assertThat( Functions.multisetUnionAll( abacee, z ), is( abacee ) );
         assertThat( Functions.multisetUnionAll( z, z ), is( z ) );
-        assertThat( Functions.multisetUnionAll( z, addc ), is( addc ) );
+        assertThat( Functions.multisetUnionAll( z, adcdc ), is( adcdc ) );
 
-        assertThat( Functions.multisetUnionDistinct( abacee, addc ), is( Arrays.asList( "a", "b", "c", "d", "e" ) ) );
-        assertThat( Functions.multisetUnionDistinct( abacee, z ), is( Arrays.asList( "a", "b", "c", "e" ) ) );
-        assertThat( Functions.multisetUnionDistinct( z, z ), is( z ) );
-        assertThat( Functions.multisetUnionDistinct( z, addc ), is( Arrays.asList( "a", "c", "d" ) ) );
+        assertThat( Functions.multisetUnionDistinct( abacee, adcdc ), is( Set.of( "a", "b", "c", "d", "e" ) ) );
+        assertThat( Functions.multisetUnionDistinct( abacee, z ), is( Set.of( "a", "b", "c", "e" ) ) );
+        assertThat( Functions.multisetUnionDistinct( z, z ), is( Set.of() ) );
+        assertThat( Functions.multisetUnionDistinct( z, adcdc ), is( Set.of( "a", "c", "d" ) ) );
     }
 
 }


### PR DESCRIPTION
 - Return the result directly from set operations without constructing a new ArrayList
 - Use `Set.copyOf()` instead of `new HashSet()`
 - Remove the unused `BUILT_IN_OPERATORS_LIST` set