### PR TITLE
Update Bouncy Castle dependency

### DIFF
--- a/dbms/build.gradle
+++ b/dbms/build.gradle
@@ -103,10 +103,10 @@ licensee {
 
     allowDependency('com.j256.simplemagic', 'simplemagic', '1.17') { because 'ISC license' }
     allowDependency('com.adobe.xmp', 'xmpcore', '6.0.6') { because 'BSD 3-Clause' }
-    allowDependency('org.bouncycastle', 'bcprov-jdk18on', '1.80') { because 'MIT license' }
-    allowDependency('org.bouncycastle', 'bcpkix-jdk18on', '1.80') { because 'MIT license' }
-    allowDependency('org.bouncycastle', 'bcutil-jdk18on', '1.80') { because 'MIT license' }
-    allowDependency('org.bouncycastle', 'bctls-jdk18on', '1.80') { because 'MIT license' }
+    allowDependency('org.bouncycastle', 'bcprov-jdk18on', '1.84') { because 'MIT license' }
+    allowDependency('org.bouncycastle', 'bcpkix-jdk18on', '1.84') { because 'MIT license' }
+    allowDependency('org.bouncycastle', 'bcutil-jdk18on', '1.84') { because 'MIT license' }
+    allowDependency('org.bouncycastle', 'bctls-jdk18on', '1.84') { because 'MIT license' }
     allowDependency('jakarta.xml.bind', 'jakarta.xml.bind-api', '2.3.3') { because 'Eclipse Distribution License 1.0' }
     allowDependency('org.codehaus.janino', 'janino', '3.0.11') { because 'BSD 3-Clause' }
     allowDependency('org.codehaus.janino', 'commons-compiler', '3.0.11') { because 'BSD 3-Clause' }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.jvmargs = -Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-
 # Dependency versions
 activej_serializer_version = 6.0-beta2
 airline_version = 2.9.0
-bouncycastle_version = 1.80
+bouncycastle_version = 1.84
 calcite_linq4j_version = 1.36.0
 commons_codec_version = 1.16.0
 commons_collections_version = 4.4


### PR DESCRIPTION
Building `master` is currently broken, because Bouncy Castle version `1.80.2` is used, which is not permitted by `licensee` task.  With this `master` builds again.