### PR TITLE
Cleanup handshake object when automatically connecting to Docker

### DIFF
--- a/core/src/main/java/org/polypheny/db/docker/AutoDocker.java
+++ b/core/src/main/java/org/polypheny/db/docker/AutoDocker.java
@@ -200,6 +200,7 @@ public final class AutoDocker {
                 if ( handshakeStatus.equals( "FAILED" ) ) {
                     status = HandshakeManager.getInstance().getHandshake( handshake.id() ).orElseThrow().lastErrorMessage();
                 }
+                HandshakeManager.getInstance().cancelAndRemoveHandshake( handshake.id() );
                 handshake = null;
                 break;
             }


### PR DESCRIPTION
This adds a missing cleanup call.  Without this, sometimes the handshake object for the local Docker instance would appear as a "draft" in the UI next to the (successfully) connected local Docker instance.