### PR TITLE
Improve code related to updating columns

### DIFF
--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -325,7 +325,7 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
             throw new RuntimeException( "Invalid scale! Scale can not be larger than length." );
         }
 
-        columns.put( columnId, columns.get( columnId ).toBuilder().type( type ).length( length ).scale( scale ).dimension( dimension ).cardinality( cardinality ).build() );
+        columns.put( columnId, columns.get( columnId ).toBuilder().type( type ).collectionsType( collectionsType ).length( length ).scale( scale ).dimension( dimension ).cardinality( cardinality ).build() );
         change( CatalogEvent.LOGICAL_REL_FIELD_TYPE_CHANGED, columnId, type );
     }
 

--- a/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
@@ -1152,6 +1152,11 @@ public class DdlManagerImpl extends DdlManager {
         // Check if model permits operation
         checkModelLogic( table, columnName );
 
+        // Check that column is not part of a primary key
+        if ( catalog.getLogicalRel( table.namespaceId ).getKeys().values().stream().filter( v -> v instanceof LogicalPrimaryKey ).flatMap( v -> v.fieldIds.stream() ).anyMatch( l -> l == logicalColumn.id ) ) {
+            throw new GenericRuntimeException( "Primary key cannot be nullable" );
+        }
+
         catalog.getLogicalRel( table.namespaceId ).setNullable( logicalColumn.id, nullable );
 
         // Reset plan cache implementation cache & routing cache

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -1292,9 +1292,10 @@ public class Crud implements InformationObserver, PropertyChangeListener {
                             .transactionManager( transactionManager )
                             .build(), UIRequest.builder().build() ).get( 0 );
             ctx.json( result );
+            if ( result.error != null ) {
+                break;
+            }
         }
-
-
     }
 
 

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -1244,7 +1244,7 @@ public class Crud implements InformationObserver, PropertyChangeListener {
             }
 
             // change default value
-            if ( oldColumn.defaultValue == null || newColumn.defaultValue == null || !oldColumn.defaultValue.equals( newColumn.defaultValue ) ) {
+            if ( !Objects.equals( oldColumn.defaultValue, newColumn.defaultValue ) ) {
                 String query;
                 if ( newColumn.defaultValue == null ) {
                     query = String.format( "ALTER TABLE %s MODIFY COLUMN \"%s\" DROP DEFAULT", tableId, newColumn.name );


### PR DESCRIPTION
## Summary

This PR fixes various issues related to updating columns.

## Changes
 - It is no longer possible to set the nullable flag for fields that are part of a primary key
 - Update `collectionType` when changing the column type
 - Do not update the default value when the old and new default value are both `NULL`
 - Return after the first update statement that fails.  Previously it reported the status of the last statement, which might be success even with previous statements failing.