### PR TITLE
Manage adapter and query interface templates in the corresponding manager classes

### DIFF
--- a/core/src/main/java/org/polypheny/db/catalog/Catalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/Catalog.java
@@ -28,9 +28,6 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.jetbrains.annotations.NotNull;
 import org.pf4j.ExtensionPoint;
-import org.polypheny.db.adapter.AbstractAdapterSetting;
-import org.polypheny.db.adapter.Adapter;
-import org.polypheny.db.adapter.AdapterManager.Function5;
 import org.polypheny.db.adapter.DeployMode;
 import org.polypheny.db.adapter.java.AdapterTemplate;
 import org.polypheny.db.catalog.catalogs.AdapterCatalog;
@@ -47,7 +44,6 @@ import org.polypheny.db.catalog.entity.LogicalUser;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.catalog.snapshot.Snapshot;
-import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 import org.polypheny.db.transaction.Transaction;
 import org.polypheny.db.util.RunMode;
 
@@ -233,17 +229,6 @@ public abstract class Catalog implements ExtensionPoint {
      */
     public abstract void dropQueryInterface( long id );
 
-    public abstract long createAdapterTemplate( Class<? extends Adapter<?>> clazz, String adapterName, String description, List<DeployMode> modes, List<AbstractAdapterSetting> settings, Function5<Long, String, Map<String, String>, DeployMode, Adapter<?>> deployer );
-
-
-    public abstract void createInterfaceTemplate( String name, QueryInterfaceTemplate queryInterfaceTemplate );
-
-    public abstract void dropInterfaceTemplate( String name );
-
-    @NotNull
-    public abstract Map<String, QueryInterfaceTemplate> getInterfaceTemplates();
-
-
     public abstract void close();
 
     public abstract void clear();
@@ -262,12 +247,6 @@ public abstract class Catalog implements ExtensionPoint {
     public abstract Map<Long, LogicalAdapter> getAdapters();
 
     public abstract Map<Long, LogicalQueryInterface> getInterfaces();
-
-    public abstract Map<Long, AdapterTemplate> getAdapterTemplates();
-
-
-    public abstract void dropAdapterTemplate( long templateId );
-
 
     public abstract PropertyChangeListener getChangeListener();
 

--- a/core/src/main/java/org/polypheny/db/catalog/IdBuilder.java
+++ b/core/src/main/java/org/polypheny/db/catalog/IdBuilder.java
@@ -63,10 +63,6 @@ public class IdBuilder {
 
     @Serialize
     @JsonProperty
-    public AtomicLong adapterTemplateId;
-
-    @Serialize
-    @JsonProperty
     public AtomicLong interfaceId;
 
     @Serialize
@@ -111,7 +107,6 @@ public class IdBuilder {
                 new AtomicLong( 0 ),
                 new AtomicLong( 0 ),
                 new AtomicLong( 0 ),
-                new AtomicLong( 0 ),
                 new AtomicLong( 0 ) );
     }
 
@@ -126,7 +121,6 @@ public class IdBuilder {
             @Deserialize("indexId") AtomicLong indexId,
             @Deserialize("keyId") AtomicLong keyId,
             @Deserialize("adapterId") AtomicLong adapterId,
-            @Deserialize("adapterTemplateId") AtomicLong adapterTemplateId,
             @Deserialize("interfaceId") AtomicLong interfaceId,
             @Deserialize("constraintId") AtomicLong constraintId,
             @Deserialize("groupId") AtomicLong groupId,
@@ -144,7 +138,6 @@ public class IdBuilder {
         this.constraintId = constraintId;
 
         this.adapterId = adapterId;
-        this.adapterTemplateId = adapterTemplateId;
         this.interfaceId = interfaceId;
         this.groupId = groupId;
         this.partitionId = partitionId;
@@ -222,11 +215,6 @@ public class IdBuilder {
     }
 
 
-    public long getNewAdapterTemplateId() {
-        return adapterTemplateId.getAndIncrement();
-    }
-
-
     public synchronized void restore( IdBuilder idBuilder ) {
         this.snapshotId.set( idBuilder.snapshotId.longValue() );
         this.entityId.set( idBuilder.entityId.longValue() );
@@ -240,7 +228,6 @@ public class IdBuilder {
         this.constraintId.set( idBuilder.constraintId.longValue() );
 
         this.adapterId.set( idBuilder.adapterId.longValue() );
-        this.adapterTemplateId.set( idBuilder.adapterTemplateId.longValue() );
         this.interfaceId.set( idBuilder.interfaceId.longValue() );
         this.groupId.set( idBuilder.groupId.longValue() );
         this.partitionId.set( idBuilder.partitionId.longValue() );

--- a/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
+++ b/core/src/main/java/org/polypheny/db/catalog/impl/PolyCatalog.java
@@ -35,12 +35,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.polypheny.db.adapter.AbstractAdapterSetting;
 import org.polypheny.db.adapter.Adapter;
 import org.polypheny.db.adapter.AdapterManager;
-import org.polypheny.db.adapter.AdapterManager.Function5;
 import org.polypheny.db.adapter.DeployMode;
-import org.polypheny.db.adapter.java.AdapterTemplate;
 import org.polypheny.db.algebra.AlgRoot;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.IdBuilder;
@@ -75,7 +72,6 @@ import org.polypheny.db.catalog.persistance.Persister;
 import org.polypheny.db.catalog.snapshot.Snapshot;
 import org.polypheny.db.catalog.snapshot.impl.SnapshotBuilder;
 import org.polypheny.db.config.RuntimeConfig;
-import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 import org.polypheny.db.nodes.Node;
 import org.polypheny.db.processing.Processor;
 import org.polypheny.db.processing.QueryContext.ParsedQueryContext;
@@ -130,12 +126,6 @@ public class PolyCatalog extends Catalog implements PolySerializable {
     public final Map<Long, LogicalQueryInterface> interfaces;
 
     @Getter
-    public final Map<Long, AdapterTemplate> adapterTemplates;
-
-    @Getter
-    public final Map<String, QueryInterfaceTemplate> interfaceTemplates;
-
-    @Getter
     public final Map<Long, AdapterCatalog> adapterCatalogs;
 
     @Serialize
@@ -188,9 +178,7 @@ public class PolyCatalog extends Catalog implements PolySerializable {
         this.adapterRestore = new ConcurrentHashMap<>( adapterRestore );
 
         // temporary data
-        this.adapterTemplates = new ConcurrentHashMap<>();
         this.adapterCatalogs = new ConcurrentHashMap<>();
-        this.interfaceTemplates = new ConcurrentHashMap<>();
 
         this.persister = memoryCatalog ? new InMemoryPersister() : new FilePersister();
 
@@ -443,36 +431,6 @@ public class PolyCatalog extends Catalog implements PolySerializable {
     @Override
     public void dropQueryInterface( long id ) {
         interfaces.remove( id );
-        change();
-    }
-
-
-    @Override
-    public long createAdapterTemplate( Class<? extends Adapter<?>> clazz, String adapterName, String description, List<DeployMode> modes, List<AbstractAdapterSetting> settings, Function5<Long, String, Map<String, String>, DeployMode, Adapter<?>> deployer ) {
-        long id = idBuilder.getNewAdapterTemplateId();
-        adapterTemplates.put( id, new AdapterTemplate( id, clazz, adapterName, settings, modes, description, deployer ) );
-        change();
-        return id;
-    }
-
-
-    @Override
-    public void createInterfaceTemplate( String name, QueryInterfaceTemplate queryInterfaceTemplate ) {
-        interfaceTemplates.put( name, queryInterfaceTemplate );
-        change();
-    }
-
-
-    @Override
-    public void dropInterfaceTemplate( String name ) {
-        interfaceTemplates.remove( name );
-        change();
-    }
-
-
-    @Override
-    public void dropAdapterTemplate( long templateId ) {
-        adapterTemplates.remove( templateId );
         change();
     }
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/Snapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/Snapshot.java
@@ -21,19 +21,16 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
-import org.polypheny.db.adapter.java.AdapterTemplate;
 import org.polypheny.db.algebra.constant.FunctionCategory;
 import org.polypheny.db.algebra.constant.Syntax;
 import org.polypheny.db.algebra.operators.OperatorTable;
 import org.polypheny.db.catalog.entity.LogicalAdapter;
-import org.polypheny.db.catalog.entity.LogicalAdapter.AdapterType;
 import org.polypheny.db.catalog.entity.LogicalQueryInterface;
 import org.polypheny.db.catalog.entity.LogicalUser;
 import org.polypheny.db.catalog.entity.logical.LogicalEntity;
 import org.polypheny.db.catalog.entity.logical.LogicalNamespace;
 import org.polypheny.db.catalog.entity.logical.LogicalTable;
 import org.polypheny.db.catalog.logistic.Pattern;
-import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 import org.polypheny.db.nodes.Identifier;
 import org.polypheny.db.nodes.Operator;
 
@@ -129,10 +126,6 @@ public interface Snapshot extends OperatorTable {
     @NotNull
     Optional<LogicalQueryInterface> getQueryInterface( String uniqueName );
 
-    @NotNull
-    Optional<QueryInterfaceTemplate> getInterfaceTemplate( String name );
-
-
     List<LogicalTable> getTablesForPeriodicProcessing();
 
     //// OTHERS
@@ -147,22 +140,8 @@ public interface Snapshot extends OperatorTable {
         return List.of();
     }
 
-
-    Optional<AdapterTemplate> getAdapterTemplate( long templateId );
-
-    @NotNull
-    List<AdapterTemplate> getAdapterTemplates();
-
     @NotNull
     Optional<? extends LogicalEntity> getLogicalEntity( long id );
-
-    @NotNull
-    Optional<AdapterTemplate> getAdapterTemplate( String name, AdapterType adapterType );
-
-    List<AdapterTemplate> getAdapterTemplates( AdapterType adapterType );
-
-    List<QueryInterfaceTemplate> getInterfaceTemplates();
-
 
     LogicalRelSnapshot rel();
 

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/SnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/SnapshotImpl.java
@@ -26,10 +26,8 @@ import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.Accessors;
 import org.jetbrains.annotations.NotNull;
-import org.polypheny.db.adapter.java.AdapterTemplate;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.LogicalAdapter;
-import org.polypheny.db.catalog.entity.LogicalAdapter.AdapterType;
 import org.polypheny.db.catalog.entity.LogicalQueryInterface;
 import org.polypheny.db.catalog.entity.LogicalUser;
 import org.polypheny.db.catalog.entity.logical.LogicalCollection;
@@ -43,7 +41,6 @@ import org.polypheny.db.catalog.snapshot.LogicalDocSnapshot;
 import org.polypheny.db.catalog.snapshot.LogicalGraphSnapshot;
 import org.polypheny.db.catalog.snapshot.LogicalRelSnapshot;
 import org.polypheny.db.catalog.snapshot.Snapshot;
-import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 
 @Value
 @Accessors(fluent = true)
@@ -66,11 +63,9 @@ public class SnapshotImpl implements Snapshot {
     ImmutableMap<String, LogicalUser> userNames;
 
     ImmutableMap<Long, LogicalQueryInterface> interfaces;
-    ImmutableMap<String, QueryInterfaceTemplate> interfaceTemplates;
     ImmutableMap<String, LogicalQueryInterface> interfaceNames;
 
     ImmutableMap<Long, LogicalAdapter> adapters;
-    ImmutableMap<Long, AdapterTemplate> adapterTemplates;
     ImmutableMap<String, LogicalAdapter> adapterNames;
 
     ImmutableMap<Long, LogicalNamespace> namespaces;
@@ -93,10 +88,8 @@ public class SnapshotImpl implements Snapshot {
         this.userNames = ImmutableMap.copyOf( users.values().stream().collect( Collectors.toMap( u -> u.name.toLowerCase(), u -> u ) ) );
         this.interfaces = ImmutableMap.copyOf( catalog.getInterfaces() );
         this.interfaceNames = ImmutableMap.copyOf( interfaces.values().stream().collect( Collectors.toMap( i -> i.name.toLowerCase(), i -> i ) ) );
-        this.interfaceTemplates = ImmutableMap.copyOf( catalog.getInterfaceTemplates() );
         this.adapters = ImmutableMap.copyOf( catalog.getAdapters() );
         this.adapterNames = ImmutableMap.copyOf( adapters.values().stream().collect( Collectors.toMap( a -> a.uniqueName.toLowerCase(), a -> a ) ) );
-        this.adapterTemplates = ImmutableMap.copyOf( catalog.getAdapterTemplates().values().stream().collect( Collectors.toMap( t -> t.id, t -> t ) ) );
     }
 
 
@@ -175,26 +168,8 @@ public class SnapshotImpl implements Snapshot {
 
 
     @Override
-    public @NotNull Optional<QueryInterfaceTemplate> getInterfaceTemplate( String name ) {
-        return Optional.ofNullable( interfaceTemplates.get( name ) );
-    }
-
-
-    @Override
     public List<LogicalTable> getTablesForPeriodicProcessing() {
         return null;
-    }
-
-
-    @Override
-    public Optional<AdapterTemplate> getAdapterTemplate( long templateId ) {
-        return Optional.ofNullable( adapterTemplates.get( templateId ) );
-    }
-
-
-    @Override
-    public @NotNull List<AdapterTemplate> getAdapterTemplates() {
-        return List.copyOf( adapterTemplates.values() );
     }
 
 
@@ -209,24 +184,6 @@ public class SnapshotImpl implements Snapshot {
         }
 
         return graph.getGraph( id );
-    }
-
-
-    @Override
-    public @NotNull Optional<AdapterTemplate> getAdapterTemplate( String name, AdapterType adapterType ) {
-        return adapterTemplates.values().stream().filter( t -> t.adapterName.equalsIgnoreCase( name ) && t.adapterType == adapterType ).findAny();
-    }
-
-
-    @Override
-    public List<AdapterTemplate> getAdapterTemplates( AdapterType adapterType ) {
-        return adapterTemplates.values().stream().filter( t -> t.adapterType == adapterType ).collect( Collectors.toList() );
-    }
-
-
-    @Override
-    public List<QueryInterfaceTemplate> getInterfaceTemplates() {
-        return List.copyOf( interfaceTemplates.values() );
     }
 
 

--- a/core/src/test/java/org/polypheny/db/snapshot/MockSnapshot.java
+++ b/core/src/test/java/org/polypheny/db/snapshot/MockSnapshot.java
@@ -24,12 +24,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.polypheny.db.adapter.java.AdapterTemplate;
 import org.polypheny.db.algebra.type.AlgDataType;
 import org.polypheny.db.algebra.type.AlgDataTypeFactory;
 import org.polypheny.db.algebra.type.AlgDataTypeImpl;
 import org.polypheny.db.catalog.entity.LogicalAdapter;
-import org.polypheny.db.catalog.entity.LogicalAdapter.AdapterType;
 import org.polypheny.db.catalog.entity.LogicalQueryInterface;
 import org.polypheny.db.catalog.entity.LogicalUser;
 import org.polypheny.db.catalog.entity.logical.LogicalEntity;
@@ -42,7 +40,6 @@ import org.polypheny.db.catalog.snapshot.LogicalDocSnapshot;
 import org.polypheny.db.catalog.snapshot.LogicalGraphSnapshot;
 import org.polypheny.db.catalog.snapshot.LogicalRelSnapshot;
 import org.polypheny.db.catalog.snapshot.Snapshot;
-import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 import org.polypheny.db.type.PolyType;
 
 public class MockSnapshot implements Snapshot {
@@ -120,49 +117,13 @@ public class MockSnapshot implements Snapshot {
 
 
     @Override
-    public @NotNull Optional<QueryInterfaceTemplate> getInterfaceTemplate( String name ) {
-        throw new UnsupportedOperationException();
-    }
-
-
-    @Override
     public List<LogicalTable> getTablesForPeriodicProcessing() {
         throw new UnsupportedOperationException();
     }
 
 
     @Override
-    public Optional<AdapterTemplate> getAdapterTemplate( long templateId ) {
-        throw new UnsupportedOperationException();
-    }
-
-
-    @Override
-    public @NotNull List<AdapterTemplate> getAdapterTemplates() {
-        throw new UnsupportedOperationException();
-    }
-
-
-    @Override
     public @NotNull Optional<? extends LogicalEntity> getLogicalEntity( long id ) {
-        throw new UnsupportedOperationException();
-    }
-
-
-    @Override
-    public @NotNull Optional<AdapterTemplate> getAdapterTemplate( String name, AdapterType adapterType ) {
-        throw new UnsupportedOperationException();
-    }
-
-
-    @Override
-    public List<AdapterTemplate> getAdapterTemplates( AdapterType adapterType ) {
-        throw new UnsupportedOperationException();
-    }
-
-
-    @Override
-    public List<QueryInterfaceTemplate> getInterfaceTemplates() {
         throw new UnsupportedOperationException();
     }
 

--- a/dbms/src/main/java/org/polypheny/db/ddl/DefaultInserter.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DefaultInserter.java
@@ -18,10 +18,12 @@ package org.polypheny.db.ddl;
 
 import java.util.Map;
 import org.apache.calcite.linq4j.function.Deterministic;
+import org.polypheny.db.adapter.AdapterManager;
 import org.polypheny.db.adapter.java.AdapterTemplate;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.entity.LogicalAdapter.AdapterType;
 import org.polypheny.db.catalog.logistic.DataModel;
+import org.polypheny.db.iface.QueryInterfaceManager;
 import org.polypheny.db.transaction.Transaction;
 import org.polypheny.db.util.PolyphenyHomeDirManager;
 import org.polypheny.db.util.RunMode;
@@ -65,7 +67,7 @@ public class DefaultInserter {
         catalog.updateSnapshot();
 
         // Deploy default store (HSQLDB)
-        AdapterTemplate storeTemplate = Catalog.snapshot().getAdapterTemplate( Catalog.defaultStore.getAdapterName(), AdapterType.STORE ).orElseThrow();
+        AdapterTemplate storeTemplate = AdapterManager.getAdapterTemplate( Catalog.defaultStore.getAdapterName(), AdapterType.STORE );
         ddlManager.createStore( "hsqldb", Catalog.defaultStore.getAdapterName(), AdapterType.STORE, storeTemplate.getDefaultSettings(), storeTemplate.getDefaultMode() );
 
         if ( mode == RunMode.TEST ) {
@@ -73,7 +75,7 @@ public class DefaultInserter {
         }
 
         // Deploy default source (CSV with HR data)
-        AdapterTemplate sourceTemplate = Catalog.snapshot().getAdapterTemplate( Catalog.defaultSource.getAdapterName(), AdapterType.SOURCE ).orElseThrow();
+        AdapterTemplate sourceTemplate = AdapterManager.getAdapterTemplate( Catalog.defaultSource.getAdapterName(), AdapterType.SOURCE );
         ddlManager.createSource( transaction, "hr", Catalog.defaultSource.getAdapterName(), Catalog.defaultNamespaceId, AdapterType.SOURCE, sourceTemplate.getDefaultSettings(), sourceTemplate.getDefaultMode() );
     }
 
@@ -100,9 +102,9 @@ public class DefaultInserter {
         if ( !catalog.getInterfaces().isEmpty() ) {
             return;
         }
-        catalog.getInterfaceTemplates().values().forEach( i -> Catalog.getInstance().createQueryInterface( i.interfaceType().toLowerCase(), i.interfaceType(), i.getDefaultSettings() ) );
+        QueryInterfaceManager.getInstance().getInterfaceTemplates().values().forEach( i -> Catalog.getInstance().createQueryInterface( i.interfaceType().toLowerCase(), i.interfaceType(), i.getDefaultSettings() ) );
         // TODO: This is ugly, both because it is racy, and depends on a string (which might be changed)
-        if ( catalog.getInterfaceTemplates().values().stream().anyMatch( t -> t.interfaceType().equals( "Prism Interface (Unix transport)" ) ) ) {
+        if ( QueryInterfaceManager.getInstance().getInterfaceTemplates().values().stream().anyMatch( t -> t.interfaceType().equals( "Prism Interface (Unix transport)" ) ) ) {
             catalog.createQueryInterface(
                     "prism interface (unix transport @ .polypheny)",
                     "Prism Interface (Unix transport)",
@@ -110,7 +112,6 @@ public class DefaultInserter {
             );
         }
         catalog.commit();
-
     }
 
 }

--- a/dbms/src/test/java/org/polypheny/db/TestHelper.java
+++ b/dbms/src/test/java/org/polypheny/db/TestHelper.java
@@ -254,7 +254,6 @@ public class TestHelper {
                     new AtomicLong( catalog.idBuilder.getIndexId().longValue() + offset.get() ),
                     new AtomicLong( catalog.idBuilder.getKeyId().longValue() + offset.get() ),
                     new AtomicLong( catalog.idBuilder.getAdapterId().longValue() + offset.get() ),
-                    new AtomicLong( catalog.idBuilder.getAdapterTemplateId().longValue() + offset.get() ),
                     new AtomicLong( catalog.idBuilder.getInterfaceId().longValue() + offset.get() ),
                     new AtomicLong( catalog.idBuilder.getConstraintId().longValue() + offset.get() ),
                     new AtomicLong( catalog.idBuilder.getGroupId().longValue() + offset.get() ),

--- a/plugins/mql-language/src/test/java/org/polypheny/db/mql/mql2alg/MqlMockCatalog.java
+++ b/plugins/mql-language/src/test/java/org/polypheny/db/mql/mql2alg/MqlMockCatalog.java
@@ -17,18 +17,9 @@
 package org.polypheny.db.mql.mql2alg;
 
 import java.beans.PropertyChangeListener;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import org.jetbrains.annotations.NotNull;
-import org.polypheny.db.adapter.AbstractAdapterSetting;
-import org.polypheny.db.adapter.Adapter;
-import org.polypheny.db.adapter.AdapterManager.Function5;
-import org.polypheny.db.adapter.DeployMode;
-import org.polypheny.db.adapter.java.AdapterTemplate;
 import org.polypheny.db.catalog.MockCatalog;
 import org.polypheny.db.catalog.catalogs.AdapterCatalog;
-import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 import org.polypheny.db.transaction.Transaction;
 
 
@@ -53,42 +44,6 @@ public class MqlMockCatalog extends MockCatalog {
 
     @Override
     public void addStoreSnapshot( AdapterCatalog snapshot ) {
-
-    }
-
-
-    @Override
-    public long createAdapterTemplate( Class<? extends Adapter<?>> clazz, String adapterName, String description, List<DeployMode> modes, List<AbstractAdapterSetting> settings, Function5<Long, String, Map<String, String>, DeployMode, Adapter<?>> deployer ) {
-        return 0;
-    }
-
-
-    @Override
-    public void createInterfaceTemplate( String name, QueryInterfaceTemplate queryInterfaceTemplate ) {
-
-    }
-
-
-    @Override
-    public void dropInterfaceTemplate( String name ) {
-
-    }
-
-
-    @Override
-    public @NotNull Map<String, QueryInterfaceTemplate> getInterfaceTemplates() {
-        return null;
-    }
-
-
-    @Override
-    public Map<Long, AdapterTemplate> getAdapterTemplates() {
-        return null;
-    }
-
-
-    @Override
-    public void dropAdapterTemplate( long templateId ) {
 
     }
 

--- a/plugins/workflow-engine/src/main/java/org/polypheny/db/workflow/engine/storage/StorageManagerImpl.java
+++ b/plugins/workflow-engine/src/main/java/org/polypheny/db/workflow/engine/storage/StorageManagerImpl.java
@@ -508,7 +508,7 @@ public class StorageManagerImpl implements StorageManager {
         }
         if ( STARTED_ADAPTER.compareAndSet( false, true ) ) {
             log.info( "Adding default workflow checkpoint adapter: " + DEFAULT_CHECKPOINT_ADAPTER );
-            AdapterTemplate storeTemplate = Catalog.snapshot().getAdapterTemplate( "HSQLDB", AdapterType.STORE ).orElseThrow();
+            AdapterTemplate storeTemplate = AdapterManager.getAdapterTemplate( "HSQLDB", AdapterType.STORE );
             Map<String, String> settings = new HashMap<>( storeTemplate.getDefaultSettings() );
             settings.put( "trxControlMode", "locks" );
             settings.put( "type", "File" );

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -132,7 +132,6 @@ import org.polypheny.db.docker.models.UpdateDockerRequest;
 import org.polypheny.db.iface.QueryInterface;
 import org.polypheny.db.iface.QueryInterfaceManager;
 import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceCreateRequest;
-import org.polypheny.db.iface.QueryInterfaceManager.QueryInterfaceTemplate;
 import org.polypheny.db.information.InformationGroup;
 import org.polypheny.db.information.InformationManager;
 import org.polypheny.db.information.InformationObserver;
@@ -2213,8 +2212,7 @@ public class Crud implements InformationObserver, PropertyChangeListener {
 
     void getAvailableQueryInterfaces( final Context ctx ) {
         QueryInterfaceManager qim = QueryInterfaceManager.getInstance();
-        List<QueryInterfaceTemplate> interfaces = qim.getAvailableQueryInterfaceTemplates();
-        ctx.json( interfaces );
+        ctx.json( qim.getAvailableQueryInterfaceTemplates() );
     }
 
 

--- a/webui/src/main/java/org/polypheny/db/webui/models/catalog/SnapshotModel.java
+++ b/webui/src/main/java/org/polypheny/db/webui/models/catalog/SnapshotModel.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.polypheny.db.adapter.AdapterManager;
 import org.polypheny.db.catalog.logistic.Pattern;
 import org.polypheny.db.catalog.snapshot.Snapshot;
 import org.polypheny.db.webui.models.AdapterTemplateModel;
@@ -118,7 +119,7 @@ public record SnapshotModel(
 
         List<AdapterModel> adapters = snapshot.getAdapters().stream().map( AdapterModel::from ).filter( Objects::nonNull ).toList();
 
-        List<AdapterTemplateModel> adapterTemplates = snapshot.getAdapterTemplates().stream().map( AdapterTemplateModel::from ).toList();
+        List<AdapterTemplateModel> adapterTemplates = AdapterManager.getInstance().getAdapterTemplates().values().stream().map( AdapterTemplateModel::from ).toList();
 
         return new SnapshotModel( snapshot.id(), namespaces, entities, fields, keys, constraints, allocations, placements, partitions, allocationColumns, adapters, adapterTemplates );
     }


### PR DESCRIPTION
Move the bookkeeping of adapter and query interface templates out of the catalog into the `AdapterManager` and `QueryInterfaceManager` respectively.  This way adapter/query interface template addition/removal (corresponding to loading/unloading plugins) does not interfere with other catalog modifications.