### PR TITLE
Use id instead of name to drop constraints

### DIFF
--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/LogicalRelSnapshot.java
@@ -226,6 +226,17 @@ public interface LogicalRelSnapshot {
     Optional<LogicalConstraint> getConstraint( long tableId, String constraintName );
 
     /**
+     * Returns the constraint with the specified name in the specified table.
+     *
+     * @param tableId The id of the table
+     * @param id The id of the constraint
+     * @return The constraint
+     */
+    @NonNull
+    Optional<LogicalConstraint> getConstraint( long tableId, long id );
+
+
+    /**
      * Return the foreign key with the specified name from the specified table
      *
      * @param tableId The id of the table

--- a/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
+++ b/core/src/main/java/org/polypheny/db/catalog/snapshot/impl/LogicalRelSnapshotImpl.java
@@ -456,6 +456,10 @@ public class LogicalRelSnapshotImpl implements LogicalRelSnapshot {
         return tableConstraints.get( tableId ).stream().filter( c -> c.name.equals( constraintName ) ).findFirst();
     }
 
+    @Override
+    public @NonNull Optional<LogicalConstraint> getConstraint( long tableId, long constraintId ) {
+        return tableConstraints.get( tableId ).stream().filter( c -> c.id == constraintId ).findFirst();
+    }
 
     @Override
     public @NonNull Optional<LogicalForeignKey> getForeignKey( long tableId, String foreignKeyName ) {

--- a/core/src/main/java/org/polypheny/db/ddl/DdlManager.java
+++ b/core/src/main/java/org/polypheny/db/ddl/DdlManager.java
@@ -258,6 +258,15 @@ public abstract class DdlManager {
     public abstract void dropConstraint( Transaction transaction, LogicalTable table, String constraintName );
 
     /**
+     * Drop a specific constraint from a table
+     *
+     * @param transaction current transaction
+     * @param table the table
+     * @param constraintId the id of the constraint to be dropped
+     */
+    public abstract void dropConstraint( Transaction transaction, LogicalTable table, long constraintId );
+
+    /**
      * Drop a foreign key of a table
      *
      * @param table the table the foreign key belongs to

--- a/core/src/test/java/org/polypheny/db/snapshot/MockRelSnapshot.java
+++ b/core/src/test/java/org/polypheny/db/snapshot/MockRelSnapshot.java
@@ -166,6 +166,7 @@ public class MockRelSnapshot implements LogicalRelSnapshot {
         throw new UnsupportedOperationException();
     }
 
+
     @Override
     public @NonNull List<LogicalForeignKey> getForeignKeys( long tableId ) {
         throw new UnsupportedOperationException();
@@ -192,6 +193,12 @@ public class MockRelSnapshot implements LogicalRelSnapshot {
 
     @Override
     public @NonNull Optional<LogicalConstraint> getConstraint( long tableId, String constraintName ) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
+    public @NonNull Optional<LogicalConstraint> getConstraint( long tableId, long id ) {
         throw new UnsupportedOperationException();
     }
 

--- a/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
+++ b/dbms/src/main/java/org/polypheny/db/ddl/DdlManagerImpl.java
@@ -841,7 +841,7 @@ public class DdlManagerImpl extends DdlManager {
         }
 
         if ( oldPk != null ) {
-            dropConstraint( statement.getTransaction(), table, ConstraintType.PRIMARY.name() );
+            dropConstraint( statement.getTransaction(), table, oldPk.id );
         }
 
         catalog.getLogicalRel( table.namespaceId ).addPrimaryKey( table.id, columnIds, statement );
@@ -929,7 +929,7 @@ public class DdlManagerImpl extends DdlManager {
                             .toList();
                     if ( !constraints.isEmpty() && constraints.stream().allMatch( k -> k.type == ConstraintType.UNIQUE ) ) {
                         for ( LogicalConstraint c : constraints ) {
-                            dropConstraint( statement.getTransaction(), table, c.name );
+                            dropConstraint( statement.getTransaction(), table, c.id );
                         }
                         continue;
                     }
@@ -997,17 +997,24 @@ public class DdlManagerImpl extends DdlManager {
 
     @Override
     public void dropConstraint( Transaction transaction, LogicalTable table, String constraintName ) {
+        LogicalConstraint constraint = catalog.getSnapshot().rel().getConstraint( table.id, constraintName ).orElseThrow();
+        dropConstraint( transaction, table, constraint.id );
+    }
+
+
+    @Override
+    public void dropConstraint( Transaction transaction, LogicalTable table, long id ) {
         // Make sure that this is a table of type TABLE (and not SOURCE)
         checkIfDdlPossible( table.entityType );
 
-        LogicalConstraint constraint = catalog.getSnapshot().rel().getConstraint( table.id, constraintName ).orElseThrow();
+        LogicalConstraint constraint = catalog.getSnapshot().rel().getConstraint( table.id, id ).orElseThrow();
 
         Supplier<Boolean> stillUsed = () -> getKeyUniqueCount( constraint.keyId ) < 2;
         if ( constraint.type == ConstraintType.UNIQUE && isForeignKey( constraint.key.id ) && stillUsed.get() ) {
             // maybe we delete multiple constraints in this transaction, so we need to check again
             transaction.attachCommitConstraint(
                     stillUsed,
-                    "The constraint " + constraintName + " is used on a key which is referenced by at least one foreign key which requires this key to be unique. Unable to drop unique constraint." );
+                    "The constraint " + constraint.name + " is used on a key which is referenced by at least one foreign key which requires this key to be unique. Unable to drop unique constraint." );
         }
 
         catalog.getLogicalRel( table.namespaceId ).deleteConstraint( constraint.id );
@@ -2991,7 +2998,7 @@ public class DdlManagerImpl extends DdlManager {
 
         // delete constraints
         for ( LogicalConstraint constraint : snapshot.rel().getConstraints( table.id ) ) {
-            dropConstraint( statement.getTransaction(), table, constraint.name );
+            dropConstraint( statement.getTransaction(), table, constraint.id );
         }
 
         // delete keys

--- a/dbms/src/test/java/org/polypheny/db/constraints/ForeignKeyConstraintTest.java
+++ b/dbms/src/test/java/org/polypheny/db/constraints/ForeignKeyConstraintTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.polypheny.db.TestHelper;
@@ -547,6 +548,25 @@ public class ForeignKeyConstraintTest {
                 } finally {
                     statement.executeUpdate( "DROP TABLE constraint_test2" );
                     statement.executeUpdate( "DROP TABLE constraint_test" );
+                }
+            }
+        }
+    }
+
+
+    @Test
+    public void dropConstraintTest() throws SQLException {
+        try ( JdbcConnection polyphenyDbConnection = new JdbcConnection( false ) ) {
+            Connection connection = polyphenyDbConnection.getConnection();
+            try ( Statement statement = connection.createStatement() ) {
+                // Create schema
+                try {
+                    statement.executeUpdate( "CREATE TABLE t(i INTEGER PRIMARY KEY)" );
+                    statement.executeUpdate( "CREATE TABLE t2(i INTEGER PRIMARY KEY, i2 INTEGER, i3 INTEGER, FOREIGN KEY (i2) REFERENCES t(i), FOREIGN KEY (i3) REFERENCES t(i))" );
+                    statement.executeUpdate( "DROP TABLE t2" );
+                } finally {
+                    statement.executeUpdate( "DROP TABLE IF EXISTS t2" );
+                    statement.executeUpdate( "DROP TABLE IF EXISTS t" );
                 }
             }
         }


### PR DESCRIPTION
The default constraint names for primary and foreign keys are not unique.  This leads to a problem, e.g. when dropping tables.  So use the constraint id instead of the constraint name when possible.