### PR TITLE
Fix update count parsing error

### DIFF
--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismUtils.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/utils/PrismUtils.java
@@ -20,7 +20,10 @@ import java.util.List;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.prisminterface.statements.PIPreparedStatement;
 import org.polypheny.db.prisminterface.statements.PIStatement;
+import org.polypheny.db.type.entity.PolyString;
 import org.polypheny.db.type.entity.PolyValue;
+import org.polypheny.db.type.entity.document.PolyDocument;
+import org.polypheny.db.type.entity.graph.PolyDictionary;
 import org.polypheny.prism.ColumnMeta;
 import org.polypheny.prism.DocumentFrame;
 import org.polypheny.prism.Frame;
@@ -98,6 +101,14 @@ public class PrismUtils {
 
 
     public static Frame buildDocumentFrame( boolean isLast, List<PolyValue> data ) {
+        // ToDo: fix me: update counts are sometimes returned as normal results instead of scalar ones.
+        if (data.size() == 1 && data.get(0).isLong()) {
+            data = List.of(new PolyDocument(
+                    new PolyString( "updateCount" ),
+                    data.get(0)
+            ));
+        }
+
         List<ProtoDocument> documents = data.stream()
                 .map( PolyValue::asDocument )
                 .map( PolyValueSerializer::buildProtoDocument )


### PR DESCRIPTION
Currently, scalar update counts from document queries are sometimes returned using the same path as regular document results. This causes the PRISM serialization mechanism to crash due to a type mismatch (PolyLong instead of PolyDocument).

This fix detects such cases and wraps the scalar result in a PolyDocument. It serves as a temporary hotfix to allow progress in the Swiss Renov project; a long-term solution would require investigating why update counts aren't returned in their expected form by the query.