### PR TITLE
Fix network interface binding of prism

### DIFF
--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIServer.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIServer.java
@@ -85,7 +85,7 @@ class PIServer {
 
     private static ServerSocketChannel createInetServer( int port ) throws IOException {
         return ServerSocketChannel.open( StandardProtocolFamily.INET )
-                .bind( new InetSocketAddress( Inet4Address.getLoopbackAddress(), port ) );
+                .bind( new InetSocketAddress( port ) );
     }
 
 


### PR DESCRIPTION
Updated the ServerSocketChannel binding to allow external TCP connections by changing the bind address from 127.0.0.1 (loopback) to 0.0.0.0 (all interfaces).

Changes:
    Replaced Inet4Address.getLoopbackAddress() with new InetSocketAddress(port)
    Enables external access to the server on port 20590 when running in Docker or other networked environments

Reason:
Previously, the server was only listening on the loopback interface, which prevented external clients from connecting even when the Docker port was correctly published.

Impact:
This change allows external tools and clients to connect to the application as expected.