### PR TITLE
Fix duplicate route registration in the HTTP interface when adding query languages

### DIFF
--- a/core/src/main/java/org/polypheny/db/iface/QueryInterface.java
+++ b/core/src/main/java/org/polypheny/db/iface/QueryInterface.java
@@ -31,6 +31,7 @@ import org.pf4j.ExtensionPoint;
 import org.polypheny.db.catalog.Catalog;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.languages.LanguageManager;
+import org.polypheny.db.languages.QueryLanguage;
 import org.polypheny.db.transaction.TransactionManager;
 
 
@@ -237,11 +238,11 @@ public abstract class QueryInterface implements Runnable, PropertyChangeListener
     @Override
     public void propertyChange( PropertyChangeEvent evt ) {
         if ( evt.getPropertyName().equals( "language" ) ) {
-            languageChange();
+            languageChange( (QueryLanguage) evt.getNewValue() );
         }
     }
 
 
-    public abstract void languageChange();
+    public abstract void languageChange( QueryLanguage language );
 
 }

--- a/plugins/http-interface/src/main/java/org/polypheny/db/http/HttpInterfacePlugin.java
+++ b/plugins/http-interface/src/main/java/org/polypheny/db/http/HttpInterfacePlugin.java
@@ -209,10 +209,8 @@ public class HttpInterfacePlugin extends PolyPlugin {
 
 
         @Override
-        public void languageChange() {
-            for ( QueryLanguage language : LanguageManager.getLanguages() ) {
-                addRoute( language );
-            }
+        public void languageChange( QueryLanguage language ) {
+            addRoute( language );
         }
 
 

--- a/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIPlugin.java
+++ b/plugins/prism-interface/src/main/java/org/polypheny/db/prisminterface/PIPlugin.java
@@ -29,6 +29,7 @@ import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
 import org.polypheny.db.iface.Authenticator;
 import org.polypheny.db.iface.QueryInterface;
 import org.polypheny.db.iface.QueryInterfaceManager;
+import org.polypheny.db.languages.QueryLanguage;
 import org.polypheny.db.plugins.PluginContext;
 import org.polypheny.db.plugins.PolyPlugin;
 import org.polypheny.db.prisminterface.PIPlugin.PrismInterface.Transport;
@@ -134,7 +135,7 @@ public class PIPlugin extends PolyPlugin {
 
 
         @Override
-        public void languageChange() {
+        public void languageChange( QueryLanguage language ) {
 
         }
 

--- a/plugins/rest-interface/src/main/java/org/polypheny/db/restapi/RestInterfacePlugin.java
+++ b/plugins/rest-interface/src/main/java/org/polypheny/db/restapi/RestInterfacePlugin.java
@@ -59,6 +59,7 @@ import org.polypheny.db.information.InformationGroup;
 import org.polypheny.db.information.InformationManager;
 import org.polypheny.db.information.InformationPage;
 import org.polypheny.db.information.InformationTable;
+import org.polypheny.db.languages.QueryLanguage;
 import org.polypheny.db.plugins.PluginContext;
 import org.polypheny.db.plugins.PolyPlugin;
 import org.polypheny.db.restapi.exception.ParserException;
@@ -362,7 +363,7 @@ public class RestInterfacePlugin extends PolyPlugin {
 
 
         @Override
-        public void languageChange() {
+        public void languageChange( QueryLanguage language ) {
 
         }
 


### PR DESCRIPTION
At each language change event, the HTTP interface adds routes for each query language present in the system.  So when a query language (e.g. SQL) is present and a new one is added (e.g. Cypher), the language change event would trigger adding routes for SQL and Cypher.  This leads to an error, because each route can be created only once (and in this case the SQL route already exists).  Since the language change event contains the new query language, just use that to only add the route for the new query language.