### PR TITLE
Drop Unique Column Fix

### DIFF
--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -520,7 +520,7 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
         long id = idBuilder.getNewConstraintId();
         LogicalConstraint constraint = new LogicalConstraint( id, keyId, type, constraintName, Objects.requireNonNull( keys.get( keyId ) ) );
         synchronized ( this ) {
-            constraints.put( keyId, constraint );
+            constraints.put( id, constraint );
             change( CatalogEvent.CONSTRAINT_CREATED, null, id );
         }
         statement.getTransaction().addNewConstraint( tableId, constraint );

--- a/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/logical/RelationalCatalog.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
@@ -254,11 +255,15 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
 
 
     private long getOrAddKey( long tableId, List<Long> columnIds, EnforcementTime enforcementTime ) {
+        return getKey(tableId, columnIds, enforcementTime)
+                .orElse( addKey( tableId, columnIds, enforcementTime ) );
+    }
+    
+    private Optional<Long> getKey( long tableId, List<Long> columnIds, EnforcementTime enforcementTime ) {
         return Catalog.snapshot()
                 .rel()
                 .getKeys( columnIds.stream().mapToLong( Long::longValue ).toArray() )
-                .map( k -> k.id )
-                .orElse( addKey( tableId, columnIds, enforcementTime ) );
+                .map( k -> k.id );
     }
 
 
@@ -493,13 +498,15 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
 
     @Override
     public void addUniqueConstraint( long tableId, String constraintName, List<Long> columnIds, Statement statement ) {
-        long keyId = getOrAddKey( tableId, columnIds, EnforcementTime.ON_QUERY );
-        // Check if there is already a unique constraint
-        List<LogicalConstraint> logicalConstraints = constraints.values().stream()
-                .filter( c -> c.keyId == keyId && c.type == ConstraintType.UNIQUE )
+        Optional<Long> keyId = getKey( tableId, columnIds, EnforcementTime.ON_QUERY );
+        if (keyId.isPresent()) {
+            // Check if there is already a unique constraint
+            List<LogicalConstraint> logicalConstraints = constraints.values().stream()
+                .filter( c -> c.keyId == keyId.get() && c.type == ConstraintType.UNIQUE )
                 .toList();
-        if ( !logicalConstraints.isEmpty() ) {
-            throw new GenericRuntimeException( "There is already a unique constraint!" );
+            if ( !logicalConstraints.isEmpty() ) {
+                throw new GenericRuntimeException( "There is already a unique constraint!" );
+            }
         }
         long id = addConstraint( tableId, constraintName, columnIds, ConstraintType.UNIQUE, statement );
         statement.getTransaction().addNewConstraint( tableId, constraints.get( id ) );
@@ -513,7 +520,7 @@ public class RelationalCatalog implements PolySerializable, LogicalRelationalCat
         long id = idBuilder.getNewConstraintId();
         LogicalConstraint constraint = new LogicalConstraint( id, keyId, type, constraintName, Objects.requireNonNull( keys.get( keyId ) ) );
         synchronized ( this ) {
-            constraints.put( id, constraint );
+            constraints.put( keyId, constraint );
             change( CatalogEvent.CONSTRAINT_CREATED, null, id );
         }
         statement.getTransaction().addNewConstraint( tableId, constraint );

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
@@ -178,6 +178,8 @@ public interface LogicalRelSnapshot {
      */
     boolean isConstraint( long keyId );
 
+    Optional<LogicalConstraint> getConstraint( long keyId );
+
     /**
      * Returns all (imported) foreign keys of a specified table
      *

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
@@ -178,8 +178,6 @@ public interface LogicalRelSnapshot {
      */
     boolean isConstraint( long keyId );
 
-    Optional<LogicalConstraint> getConstraint( long keyId );
-
     /**
      * Returns all (imported) foreign keys of a specified table
      *

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
@@ -425,6 +425,11 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
         return constraints.containsKey( keyId );
     }
 
+    @Override
+    public Optional<LogicalConstraint> getConstraint( long keyId ) {
+        return Optional.ofNullable(constraints.get( keyId ));
+    }
+
 
     @Override
     public @NotNull List<LogicalForeignKey> getForeignKeys( long tableId ) {

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
@@ -422,12 +422,7 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
 
     @Override
     public boolean isConstraint( long keyId ) {
-        return constraints.containsKey( keyId );
-    }
-
-    @Override
-    public Optional<LogicalConstraint> getConstraint( long keyId ) {
-        return Optional.ofNullable(constraints.get( keyId ));
+        return constraints.entrySet().stream().anyMatch(  c -> c.getValue().getKeyId() == keyId );
     }
 
 

--- a/core/src/test/java/org/polypheny/db/snapshot/MockRelSnapshot.java
+++ b/core/src/test/java/org/polypheny/db/snapshot/MockRelSnapshot.java
@@ -168,6 +168,12 @@ public class MockRelSnapshot implements LogicalRelSnapshot {
 
 
     @Override
+    public Optional<LogicalConstraint> getConstraint( long keyId ) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
     public @NonNull List<LogicalForeignKey> getForeignKeys( long tableId ) {
         throw new UnsupportedOperationException();
     }

--- a/core/src/test/java/org/polypheny/db/snapshot/MockRelSnapshot.java
+++ b/core/src/test/java/org/polypheny/db/snapshot/MockRelSnapshot.java
@@ -166,13 +166,6 @@ public class MockRelSnapshot implements LogicalRelSnapshot {
         throw new UnsupportedOperationException();
     }
 
-
-    @Override
-    public Optional<LogicalConstraint> getConstraint( long keyId ) {
-        throw new UnsupportedOperationException();
-    }
-
-
     @Override
     public @NonNull List<LogicalForeignKey> getForeignKeys( long tableId ) {
         throw new UnsupportedOperationException();

--- a/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
@@ -50,6 +50,7 @@ import org.polypheny.db.algebra.AlgRoot;
 import org.polypheny.db.algebra.BiAlg;
 import org.polypheny.db.algebra.SingleAlg;
 import org.polypheny.db.algebra.constant.Kind;
+import org.polypheny.db.algebra.logical.common.LogicalContextSwitcher;
 import org.polypheny.db.algebra.logical.relational.LogicalRelScan;
 import org.polypheny.db.algebra.logical.relational.LogicalRelViewScan;
 import org.polypheny.db.algebra.type.AlgDataType;
@@ -912,6 +913,11 @@ public class DdlManagerImpl extends DdlManager {
                 } else if ( snapshot.isForeignKey( key.id ) ) {
                     throw new GenericRuntimeException( "Cannot drop column '" + column.name + "' because it is part of the foreign key with the name: '" + snapshot.getForeignKeys( key ).get( 0 ).name + "'." );
                 } else if ( snapshot.isConstraint( key.id ) ) {
+                    LogicalConstraint constraint = snapshot.getConstraint( key.id ).orElseThrow();
+                    if (constraint.type == ConstraintType.UNIQUE) {
+                        dropConstraint( statement.getTransaction(), table, constraint.name);
+                        continue;
+                    }
                     throw new GenericRuntimeException( "Cannot drop column '" + column.name + "' because it is part of the constraint with the name: '" + snapshot.getConstraints( key ).get( 0 ).name + "'." );
                 }
                 throw new GenericRuntimeException( "Ok, strange... Something is going wrong here!" );


### PR DESCRIPTION
This PR addresses three issues related to unique constraints:

1. **Duplicate key creation**: Previously, adding a unique constraint resulted in two keys being created. This PR ensures only one key is created per unique constraint.
2. **Constraint check on column drop**: When dropping individual columns (outside of `DROP TABLE`), existing constraints were not properly checked by type. This PR introduces a type check and removal procedure to ensure constraints are correctly identified and handled before column removal.
3. **Constraint Lookup in Snapshot**: Snapshots store constraints by id instead of keyId. Previously the check passed a keyId to the snapshot resulting isConstraint to return wrong results. This is now fixed by looking up the constraint id for the given keyId.