### PR TITLE
Make the varchar type check null-safe

### DIFF
--- a/plugins/http-interface/src/main/java/org/polypheny/db/http/model/DbColumn.java
+++ b/plugins/http-interface/src/main/java/org/polypheny/db/http/model/DbColumn.java
@@ -67,7 +67,7 @@ public class DbColumn {
         this.name = name;
         this.dataType = dataType;
         this.nullable = nullable;
-        if ( dataType.equals( "varchar" ) ) {
+        if ( "varchar".equals( dataType ) ) {
             this.precision = precision;
         }
         this.sort = sort;


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/34511731.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Reversed the varchar equality check so partially populated column metadata cannot throw a NullPointerException.
