### PR TITLE
Default value deserialization fix

### DIFF
--- a/core/src/main/java/org/polypheny/db/catalog/entity/LogicalDefaultValue.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/LogicalDefaultValue.java
@@ -53,7 +53,7 @@ public class LogicalDefaultValue implements Serializable {
             @Deserialize("functionName") final String functionName ) {
         this.fieldId = fieldId;
         this.type = type;
-        this.value = PolyValue.deserialize( typedJson );
+        this.value = PolyValue.fromJson( typedJson );
         this.typedJson = typedJson;
         this.functionName = functionName;
     }


### PR DESCRIPTION
During rollback, default values need to be deserialized from a typed JSON format. PolyValue provides deserialization methods for both binary and typed JSON formats. Currently, the binary deserialization method is mistakenly called with typed JSON data, which causes an exception during rollback.

This PR fixes the issue by invoking the correct deserialization method for the typed JSON format.