### PR TITLE
Various source improvements

### DIFF
--- a/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
+++ b/core/src/main/java/org/polypheny/db/catalog/entity/logical/LogicalTable.java
@@ -40,7 +40,7 @@ import org.polypheny.db.catalog.logistic.DataModel;
 import org.polypheny.db.catalog.logistic.EntityType;
 import org.polypheny.db.schema.ColumnStrategy;
 
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 @SuperBuilder(toBuilder = true)
 @Value
 @NonFinal

--- a/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
@@ -276,6 +276,7 @@ public class DdlManagerImpl extends DdlManager {
             List<AllocationColumn> aColumns = new ArrayList<>();
             int colPos = 1;
 
+            List<Long> pkIds = new ArrayList<>();
             for ( ExportedColumn exportedColumn : entry.getValue() ) {
                 LogicalColumn column = catalog.getLogicalRel( namespace ).addColumn(
                         exportedColumn.name(),
@@ -300,6 +301,13 @@ public class DdlManagerImpl extends DdlManager {
 
                 columns.add( column );
                 aColumns.add( allocationColumn );
+                if ( exportedColumn.primary() ) {
+                    pkIds.add( column.id );
+                }
+            }
+
+            if ( !pkIds.isEmpty() ) {
+                catalog.getLogicalRel( namespace ).addPrimaryKey( logical.id, pkIds, transaction.createStatement() );
             }
 
             buildRelationalNamespace( namespace, logical, adapter );

--- a/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/sources/AbstractJdbcSource.java
+++ b/plugins/jdbc-adapter-framework/src/main/java/org/polypheny/db/adapter/jdbc/sources/AbstractJdbcSource.java
@@ -43,6 +43,7 @@ import org.polypheny.db.adapter.jdbc.connection.ConnectionHandler;
 import org.polypheny.db.adapter.jdbc.connection.ConnectionHandlerException;
 import org.polypheny.db.adapter.jdbc.connection.TransactionalConnectionFactory;
 import org.polypheny.db.catalog.catalogs.RelAdapterCatalog;
+import org.polypheny.db.catalog.entity.allocation.AllocationTable;
 import org.polypheny.db.catalog.entity.allocation.AllocationTableWrapper;
 import org.polypheny.db.catalog.entity.logical.LogicalTableWrapper;
 import org.polypheny.db.catalog.entity.physical.PhysicalEntity;
@@ -343,6 +344,14 @@ public abstract class AbstractJdbcSource extends DataSource<RelAdapterCatalog> i
         adapterCatalog.replacePhysical( physical );
 
         return List.of( physical );
+    }
+
+
+    @Override
+    public void restoreTable( AllocationTable alloc, List<PhysicalEntity> entities, Context context ) {
+        PhysicalEntity table = entities.get( 0 );
+        updateNamespace( table.namespaceName, table.namespaceId );
+        adapterCatalog.addPhysical( alloc, currentJdbcSchema.createJdbcTable( table.unwrapOrThrow( PhysicalTable.class ) ) );
     }
 
 

--- a/plugins/monetdb-adapter/src/main/java/org/polypheny/db/adapter/monetdb/sources/MonetdbSource.java
+++ b/plugins/monetdb-adapter/src/main/java/org/polypheny/db/adapter/monetdb/sources/MonetdbSource.java
@@ -20,7 +20,6 @@ package org.polypheny.db.adapter.monetdb.sources;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.polypheny.db.adapter.DeployMode;
@@ -28,16 +27,10 @@ import org.polypheny.db.adapter.RelationalDataSource;
 import org.polypheny.db.adapter.annotations.AdapterProperties;
 import org.polypheny.db.adapter.annotations.AdapterSettingInteger;
 import org.polypheny.db.adapter.annotations.AdapterSettingString;
-import org.polypheny.db.adapter.jdbc.JdbcTable;
 import org.polypheny.db.adapter.jdbc.connection.ConnectionFactory;
 import org.polypheny.db.adapter.jdbc.connection.TransactionalConnectionFactory;
 import org.polypheny.db.adapter.jdbc.sources.AbstractJdbcSource;
 import org.polypheny.db.adapter.monetdb.MonetdbSqlDialect;
-import org.polypheny.db.catalog.entity.allocation.AllocationTableWrapper;
-import org.polypheny.db.catalog.entity.logical.LogicalTableWrapper;
-import org.polypheny.db.catalog.entity.physical.PhysicalEntity;
-import org.polypheny.db.catalog.entity.physical.PhysicalTable;
-import org.polypheny.db.prepare.Context;
 import org.polypheny.db.sql.language.SqlDialect;
 
 
@@ -107,25 +100,6 @@ public class MonetdbSource extends AbstractJdbcSource {
     @Override
     protected boolean requiresSchema() {
         return true;
-    }
-
-
-    @Override
-    public List<PhysicalEntity> createTable( Context context, LogicalTableWrapper logical, AllocationTableWrapper allocation ) {
-        PhysicalTable table = adapterCatalog.createTable(
-                logical.table.getNamespaceName(),
-                logical.table.name,
-                logical.columns.stream().collect( Collectors.toMap( c -> c.id, c -> c.name ) ),
-                logical.table,
-                logical.columns.stream().collect( Collectors.toMap( t -> t.id, t -> t ) ),
-                logical.pkIds,
-                allocation );
-
-        JdbcTable physical = currentJdbcSchema.createJdbcTable( table );
-
-        adapterCatalog.replacePhysical( physical );
-
-        return List.of( physical );
     }
 
 

--- a/plugins/mysql-adapter/src/main/java/org/polypheny/db/adapter/jdbc/MysqlSourcePlugin.java
+++ b/plugins/mysql-adapter/src/main/java/org/polypheny/db/adapter/jdbc/MysqlSourcePlugin.java
@@ -20,7 +20,6 @@ package org.polypheny.db.adapter.jdbc;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.polypheny.db.adapter.AdapterManager;
 import org.polypheny.db.adapter.DeployMode;
@@ -30,13 +29,8 @@ import org.polypheny.db.adapter.annotations.AdapterSettingInteger;
 import org.polypheny.db.adapter.annotations.AdapterSettingList;
 import org.polypheny.db.adapter.annotations.AdapterSettingString;
 import org.polypheny.db.adapter.jdbc.sources.AbstractJdbcSource;
-import org.polypheny.db.catalog.entity.allocation.AllocationTableWrapper;
-import org.polypheny.db.catalog.entity.logical.LogicalTableWrapper;
-import org.polypheny.db.catalog.entity.physical.PhysicalEntity;
-import org.polypheny.db.catalog.entity.physical.PhysicalTable;
 import org.polypheny.db.plugins.PluginContext;
 import org.polypheny.db.plugins.PolyPlugin;
-import org.polypheny.db.prepare.Context;
 import org.polypheny.db.sql.language.dialect.MysqlSqlDialect;
 
 @SuppressWarnings("unused")
@@ -94,24 +88,6 @@ public class MysqlSourcePlugin extends PolyPlugin {
 
         public MysqlSource( final long storeId, final String uniqueName, final Map<String, String> settings, final DeployMode mode ) {
             super( storeId, uniqueName, settings, mode, "org.mariadb.jdbc.Driver", MysqlSqlDialect.DEFAULT, false );
-        }
-
-
-        @Override
-        public List<PhysicalEntity> createTable( Context context, LogicalTableWrapper logical, AllocationTableWrapper allocation ) {
-            PhysicalTable table = adapterCatalog.createTable(
-                    logical.table.getNamespaceName(),
-                    logical.table.name,
-                    logical.columns.stream().collect( Collectors.toMap( c -> c.id, c -> c.name ) ),
-                    logical.table,
-                    logical.columns.stream().collect( Collectors.toMap( t -> t.id, t -> t ) ),
-                    logical.pkIds, allocation );
-
-            JdbcTable physical = currentJdbcSchema.createJdbcTable( table );
-
-            adapterCatalog.replacePhysical( physical );
-
-            return List.of( physical );
         }
 
 

--- a/plugins/postgres-adapter/src/main/java/org/polypheny/db/adapter/postgres/source/PostgresqlSource.java
+++ b/plugins/postgres-adapter/src/main/java/org/polypheny/db/adapter/postgres/source/PostgresqlSource.java
@@ -32,6 +32,7 @@ import org.polypheny.db.adapter.jdbc.sources.AbstractJdbcSource;
 import org.polypheny.db.adapter.postgres.PostgresqlSqlDialect;
 import org.polypheny.db.catalog.entity.allocation.AllocationTableWrapper;
 import org.polypheny.db.catalog.entity.logical.LogicalTableWrapper;
+import org.polypheny.db.catalog.entity.allocation.AllocationTable;
 import org.polypheny.db.catalog.entity.physical.PhysicalEntity;
 import org.polypheny.db.catalog.entity.physical.PhysicalTable;
 import org.polypheny.db.prepare.Context;
@@ -120,6 +121,14 @@ public class PostgresqlSource extends AbstractJdbcSource {
     @Override
     public RelationalDataSource asRelationalDataSource() {
         return this;
+    }
+
+
+    @Override
+    public void restoreTable( AllocationTable alloc, List<PhysicalEntity> entities, Context context ) {
+        PhysicalEntity table = entities.get( 0 );
+        updateNamespace( table.namespaceName, table.namespaceId );
+        adapterCatalog.addPhysical( alloc, currentJdbcSchema.createJdbcTable( table.unwrapOrThrow( PhysicalTable.class ) ) );
     }
 
 }

--- a/plugins/postgres-adapter/src/main/java/org/polypheny/db/adapter/postgres/source/PostgresqlSource.java
+++ b/plugins/postgres-adapter/src/main/java/org/polypheny/db/adapter/postgres/source/PostgresqlSource.java
@@ -20,7 +20,6 @@ package org.polypheny.db.adapter.postgres.source;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.polypheny.db.adapter.DeployMode;
 import org.polypheny.db.adapter.RelationalDataSource;
@@ -30,8 +29,6 @@ import org.polypheny.db.adapter.annotations.AdapterSettingList;
 import org.polypheny.db.adapter.annotations.AdapterSettingString;
 import org.polypheny.db.adapter.jdbc.sources.AbstractJdbcSource;
 import org.polypheny.db.adapter.postgres.PostgresqlSqlDialect;
-import org.polypheny.db.catalog.entity.allocation.AllocationTableWrapper;
-import org.polypheny.db.catalog.entity.logical.LogicalTableWrapper;
 import org.polypheny.db.catalog.entity.allocation.AllocationTable;
 import org.polypheny.db.catalog.entity.physical.PhysicalEntity;
 import org.polypheny.db.catalog.entity.physical.PhysicalTable;
@@ -100,21 +97,6 @@ public class PostgresqlSource extends AbstractJdbcSource {
     @Override
     protected boolean requiresSchema() {
         return true;
-    }
-
-
-    @Override
-    public List<PhysicalEntity> createTable( Context context, LogicalTableWrapper logical, AllocationTableWrapper allocation ) {
-        PhysicalTable table = adapterCatalog.createTable(
-                logical.table.getNamespaceName(),
-                logical.table.name,
-                logical.columns.stream().collect( Collectors.toMap( c -> c.id, c -> c.name ) ),
-                logical.table,
-                logical.columns.stream().collect( Collectors.toMap( t -> t.id, t -> t ) ),
-                logical.pkIds, allocation );
-
-        adapterCatalog.replacePhysical( currentJdbcSchema.createJdbcTable( table ) );
-        return List.of( table );
     }
 
 

--- a/plugins/postgres-adapter/src/main/java/org/polypheny/db/adapter/postgres/source/PostgresqlSource.java
+++ b/plugins/postgres-adapter/src/main/java/org/polypheny/db/adapter/postgres/source/PostgresqlSource.java
@@ -29,10 +29,6 @@ import org.polypheny.db.adapter.annotations.AdapterSettingList;
 import org.polypheny.db.adapter.annotations.AdapterSettingString;
 import org.polypheny.db.adapter.jdbc.sources.AbstractJdbcSource;
 import org.polypheny.db.adapter.postgres.PostgresqlSqlDialect;
-import org.polypheny.db.catalog.entity.allocation.AllocationTable;
-import org.polypheny.db.catalog.entity.physical.PhysicalEntity;
-import org.polypheny.db.catalog.entity.physical.PhysicalTable;
-import org.polypheny.db.prepare.Context;
 
 
 @Slf4j
@@ -103,14 +99,6 @@ public class PostgresqlSource extends AbstractJdbcSource {
     @Override
     public RelationalDataSource asRelationalDataSource() {
         return this;
-    }
-
-
-    @Override
-    public void restoreTable( AllocationTable alloc, List<PhysicalEntity> entities, Context context ) {
-        PhysicalEntity table = entities.get( 0 );
-        updateNamespace( table.namespaceName, table.namespaceId );
-        adapterCatalog.addPhysical( alloc, currentJdbcSchema.createJdbcTable( table.unwrapOrThrow( PhysicalTable.class ) ) );
     }
 
 }

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -292,7 +292,14 @@ public class Crud implements InformationObserver, PropertyChangeListener {
                         .batch( request.noLimit ? -1 : getPageSize() )
                         .transactionManager( transactionManager )
                         .build(), transaction ).get( 0 );
-        resultBuilder = (RelationalResultBuilder<?, ?>) builder.apply( implementationContext.execute( implementationContext.getStatement() ), request, implementationContext.getStatement() );
+        ExecutedContext ec = implementationContext.execute( implementationContext.getStatement() );
+
+        if ( ec.getException().isPresent() ) {
+            // TODO: Create a dedicated error result class
+            return RelationalResult.builder().exception( ec.getException().get() ).error( ec.getException().get().toString() ).build();
+        }
+
+        resultBuilder = (RelationalResultBuilder<?, ?>) builder.apply( ec, request, implementationContext.getStatement() );
 
         // determine if it is a view or a table
         LogicalTable table = Catalog.snapshot().rel().getTable( request.entityId ).orElseThrow();


### PR DESCRIPTION
This improves various aspects related to sources:
 - Restore JDBC source tables on startup
 - Improve comparison of logical tables: tables without primary key will no longer be considered equal
 - When a source table contains a primary key, add this information to the logical table
 - Reduce code duplication between JDBC sources
 - Add missing error handling to `Crud#getTable`