### PR TITLE
Remove loading/unloading of plugins after startup

### DIFF
--- a/config/src/main/java/org/polypheny/db/config/Config.java
+++ b/config/src/main/java/org/polypheny/db/config/Config.java
@@ -525,7 +525,7 @@ public abstract class Config {
     }
 
 
-    public void setList( List<ConfigScalar> values ) {
+    public void setList( List<? extends ConfigScalar> values ) {
         throw new ConfigRuntimeException( "Not possible to set a list on a configuration element of type " + this.getClass().getSimpleName() + "!" );
     }
 

--- a/config/src/main/java/org/polypheny/db/config/ConfigList.java
+++ b/config/src/main/java/org/polypheny/db/config/ConfigList.java
@@ -283,13 +283,13 @@ public class ConfigList extends Config {
 
 
     @Override
-    public void setList( List<ConfigScalar> values ) {
+    public void setList( List<? extends ConfigScalar> values ) {
         if ( requiresRestart() ) {
             if ( this.oldList == null ) {
                 this.oldList = this.list;
             }
         }
-        this.list = values;
+        this.list = values.stream().map( v -> (ConfigScalar) v ).toList();
         values.forEach( val -> val.addObserver( listener ) );
         if ( this.oldList != null && this.oldList.equals( this.list ) ) {
             this.oldList = null;

--- a/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
+++ b/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
@@ -486,14 +486,6 @@ public enum RuntimeConfig {
             ConfigType.BOOLEAN,
             "monitoringGroup" ),
 
-    AVAILABLE_PLUGINS(
-            "runtime/availablePlugins",
-            "All plugins, which are available, be it active, only loaded or unloaded.",
-            List.of(),
-            ConfigType.PLUGIN_LIST,
-            "pluginsGroup"
-    ),
-
     WORKFLOWS_WORKERS(
             "workflows/globalWorkers",
             "The maximum number of worker threads over all workflows. Changes apply as soon as all currently executing workflows have finished.",
@@ -510,16 +502,6 @@ public enum RuntimeConfig {
             "workflowsSettingsGroup"
     ),
 
-    BLOCKED_PLUGINS(
-            "runtime/blockedPlugins",
-            "All plugins, which are blocked by default.",
-            List.of( "druid-adapter",
-                    "elasticsearch-adapter",
-                    "geode-adapter",
-                    "html-adapter",
-                    "pig-adapter" ),
-            ConfigType.STRING_LIST
-    ),
 
     INSTANCE_UUID(
             "runtime/uuid",

--- a/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
+++ b/core/src/main/java/org/polypheny/db/config/RuntimeConfig.java
@@ -486,6 +486,14 @@ public enum RuntimeConfig {
             ConfigType.BOOLEAN,
             "monitoringGroup" ),
 
+    AVAILABLE_PLUGINS(
+            "runtime/availablePlugins",
+            "All plugins which are loaded.",
+            List.of(),
+            ConfigType.PLUGIN_LIST,
+            "pluginsGroup"
+    ),
+
     WORKFLOWS_WORKERS(
             "workflows/globalWorkers",
             "The maximum number of worker threads over all workflows. Changes apply as soon as all currently executing workflows have finished.",
@@ -800,7 +808,7 @@ public enum RuntimeConfig {
     }
 
 
-    public void setList( final List<ConfigScalar> values ) {
+    public void setList( final List<? extends ConfigScalar> values ) {
         configManager.getConfig( key ).setList( values );
     }
 

--- a/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
+++ b/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
@@ -48,6 +48,8 @@ import org.pf4j.PluginFactory;
 import org.pf4j.PluginLoader;
 import org.pf4j.PluginWrapper;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
+import org.polypheny.db.config.ConfigPlugin;
+import org.polypheny.db.config.RuntimeConfig;
 import org.polypheny.db.iface.Authenticator;
 import org.polypheny.db.monitoring.repository.PersistentMonitoringRepository;
 import org.polypheny.db.processing.TransactionExtension;
@@ -137,8 +139,14 @@ public class PolyPluginManager extends DefaultPluginManager {
 
     public static void init() {
         pluginManager.loadPlugins();
-
         pluginManager.startPlugins();
+
+        RuntimeConfig.AVAILABLE_PLUGINS.setList(
+                pluginManager.getStartedPlugins().stream().map( p -> (PolyPluginDescriptor) p.getDescriptor() )
+                        .map( p -> new ConfigPlugin( p.getPluginId(), org.polypheny.db.config.PluginStatus.ACTIVE,
+                                p.imagePath, p.categories, p.getPluginDescription(), p.getVersion(), p.isSystemComponent, p.isUiVisible ) )
+                        .toList()
+        );
 
         PLUGINS.putAll( pluginManager.getStartedPlugins().stream().collect( Collectors.toMap( PluginWrapper::getPluginId, p -> p ) ) );
 

--- a/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
+++ b/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
@@ -45,14 +45,8 @@ import org.pf4j.PluginClassLoader;
 import org.pf4j.PluginDescriptor;
 import org.pf4j.PluginFactory;
 import org.pf4j.PluginLoader;
-import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
 import org.polypheny.db.catalog.exceptions.GenericRuntimeException;
-import org.polypheny.db.config.Config;
-import org.polypheny.db.config.Config.ConfigListener;
-import org.polypheny.db.config.ConfigPlugin;
-import org.polypheny.db.config.ConfigString;
-import org.polypheny.db.config.RuntimeConfig;
 import org.polypheny.db.iface.Authenticator;
 import org.polypheny.db.monitoring.repository.PersistentMonitoringRepository;
 import org.polypheny.db.processing.TransactionExtension;
@@ -140,36 +134,13 @@ public class PolyPluginManager extends DefaultPluginManager {
     }
 
 
-    public static void init( boolean resetPluginsOnStartup ) {
-        if ( resetPluginsOnStartup ) {
-            RuntimeConfig.AVAILABLE_PLUGINS.getList( ConfigPlugin.class ).clear();
-            RuntimeConfig.BLOCKED_PLUGINS.getList( ConfigString.class ).clear();
-        }
-
-        attachRuntimeToPlugins();
-
+    public static void init() {
         pluginManager.loadPlugins();
 
         // start (active/resolved) the plugins
-        if ( RuntimeConfig.AVAILABLE_PLUGINS.getList( ConfigPlugin.class ).isEmpty() ) {
-            // no old config there so we just start, except the blocked ones
-            for ( PluginWrapper resolvedPlugin : pluginManager.resolvedPlugins ) {
-                if ( !RuntimeConfig.BLOCKED_PLUGINS.getStringList().contains( resolvedPlugin.getPluginId() ) ) {
-                    pluginManager.startPlugin( resolvedPlugin.getPluginId() );
-                }
-            }
-            pluginManager.startPlugins();
-        } else {
-            for ( ConfigPlugin plugin : RuntimeConfig.AVAILABLE_PLUGINS.getList( ConfigPlugin.class ) ) {
-                if ( plugin.getStatus() == org.polypheny.db.config.PluginStatus.ACTIVE ) {
-                    pluginManager.startPlugin( plugin.getPluginId() );
-                }
-            }
-        }
+        pluginManager.startPlugins();
 
         PLUGINS.putAll( pluginManager.getStartedPlugins().stream().collect( Collectors.toMap( PluginWrapper::getPluginId, p -> p ) ) );
-
-        attachPluginsToRuntime();
 
         // print extensions for each started plugin
         List<PluginWrapper> startedPlugins = pluginManager.getStartedPlugins();
@@ -177,118 +148,6 @@ public class PolyPluginManager extends DefaultPluginManager {
             String pluginId = plugin.getDescriptor().getPluginId();
             log.info( "Plugin '{}' added", pluginId );
         }
-    }
-
-
-    private static void attachRuntimeToPlugins() {
-        PLUGINS.addListener( e -> RuntimeConfig.AVAILABLE_PLUGINS.setList(
-                PLUGINS
-                        .values()
-                        .stream()
-                        .map( p -> (PolyPluginDescriptor) p.getDescriptor() )
-                        .map( d -> new ConfigPlugin(
-                                d.getPluginId(),
-                                org.polypheny.db.config.PluginStatus.ACTIVE,
-                                d.imagePath, d.categories,
-                                d.getPluginDescription(),
-                                d.getVersion(),
-                                d.isSystemComponent,
-                                d.isUiVisible ) )
-                        .collect( Collectors.toList() ) ) );
-    }
-
-
-    private static void attachPluginsToRuntime() {
-        RuntimeConfig.AVAILABLE_PLUGINS.addObserver( new ConfigListener() {
-            @Override
-            public void onConfigChange( Config c ) {
-                // check if still the same plugins are present
-                List<ConfigPlugin> configs = RuntimeConfig.AVAILABLE_PLUGINS.getList( ConfigPlugin.class );
-
-                List<String> removed = configs.stream().map( ConfigPlugin::getPluginId ).collect( Collectors.toList() );
-                PLUGINS.keySet().forEach( removed::remove );
-
-                configs.forEach( p -> {
-                    if ( toState( p.getStatus() ) != PLUGINS.get( p.getPluginId() ).getPluginState() ) {
-                        if ( p.getStatus() == org.polypheny.db.config.PluginStatus.ACTIVE ) {
-                            // start
-                            startAvailablePlugin( p.getPluginId() );
-                        } else {
-                            // stop
-                            stopAvailablePlugin( p.getPluginId() );
-                        }
-                    }
-                } );
-
-            }
-
-
-            @Override
-            public void restart( Config c ) {
-
-            }
-        } );
-    }
-
-
-    /**
-     * Stop a plugin, which was loaded and started previously.
-     *
-     * @param pluginId identifier of the plugin
-     */
-    private static void stopAvailablePlugin( String pluginId ) {
-        if ( !PLUGINS.containsKey( pluginId ) ) {
-            throw new GenericRuntimeException( "Plugin is not not loaded and can not be stopped." );
-        }
-        PluginWrapper plugin = PLUGINS.get( pluginId );
-
-        if ( plugin.getPluginState() != PluginState.STARTED ) {
-            throw new GenericRuntimeException( "Plugin is not active and can not be stopped." );
-        }
-        PolyPluginDescriptor descriptor = (PolyPluginDescriptor) plugin.getDescriptor();
-        if ( descriptor.isSystemComponent ) {
-            throw new GenericRuntimeException( "Plugin is system component and cannot be stopped." );
-        }
-
-        pluginManager.stopPlugin( pluginId );
-        PLUGINS.get( pluginId ).setPluginState( org.pf4j.PluginState.STOPPED );
-    }
-
-
-    /**
-     * Starts a plugin, which was loaded previously.
-     *
-     * @param pluginId identifier of the plugin
-     */
-    private static void startAvailablePlugin( String pluginId ) {
-        if ( !PLUGINS.containsKey( pluginId ) ) {
-            throw new GenericRuntimeException( "Plugin is not not loaded and can not be started." );
-        }
-
-        PolyPluginDescriptor descriptor = (PolyPluginDescriptor) PLUGINS.get( pluginId ).getDescriptor();
-
-        if ( descriptor.hasVersionDependencies ) {
-            log.debug( "Cannot load plugin {} because version dependencies are not yet supported", pluginId );
-            return;
-        }
-
-        pluginManager.startPlugin( pluginId );
-        PLUGINS.get( pluginId ).setPluginState( org.pf4j.PluginState.STARTED );
-    }
-
-
-    /**
-     * Mapping of the internal PluginStatus to the PF4J PluginStatus
-     *
-     * @param status the status in the Polypheny format
-     * @return the status in the PF4j format
-     */
-    private static org.pf4j.PluginState toState( org.polypheny.db.config.PluginStatus status ) {
-        return switch ( status ) {
-            case UNLOADED -> PluginState.CREATED;
-            case LOADED -> PluginState.DISABLED;
-            case ACTIVE -> PluginState.STARTED;
-        };
     }
 
 

--- a/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
+++ b/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
@@ -16,24 +16,16 @@
 
 package org.polypheny.db.plugins;
 
-import com.google.gson.TypeAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -95,24 +87,20 @@ public class PolyPluginManager extends DefaultPluginManager {
         if ( jarFile.isFile() ) {  // Run with JAR file
             // Copy plugins bundled into the jar file to the designated plugins' folder.
             // Overwrites existing plugins with same name (name includes version number).
-            try {
-                final JarFile jar = new JarFile( jarFile );
-                final Enumeration<JarEntry> entries = jar.entries();
-                while ( entries.hasMoreElements() ) {
-                    final String name = entries.nextElement().getName();
+            try ( JarFile jar = new JarFile( jarFile ) ) {
+                for ( String name : jar.stream().map( JarEntry::getName ).toList() ) {
                     if ( name.startsWith( "plugins/" ) && name.endsWith( ".zip" ) ) {
                         FileUtils.copyURLToFile(
                                 PolyPluginManager.class.getResource( "/" + name ),
                                 new File( pluginsFolder, name.split( "/" )[1] ) );
                     }
                 }
-                jar.close();
             } catch ( Exception e ) {
                 // ignore
             }
         }
         pluginManager = new PolyPluginManager(
-                Path.of( PolyphenyHomeDirManager.getInstance().registerNewFolder( "plugins" ).getPath() ),
+                pluginsFolder.toPath(),
                 Path.of( "../build/plugins" ),
                 Path.of( "./build/plugins" ),
                 Path.of( "../../build/plugins" ) );
@@ -155,7 +143,6 @@ public class PolyPluginManager extends DefaultPluginManager {
 
     public static void init( boolean resetPluginsOnStartup ) {
         if ( resetPluginsOnStartup ) {
-            //deletePluginFolder(); we cannot delete the folder, we can only reset the plugins, because we need the folder for the plugins
             RuntimeConfig.AVAILABLE_PLUGINS.getList( ConfigPlugin.class ).clear();
             RuntimeConfig.BLOCKED_PLUGINS.getList( ConfigString.class ).clear();
         }
@@ -189,38 +176,26 @@ public class PolyPluginManager extends DefaultPluginManager {
         List<PluginWrapper> startedPlugins = pluginManager.getStartedPlugins();
         for ( PluginWrapper plugin : startedPlugins ) {
             String pluginId = plugin.getDescriptor().getPluginId();
-            log.info( String.format( "Plugin '%s' added", pluginId ) );
-        }
-    }
-
-
-    private static void deletePluginFolder() {
-        try {
-            FileUtils.deleteDirectory( PolyphenyHomeDirManager.getInstance().registerNewFolder( "plugins" ) );
-        } catch ( IOException e ) {
-            throw new GenericRuntimeException( e );
+            log.info( "Plugin '{}' added", pluginId );
         }
     }
 
 
     private static void attachRuntimeToPlugins() {
-        PLUGINS.addListener( ( e ) -> {
-            RuntimeConfig.AVAILABLE_PLUGINS.getList( ConfigPlugin.class ).clear();
-            RuntimeConfig.AVAILABLE_PLUGINS.setList(
-                    PLUGINS
-                            .values()
-                            .stream()
-                            .map( p -> (PolyPluginDescriptor) p.getDescriptor() )
-                            .map( d -> new ConfigPlugin(
-                                    d.getPluginId(),
-                                    org.polypheny.db.config.PluginStatus.ACTIVE,
-                                    d.imagePath, d.categories,
-                                    d.getPluginDescription(),
-                                    d.getVersion(),
-                                    d.isSystemComponent,
-                                    d.isUiVisible ) )
-                            .collect( Collectors.toList() ) );
-        } );
+        PLUGINS.addListener( e -> RuntimeConfig.AVAILABLE_PLUGINS.setList(
+                PLUGINS
+                        .values()
+                        .stream()
+                        .map( p -> (PolyPluginDescriptor) p.getDescriptor() )
+                        .map( d -> new ConfigPlugin(
+                                d.getPluginId(),
+                                org.polypheny.db.config.PluginStatus.ACTIVE,
+                                d.imagePath, d.categories,
+                                d.getPluginDescription(),
+                                d.getVersion(),
+                                d.isSystemComponent,
+                                d.isUiVisible ) )
+                        .collect( Collectors.toList() ) ) );
     }
 
 
@@ -292,26 +267,14 @@ public class PolyPluginManager extends DefaultPluginManager {
         }
 
         PolyPluginDescriptor descriptor = (PolyPluginDescriptor) PLUGINS.get( pluginId ).getDescriptor();
-        boolean isCompatible = isCompatible( descriptor.versionDependencies );
 
-        if ( !isCompatible ) {
-            log.debug( "Cannot load plugin {} with version {}.", pluginId, ((PolyPluginDescriptor) PLUGINS.get( pluginId ).getDescriptor()).versionDependencies );
+        if ( descriptor.hasVersionDependencies ) {
+            log.debug( "Cannot load plugin {} because version dependencies are not yet supported", pluginId );
             return;
         }
 
         pluginManager.startPlugin( pluginId );
         PLUGINS.get( pluginId ).setPluginState( org.pf4j.PluginState.STARTED );
-    }
-
-
-    private static boolean isCompatible( VersionDependency versionDependencies ) {
-        // todo check if main version fits
-        if ( versionDependencies.type == DependencyType.NONE ) {
-            return true;
-        }
-
-        throw new GenericRuntimeException( "Polypheny dependencies for plugins are not yet supported." );
-
     }
 
 
@@ -322,17 +285,11 @@ public class PolyPluginManager extends DefaultPluginManager {
      * @return the status in the PF4j format
      */
     private static org.pf4j.PluginState toState( org.polypheny.db.config.PluginStatus status ) {
-        switch ( status ) {
-
-            case UNLOADED:
-                return org.pf4j.PluginState.CREATED;
-            case LOADED:
-                return org.pf4j.PluginState.DISABLED;
-            case ACTIVE:
-                return org.pf4j.PluginState.STARTED;
-            default:
-                throw new GenericRuntimeException( "Could not find the corresponding plugin state." );
-        }
+        return switch ( status ) {
+            case UNLOADED -> PluginState.CREATED;
+            case LOADED -> PluginState.DISABLED;
+            case ACTIVE -> PluginState.STARTED;
+        };
     }
 
 
@@ -408,7 +365,7 @@ public class PolyPluginManager extends DefaultPluginManager {
      */
     public static void setPersistentRepository( PersistentMonitoringRepository repository ) {
         if ( PERSISTENT_MONITORING != null ) {
-            throw new RuntimeException( "There is already a persistent repository." );
+            throw new GenericRuntimeException( "There is already a persistent repository." );
         }
         PERSISTENT_MONITORING = repository;
     }
@@ -483,7 +440,7 @@ public class PolyPluginManager extends DefaultPluginManager {
         @Getter
         private final List<String> categories;
         @Getter
-        private final VersionDependency versionDependencies;
+        private final boolean hasVersionDependencies;
         private final boolean isSystemComponent;
         private final boolean isUiVisible;
 
@@ -492,46 +449,26 @@ public class PolyPluginManager extends DefaultPluginManager {
             super( descriptor.getPluginId(), descriptor.getPluginDescription(), descriptor.getPluginClass(), descriptor.getVersion(), descriptor.getRequires(), descriptor.getProvider(), descriptor.getLicense() );
             this.imagePath = manifest.getMainAttributes().getValue( PLUGIN_ICON_PATH );
             this.categories = getCategories( manifest );
-            this.versionDependencies = getVersionDependencies( manifest );
-            this.isSystemComponent = Boolean.TRUE.equals( getManifestValue( Boolean::valueOf, manifest, PLUGIN_SYSTEM_COMPONENT, false ) );
-            this.isUiVisible = Boolean.TRUE.equals( getManifestValue( Boolean::valueOf, manifest, PLUGIN_UI_VISIBLE, false ) );
+            this.hasVersionDependencies = hasVersionDependencies( manifest );
+            this.isSystemComponent = Boolean.TRUE.equals( getManifestValue( Boolean::valueOf, manifest, PLUGIN_SYSTEM_COMPONENT ) );
+            this.isUiVisible = Boolean.TRUE.equals( getManifestValue( Boolean::valueOf, manifest, PLUGIN_UI_VISIBLE ) );
         }
 
 
-        private <T> T getManifestValue( Function1<String, T> transformer, Manifest manifest, String key, boolean allowsNull ) {
+        private <T> T getManifestValue( Function1<String, T> transformer, Manifest manifest, String key ) {
             String attribute = manifest.getMainAttributes().getValue( key );
 
-            if ( attribute == null && !allowsNull ) {
-                if ( !allowsNull ) {
-                    throw new GenericRuntimeException( String.format( "Plugin contains not all required keys: %s", key ) );
-                }
-                return null;
+            if ( attribute == null ) {
+                throw new GenericRuntimeException( "Plugin contains not all required keys: %s", key );
             }
 
             return transformer.apply( attribute );
         }
 
 
-        private VersionDependency getVersionDependencies( Manifest manifest ) {
+        private boolean hasVersionDependencies( Manifest manifest ) {
             String dep = manifest.getMainAttributes().getValue( PLUGIN_POLYPHENY_DEPENDENCIES );
-
-            if ( dep == null || dep.trim().isEmpty() ) {
-                return new VersionDependency( DependencyType.NONE, null );
-            }
-
-            String[] splits = dep.split( "-" );
-
-            if ( splits.length == 2 ) {
-                return new VersionDependency( DependencyType.RANGE, Stream.of( splits ).map( String::trim ).collect( Collectors.toList() ) );
-            }
-            splits = dep.split( "," );
-
-            if ( splits.length > 1 ) {
-                return new VersionDependency( DependencyType.LIST, Stream.of( splits ).map( String::trim ).collect( Collectors.toList() ) );
-            }
-
-            return new VersionDependency( DependencyType.SINGLE, List.of( dep.trim() ) );
-
+            return dep != null && !dep.trim().isEmpty();
         }
 
 
@@ -542,7 +479,7 @@ public class PolyPluginManager extends DefaultPluginManager {
                 return List.of();
             }
 
-            return Arrays.stream( categories.split( "," ) ).map( String::trim ).collect( Collectors.toList() );
+            return Arrays.stream( categories.split( "," ) ).map( String::trim ).toList();
         }
 
     }
@@ -588,92 +525,6 @@ public class PolyPluginManager extends DefaultPluginManager {
                     .id( wrapper.getPluginId() )
                     .loaded( PLUGINS.containsKey( wrapper.getPluginId() ) );
         }
-
-
-        public static TypeAdapter<PluginStatus> getSerializer() {
-            return new TypeAdapter<>() {
-                @Override
-                public void write( JsonWriter out, PluginStatus value ) throws IOException {
-                    out.beginObject();
-                    out.name( "id" );
-                    out.value( value.id );
-                    out.name( "stringPath" );
-                    out.value( value.stringPath );
-                    out.name( "loaded" );
-                    out.value( value.loaded );
-                    out.name( "imagePath" );
-                    out.value( value.imagePath );
-                    out.name( "isSystemComponent" );
-                    out.value( value.isSystemComponent );
-                    out.name( "isUiVisible" );
-                    out.value( value.isUiVisible );
-                    out.endObject();
-                }
-
-
-                @Override
-                public PluginStatus read( JsonReader in ) throws IOException {
-                    in.beginObject();
-                    String id = null;
-                    String stringPath = null;
-                    boolean loaded = false;
-                    String imagePath = null;
-                    boolean isSystemComponent = false;
-                    boolean isUiVisible = false;
-
-                    while ( in.peek() != JsonToken.END_OBJECT ) {
-                        String name = in.nextName();
-                        switch ( name ) {
-                            case "id":
-                                id = in.nextString();
-                                break;
-                            case "stringPath":
-                                stringPath = in.nextString();
-                                break;
-                            case "loaded":
-                                loaded = in.nextBoolean();
-                                break;
-                            case "imagePath":
-                                imagePath = in.nextString();
-                                break;
-                            case "isSystemComponent":
-                                isSystemComponent = in.nextBoolean();
-                                break;
-                            case "isUiVisible":
-                                isUiVisible = in.nextBoolean();
-                                break;
-                            default:
-                                log.error( "Name is not known." );
-                                return null;
-                        }
-                    }
-                    in.endObject();
-
-                    return new PluginStatus( stringPath, imagePath, isSystemComponent, isUiVisible ).id( id ).loaded( loaded );
-                }
-            };
-        }
-
-    }
-
-
-    /**
-     * Different potential types of dependencies.
-     */
-    public enum DependencyType {
-        SINGLE, // specific version e.g. 0.8.1
-        RANGE, // range of potential versions e.g. 0.8 - 0.9
-        LIST, // different supported version e.g. 0.8.1, 0.9.*
-        NONE
-    }
-
-
-    @AllArgsConstructor
-    public static class VersionDependency {
-
-        public DependencyType type;
-
-        final List<String> versions;
 
     }
 

--- a/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
+++ b/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
@@ -22,13 +22,12 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.linq4j.function.Function1;
 import org.apache.commons.io.FileUtils;
@@ -62,13 +61,13 @@ import org.polypheny.db.util.PolyphenyHomeDirManager;
 
 /**
  * Own implementation of the PluginManager from PF4J, which handles the default location, where plugins are loaded from.
- * Custom properties include picture, required-version-of-polypheny.
+ * Custom properties include picture.
  */
 @Slf4j
 public class PolyPluginManager extends DefaultPluginManager {
 
     @Getter
-    private static PersistentMonitoringRepository PERSISTENT_MONITORING;
+    private final static AtomicReference<PersistentMonitoringRepository> PERSISTENT_MONITORING = new AtomicReference<>( null );
 
     @Getter
     public static ObservableMap<String, PluginWrapper> PLUGINS = new ObservableMap<>();
@@ -108,7 +107,7 @@ public class PolyPluginManager extends DefaultPluginManager {
 
 
     public PolyPluginManager( Path... paths ) {
-        super( List.of( paths ) );
+        super( paths );
     }
 
 
@@ -294,57 +293,6 @@ public class PolyPluginManager extends DefaultPluginManager {
 
 
     /**
-     * Tries to load a provided plugin
-     *
-     * @param file a file, which might point to a plugin
-     * @return the status of the loading process
-     */
-    public static PluginStatus loadAdditionalPlugin( File file ) {
-        AFTER_INIT.clear();
-        PluginStatus status = new PluginStatus( file.getPath(), null, false, false );
-        PluginWrapper plugin;
-        try {
-            plugin = pluginManager.getPlugin( pluginManager.loadPlugin( file.toPath() ) );
-            status.id( plugin.getPluginId() );
-        } catch ( Exception e ) {
-            return status.loaded( false );
-        }
-        if ( PLUGINS.containsKey( plugin.getPluginId() ) ) {
-            return status.loaded( false );
-        }
-
-        PLUGINS.put( plugin.getPluginId(), plugin );
-        AFTER_INIT.forEach( Runnable::run );
-
-        PolyPluginDescriptor descriptor = (PolyPluginDescriptor) plugin.getDescriptor();
-        return status.loaded( true )
-                .imagePath( descriptor.imagePath )
-                .isUiVisible( descriptor.isUiVisible )
-                .isSystemComponent( descriptor.isSystemComponent );
-    }
-
-
-    /**
-     * Tries to unload a plugin.
-     *
-     * @param pluginId the identifier of the plugin to unload
-     * @return the status of the unloading process
-     */
-    public static PluginStatus unloadAdditionalPlugin( String pluginId ) {
-        PluginWrapper plugin = pluginManager.getStartedPlugins().stream().filter( p -> p.getPluginId().equals( pluginId ) ).findFirst().orElseThrow();
-        PolyPluginDescriptor descriptor = ((PolyPluginDescriptor) plugin.getDescriptor());
-        PluginStatus status = new PluginStatus( plugin.getPluginId(), descriptor.getImagePath(), descriptor.isSystemComponent, descriptor.isUiVisible );
-        try {
-            pluginManager.unloadPlugin( pluginId );
-        } catch ( Exception e ) {
-            return status.loaded( true );
-        }
-        PLUGINS.remove( pluginId );
-        return status.loaded( false );
-    }
-
-
-    /**
      * The processes, which plugins can register on start, which will be executed as late as possible.
      *
      * @param transactionManager the transactionManager, which plugins like explore-by-example use
@@ -364,10 +312,9 @@ public class PolyPluginManager extends DefaultPluginManager {
      * @param repository the implementation
      */
     public static void setPersistentRepository( PersistentMonitoringRepository repository ) {
-        if ( PERSISTENT_MONITORING != null ) {
+        if ( !PERSISTENT_MONITORING.compareAndSet( null, repository ) ) {
             throw new GenericRuntimeException( "There is already a persistent repository." );
         }
-        PERSISTENT_MONITORING = repository;
     }
 
 
@@ -485,45 +432,11 @@ public class PolyPluginManager extends DefaultPluginManager {
     }
 
 
-    @Accessors(fluent = true)
-    public static class PluginStatus {
-
-
-        @Setter
-        boolean loaded = false;
-        final String stringPath;
-
-        @Setter
-        private String id;
-
-        @Setter
-        private String imagePath;
-
-        @Setter
-        private boolean isSystemComponent;
-
-        @Setter
-        private boolean isUiVisible;
-
-
-        public PluginStatus( String stringPath, String imagePath, boolean isSystemComponent, boolean isUiVisible ) {
-            this.stringPath = stringPath;
-            this.imagePath = imagePath;
-            this.isSystemComponent = isSystemComponent;
-            this.isUiVisible = isUiVisible;
-        }
-
-
-        public Path getPath() {
-            return Path.of( stringPath );
-        }
-
+    public record PluginStatus( String id, boolean loaded, String path, String imagePath, boolean isSystemComponent, boolean isUiVisible ) {
 
         public static PluginStatus from( PluginWrapper wrapper ) {
             PolyPluginDescriptor descriptor = ((PolyPluginDescriptor) wrapper.getDescriptor());
-            return new PluginStatus( wrapper.getPluginPath().toAbsolutePath().toString(), descriptor.getImagePath(), descriptor.isSystemComponent, descriptor.isUiVisible )
-                    .id( wrapper.getPluginId() )
-                    .loaded( PLUGINS.containsKey( wrapper.getPluginId() ) );
+            return new PluginStatus( wrapper.getPluginId(), PLUGINS.containsKey( wrapper.getPluginId() ), wrapper.getPluginPath().toAbsolutePath().toString(), descriptor.getImagePath(), descriptor.isSystemComponent, descriptor.isUiVisible );
         }
 
     }

--- a/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
+++ b/core/src/main/java/org/polypheny/db/plugins/PolyPluginManager.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.db.plugins;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.nio.file.Path;
@@ -137,14 +138,12 @@ public class PolyPluginManager extends DefaultPluginManager {
     public static void init() {
         pluginManager.loadPlugins();
 
-        // start (active/resolved) the plugins
         pluginManager.startPlugins();
 
         PLUGINS.putAll( pluginManager.getStartedPlugins().stream().collect( Collectors.toMap( PluginWrapper::getPluginId, p -> p ) ) );
 
         // print extensions for each started plugin
-        List<PluginWrapper> startedPlugins = pluginManager.getStartedPlugins();
-        for ( PluginWrapper plugin : startedPlugins ) {
+        for ( PluginWrapper plugin : pluginManager.getStartedPlugins() ) {
             String pluginId = plugin.getDescriptor().getPluginId();
             log.info( "Plugin '{}' added", pluginId );
         }
@@ -265,7 +264,7 @@ public class PolyPluginManager extends DefaultPluginManager {
             String attribute = manifest.getMainAttributes().getValue( key );
 
             if ( attribute == null ) {
-                throw new GenericRuntimeException( "Plugin contains not all required keys: %s", key );
+                throw new GenericRuntimeException( "Plugin is missing required key: %s", key );
             }
 
             return transformer.apply( attribute );
@@ -291,7 +290,7 @@ public class PolyPluginManager extends DefaultPluginManager {
     }
 
 
-    public record PluginStatus( String id, boolean loaded, String path, String imagePath, boolean isSystemComponent, boolean isUiVisible ) {
+    public record PluginStatus( @JsonSerialize String id, @JsonSerialize boolean loaded, @JsonSerialize String path, @JsonSerialize String imagePath, @JsonSerialize boolean isSystemComponent, @JsonSerialize boolean isUiVisible ) {
 
         public static PluginStatus from( PluginWrapper wrapper ) {
             PolyPluginDescriptor descriptor = ((PolyPluginDescriptor) wrapper.getDescriptor());

--- a/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
+++ b/dbms/src/main/java/org/polypheny/db/PolyphenyDb.java
@@ -303,7 +303,7 @@ public class PolyphenyDb {
         }
 
         // Initialize plugin manager
-        PolyPluginManager.init( resetPlugins );
+        PolyPluginManager.init();
 
         // Startup and restore catalog
         Catalog catalog = startCatalog();

--- a/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringServiceFactory.java
+++ b/monitoring/src/main/java/org/polypheny/db/monitoring/core/MonitoringServiceFactory.java
@@ -27,7 +27,7 @@ public class MonitoringServiceFactory {
 
     public static MonitoringService createMonitoringService( boolean resetRepository ) {
         // Create repository
-        PersistentMonitoringRepository persistentRepo = PolyPluginManager.getPERSISTENT_MONITORING();
+        PersistentMonitoringRepository persistentRepo = PolyPluginManager.getPERSISTENT_MONITORING().get();
         StatisticRepository statisticRepo = new StatisticRepository();
 
         // Initialize the repo and open connection

--- a/webui/src/main/java/org/polypheny/db/webui/Crud.java
+++ b/webui/src/main/java/org/polypheny/db/webui/Crud.java
@@ -2898,37 +2898,6 @@ public class Crud implements InformationObserver, PropertyChangeListener {
 
 
     /**
-     * Loads the plugin in the supplied path.
-     */
-    public void loadPlugins( final Context ctx ) {
-        ctx.uploadedFiles( "plugins" ).forEach( file -> {
-            String[] splits = file.filename().split( "/" );
-            String normalizedFileName = splits[splits.length - 1];
-            splits = normalizedFileName.split( "\\\\" );
-            normalizedFileName = splits[splits.length - 1];
-            File f = new File( System.getProperty( "user.home" ), ".polypheny/plugins/" + normalizedFileName );
-            try {
-                FileUtils.copyInputStreamToFile( file.content(), f );
-            } catch ( IOException e ) {
-                throw new GenericRuntimeException( e );
-            }
-            PolyPluginManager.loadAdditionalPlugin( f );
-        } );
-
-    }
-
-
-    /**
-     * Unload the plugin with the supplied pluginId.
-     */
-    public void unloadPlugin( final Context ctx ) {
-        String pluginId = ctx.bodyAsClass( String.class );
-
-        ctx.json( PolyPluginManager.unloadAdditionalPlugin( pluginId ) );
-    }
-
-
-    /**
      * Helper method to zip a directory
      */
     private static void zipDirectory( String basePath, File dir, ZipOutputStream zipOut ) throws IOException {

--- a/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
+++ b/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
@@ -401,10 +401,6 @@ public class HttpServer implements Runnable {
 
 
     private static void attachPluginRoutes( Javalin webuiServer, Crud crud ) {
-        webuiServer.post( "/loadPlugins", crud::loadPlugins );
-
-        webuiServer.post( "/unloadPlugin", crud::unloadPlugin );
-
         webuiServer.get( "/getAvailablePlugins", crud::getAvailablePlugins );
     }
 

--- a/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
+++ b/webui/src/main/java/org/polypheny/db/webui/HttpServer.java
@@ -230,7 +230,7 @@ public class HttpServer implements Runnable {
 
         attachStatisticRoutes( webuiServer, crud );
 
-        attachPluginRoutes( webuiServer, crud );
+        webuiServer.get( "/getAvailablePlugins", crud::getAvailablePlugins );
 
         attachDockerRoutes( webuiServer, crud );
 
@@ -397,11 +397,6 @@ public class HttpServer implements Runnable {
         webuiServer.get( "/docker/settings", crud::getDockerSettings );
 
         webuiServer.patch( "/docker/settings", crud::updateDockerSettings );
-    }
-
-
-    private static void attachPluginRoutes( Javalin webuiServer, Crud crud ) {
-        webuiServer.get( "/getAvailablePlugins", crud::getAvailablePlugins );
     }
 
 


### PR DESCRIPTION
After this change, plugins are loaded once at startup and remain loaded until Polypheny quits.  The option to load/unload plugins after startup is removed because is not tested and adds a lot of complexity which will conflict with an upcoming change.