### PR TITLE
Fix missing binary data handling in result set type switch

### DIFF
--- a/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/JdbcUtils.java
+++ b/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/JdbcUtils.java
@@ -58,6 +58,7 @@ import org.polypheny.db.information.InformationTable;
 import org.polypheny.db.sql.language.util.SqlTypeRepresentation;
 import org.polypheny.db.type.entity.PolyBoolean;
 import org.polypheny.db.type.entity.PolyString;
+import org.polypheny.db.type.entity.PolyBinary;
 import org.polypheny.db.type.entity.PolyValue;
 import org.polypheny.db.type.entity.numerical.PolyBigDecimal;
 import org.polypheny.db.type.entity.numerical.PolyDouble;

--- a/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/JdbcUtils.java
+++ b/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/JdbcUtils.java
@@ -175,6 +175,8 @@ public final class JdbcUtils {
                             return PolyBigDecimal.ofNullable( (BigDecimal) o );
                         case Types.BIGINT:
                             return PolyBigDecimal.ofNullable( (Number) o );
+                        case Types.BINARY:
+                            return PolyBinary.ofNullable( (byte[]) o );
                     }
                 default:
                     throw new GenericRuntimeException( "not implemented " + reps[i] + " " + types[i] );


### PR DESCRIPTION
In Polypheny's implementation of querries, result set values are processed using a switch statement that distinguishes between data types. However, the case for binary data was missing, which could lead to a crash when such data is encountered. This commit adds the missing case to handle binary data properly, resolving the associated error.