### PR TITLE
Bump version of Github Actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,9 +16,9 @@ jobs:
         name: ${{ matrix.adapter }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
             -   name: Set up JDK
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     distribution: 'temurin'
                     java-version: 21

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -17,9 +17,9 @@ jobs:
         name: Java ${{ matrix.java }} @ ${{ matrix.os }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
             -   name: Set up JDK
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     distribution: 'temurin'
                     java-version: ${{ matrix.java }}

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -16,9 +16,9 @@ jobs:
         name: ${{ matrix.os }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
             -   name: Set up JDK
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     distribution: 'temurin'
                     java-version: 21


### PR DESCRIPTION
In the workflow logs there are warnings about actions using the deprecated Node 20, so update those actions to a newer version.